### PR TITLE
fix build warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,4 +53,6 @@ dkms.conf
 
 # Repository specific
 test/test
+test/galaga_nes.h
+test/smw_snes.h
 .vscode/*

--- a/src/rcheevos/alloc.c
+++ b/src/rcheevos/alloc.c
@@ -3,7 +3,7 @@
 void* rc_alloc(void* pointer, int* offset, int size, rc_scratch_t* scratch) {
   void* ptr;
 
-  *offset = (*offset + RC_ALIGNMENT - 1) & -RC_ALIGNMENT;
+  *offset = (*offset + RC_ALIGNMENT - 1) & ~(RC_ALIGNMENT - 1);
 
   if (pointer != 0) {
     ptr = (void*)((char*)pointer + *offset);

--- a/src/rcheevos/operand.c
+++ b/src/rcheevos/operand.c
@@ -295,8 +295,8 @@ typedef struct {
 rc_luapeek_t;
 
 static int rc_luapeek(lua_State* L) {
-  unsigned address = luaL_checkinteger(L, 1);
-  unsigned num_bytes = luaL_checkinteger(L, 2);
+  unsigned address = (unsigned)luaL_checkinteger(L, 1);
+  unsigned num_bytes = (unsigned)luaL_checkinteger(L, 2);
   rc_luapeek_t* luapeek = (rc_luapeek_t*)lua_touserdata(L, 3);
 
   unsigned value = luapeek->peek(address, num_bytes, luapeek->ud);

--- a/src/rcheevos/term.c
+++ b/src/rcheevos/term.c
@@ -84,5 +84,5 @@ unsigned rc_evaluate_term(rc_term_t* self, rc_peek_t peek, void* ud, lua_State* 
     return value * (rc_evaluate_operand(&self->operand2, peek, ud, L) ^ self->invert);
   }
 
-  return value * self->operand2.fp_value;
+  return (unsigned)(value * self->operand2.fp_value);
 }


### PR DESCRIPTION
```
alloc.c(6): warning C4146: unary minus operator applied to unsigned type, result still unsigned
term.c(87): warning C4244: 'return': conversion from 'double' to 'unsigned int', possible loss of data
operand.c(298): warning C4244: 'initializing': conversion from 'lua_Integer' to 'unsigned int', possible loss of data
operand.c(299): warning C4244: 'initializing': conversion from 'lua_Integer' to 'unsigned int', possible loss of data
```