### PR TITLE
fix unnamed struct warning

### DIFF
--- a/src/rcheevos/internal.h
+++ b/src/rcheevos/internal.h
@@ -3,8 +3,10 @@
 
 #include "rcheevos.h"
 
+#define RC_TAG2(x,y) x ## y
+#define RC_TAG(x,y) RC_TAG2(x,y)
 #define RC_OFFSETOF(s, f) ((int)(long long)(&((s*)0)->f))
-#define RC_ALIGNOF(t) RC_OFFSETOF(struct _unnamed{char c; t d;}, d)
+#define RC_ALIGNOF(t) RC_OFFSETOF(struct RC_TAG(_unnamed, __LINE__) {char c; t d;}, d)
 
 #define RC_ALLOC(t, p, o, s) ((t*)rc_alloc(p, o, sizeof(t), RC_ALIGNOF(t), s))
 

--- a/src/rcheevos/internal.h
+++ b/src/rcheevos/internal.h
@@ -4,7 +4,7 @@
 #include "rcheevos.h"
 
 #define RC_OFFSETOF(s, f) ((int)(long long)(&((s*)0)->f))
-#define RC_ALIGNOF(t) RC_OFFSETOF(struct{char c; t d;}, d)
+#define RC_ALIGNOF(t) RC_OFFSETOF(struct _unnamed{char c; t d;}, d)
 
 #define RC_ALLOC(t, p, o, s) ((t*)rc_alloc(p, o, sizeof(t), RC_ALIGNOF(t), s))
 


### PR DESCRIPTION
```2>condition.c
2>e:\source\raintegration\rcheevos\src\rcheevos\condition.c(11): warning C4116: unnamed type definition in parentheses
2>condset.c
2>e:\source\raintegration\rcheevos\src\rcheevos\condset.c(30): warning C4116: unnamed type definition in parentheses
2>expression.c
2>e:\source\raintegration\rcheevos\src\rcheevos\expression.c(7): warning C4116: unnamed type definition in parentheses
2>format.c
2>lboard.c
2>e:\source\raintegration\rcheevos\src\rcheevos\lboard.c(95): warning C4116: unnamed type definition in parentheses
2>e:\source\raintegration\rcheevos\src\rcheevos\lboard.c(140): warning C4116: unnamed type definition in parentheses
2>e:\source\raintegration\rcheevos\src\rcheevos\lboard.c(151): warning C4116: unnamed type definition in parentheses
...
```