### PR TITLE
Add "prior" memory type

### DIFF
--- a/include/rcheevos.h
+++ b/include/rcheevos.h
@@ -109,7 +109,8 @@ enum {
   RC_OPERAND_DELTA,   /* The value last known at this address. */
   RC_OPERAND_CONST,   /* A 32-bit unsigned integer. */
   RC_OPERAND_FP,      /* A floating point value. */
-  RC_OPERAND_LUA      /* A Lua function that provides the value. */
+  RC_OPERAND_LUA,     /* A Lua function that provides the value. */
+  RC_OPERAND_PRIOR    /* The last differing value at this address. */
 };
 
 typedef struct {
@@ -118,8 +119,10 @@ typedef struct {
     struct {
       /* The memory address or constant value of this variable. */
       unsigned value;
-      /* The previous memory contents if RC_OPERAND_DELTA. */
+      /* The previous memory contents if RC_OPERAND_DELTA or RC_OPERAND_PRIOR. */
       unsigned previous;
+      /* The last differing value if RC_OPERAND_PRIOR. */
+      unsigned prior;
 
       /* The size of the variable. */
       char size;

--- a/src/rcheevos/operand.c
+++ b/src/rcheevos/operand.c
@@ -76,6 +76,10 @@ static int rc_parse_operand_memory(rc_operand_t* self, const char** memaddr) {
       self->is_bcd = 1;
       break;
 
+    case 'p': case 'P':
+      self->type = RC_OPERAND_PRIOR;
+      break;
+
     default:
       self->type = RC_OPERAND_ADDRESS;
       aux--;
@@ -287,6 +291,7 @@ int rc_parse_operand(rc_operand_t* self, const char** memaddr, int is_trigger, l
   self->size = RC_OPERAND_8_BITS;
   self->is_bcd = 0;
   self->previous = 0;
+  self->prior = 0;
 
   if (is_trigger) {
     return rc_parse_operand_trigger(self, memaddr, L, funcs_ndx);
@@ -363,6 +368,7 @@ unsigned rc_evaluate_operand(rc_operand_t* self, rc_peek_t peek, void* ud, lua_S
 
     case RC_OPERAND_ADDRESS:
     case RC_OPERAND_DELTA:
+    case RC_OPERAND_PRIOR:
       switch (self->size) {
         case RC_OPERAND_BIT_0:
           value = (peek(self->value, 1, ud) >> 0) & 1;
@@ -460,6 +466,12 @@ unsigned rc_evaluate_operand(rc_operand_t* self, rc_peek_t peek, void* ud, lua_S
         unsigned previous = self->previous;
         self->previous = value;
         value = previous;
+      } else if (self->type == RC_OPERAND_PRIOR) {
+        if (self->previous != value) {
+          self->prior = self->previous;
+          self->previous = value;
+        }
+        value = self->prior;
       }
 
       break;

--- a/test/test.c
+++ b/test/test.c
@@ -1632,6 +1632,8 @@ static void test_term(void) {
     parse_comp_term_value("V6", &memory, 6);
     parse_comp_term_value("V6*2", &memory, 12);
     parse_comp_term_value("V6*0.5", &memory, 3);
+    parse_comp_term_value("V-6", &memory, (unsigned)(-6));
+    parse_comp_term_value("V-6*2", &memory, (unsigned)(-12));
 
     /* memory */
     parse_comp_term_value("0xH01", &memory, 0x12);

--- a/test/test.c
+++ b/test/test.c
@@ -13,7 +13,7 @@
 
 typedef struct {
   unsigned char* ram;
-  int size;
+  unsigned size;
 }
 memory_t;
 
@@ -44,6 +44,7 @@ static void parse_operand(rc_operand_t* self, const char** memaddr) {
   assert(ret >= 0);
   assert(**memaddr == 0);
   self->previous = 0;
+  self->prior = 0;
 }
 
 static void comp_operand(rc_operand_t* self, char expected_type, char expected_size, unsigned expected_value) {
@@ -157,6 +158,38 @@ static void test_operand(void) {
     parse_comp_operand("d0xH12345678", RC_OPERAND_DELTA, RC_OPERAND_8_BITS, 0x12345678U);
     parse_comp_operand("d0xHABCD", RC_OPERAND_DELTA, RC_OPERAND_8_BITS, 0xABCDU);
     parse_comp_operand("d0xhabcd", RC_OPERAND_DELTA, RC_OPERAND_8_BITS, 0xABCDU);
+  }
+
+  {
+    /*------------------------------------------------------------------------
+    TestParseVariablePriorMem
+    ------------------------------------------------------------------------*/
+
+    /* sizes */
+    parse_comp_operand("p0xH1234", RC_OPERAND_PRIOR, RC_OPERAND_8_BITS, 0x1234U);
+    parse_comp_operand("p0x 1234", RC_OPERAND_PRIOR, RC_OPERAND_16_BITS, 0x1234U);
+    parse_comp_operand("p0x1234", RC_OPERAND_PRIOR, RC_OPERAND_16_BITS, 0x1234U);
+    parse_comp_operand("p0xW1234", RC_OPERAND_PRIOR, RC_OPERAND_24_BITS, 0x1234U);
+    parse_comp_operand("p0xX1234", RC_OPERAND_PRIOR, RC_OPERAND_32_BITS, 0x1234U);
+    parse_comp_operand("p0xL1234", RC_OPERAND_PRIOR, RC_OPERAND_LOW, 0x1234U);
+    parse_comp_operand("p0xU1234", RC_OPERAND_PRIOR, RC_OPERAND_HIGH, 0x1234U);
+    parse_comp_operand("p0xM1234", RC_OPERAND_PRIOR, RC_OPERAND_BIT_0, 0x1234U);
+    parse_comp_operand("p0xN1234", RC_OPERAND_PRIOR, RC_OPERAND_BIT_1, 0x1234U);
+    parse_comp_operand("p0xO1234", RC_OPERAND_PRIOR, RC_OPERAND_BIT_2, 0x1234U);
+    parse_comp_operand("p0xP1234", RC_OPERAND_PRIOR, RC_OPERAND_BIT_3, 0x1234U);
+    parse_comp_operand("p0xQ1234", RC_OPERAND_PRIOR, RC_OPERAND_BIT_4, 0x1234U);
+    parse_comp_operand("p0xR1234", RC_OPERAND_PRIOR, RC_OPERAND_BIT_5, 0x1234U);
+    parse_comp_operand("p0xS1234", RC_OPERAND_PRIOR, RC_OPERAND_BIT_6, 0x1234U);
+    parse_comp_operand("p0xT1234", RC_OPERAND_PRIOR, RC_OPERAND_BIT_7, 0x1234U);
+
+    /* ignores case */
+    parse_comp_operand("P0Xh1234", RC_OPERAND_PRIOR, RC_OPERAND_8_BITS, 0x1234U);
+
+    /* addresses */
+    parse_comp_operand("p0xH0000", RC_OPERAND_PRIOR, RC_OPERAND_8_BITS, 0x0000U);
+    parse_comp_operand("p0xH12345678", RC_OPERAND_PRIOR, RC_OPERAND_8_BITS, 0x12345678U);
+    parse_comp_operand("p0xHABCD", RC_OPERAND_PRIOR, RC_OPERAND_8_BITS, 0xABCDU);
+    parse_comp_operand("p0xhabcd", RC_OPERAND_PRIOR, RC_OPERAND_8_BITS, 0xABCDU);
   }
 
   {
@@ -278,6 +311,44 @@ static void test_operand(void) {
 
     assert(rc_evaluate_operand(&op, peek, &memory, NULL) == 0x16U);
     assert(rc_evaluate_operand(&op, peek, &memory, NULL) == 0x16U);
+  }
+
+  {
+    /*------------------------------------------------------------------------
+    TestVariableGetValueDelta
+    ------------------------------------------------------------------------*/
+
+    unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+    memory_t memory;
+    rc_operand_t op;
+    const char* memaddr;
+
+    memory.ram = ram;
+    memory.size = sizeof(ram);
+
+    memaddr = "p0xh1";
+    parse_operand(&op, &memaddr);
+
+    /* RC_OPERAND_PRIOR only updates when the memory value changes */
+    assert(rc_evaluate_operand(&op, peek, &memory, NULL) == 0x00); /* first call gets uninitialized value */
+    assert(rc_evaluate_operand(&op, peek, &memory, NULL) == 0x00); /* value only changes when memory changes */
+
+    ram[1] = 0x13;
+    assert(rc_evaluate_operand(&op, peek, &memory, NULL) == 0x12U);
+    assert(rc_evaluate_operand(&op, peek, &memory, NULL) == 0x12U);
+    assert(rc_evaluate_operand(&op, peek, &memory, NULL) == 0x12U);
+    assert(rc_evaluate_operand(&op, peek, &memory, NULL) == 0x12U);
+
+    ram[1] = 0x14;
+    assert(rc_evaluate_operand(&op, peek, &memory, NULL) == 0x13U);
+
+    ram[1] = 0x15;
+    assert(rc_evaluate_operand(&op, peek, &memory, NULL) == 0x14U);
+
+    ram[1] = 0x16;
+    assert(rc_evaluate_operand(&op, peek, &memory, NULL) == 0x15U);
+    assert(rc_evaluate_operand(&op, peek, &memory, NULL) == 0x15U);
+    assert(rc_evaluate_operand(&op, peek, &memory, NULL) == 0x15U);
   }
 }
 


### PR DESCRIPTION
Supports https://github.com/RetroAchievements/RAIntegration/issues/176

Works like delta, but reports the last different value, instead of the value from the previous frame.

For example:

| Frame | Value | Delta | Prior |
| ----- | ----- | ----- | ----- |
|    1 |   25 |    0 |    0 |
|    2 |   25 |   25 |    0 |
|    3 |   30 |   25 |   25 |
|    4 |   35 |   30 |   30 |
|    5 |   35 |   35 |   30 |   
|    6 |   35 |   35 |   30 |
|    7 |   40 |   35 |   35 |

Represented by placing a 'P' or 'p' before the '0x' in a memory reference:
```
p0x1234
```
Can be combined with any existing logic:
```
p0x1234>0                // prior value is greater than 0
R:p0x1234!=0             // reset if prior value is not 0
P:p0x1234=10             // pause if prior value is 10
R:p0x1234>p0x1234         // reset if value is greater than prior value
R:d0x1234!=p0x1234       // reset if delta value differs from prior value
```

Note that `prior` will equal `value` only if the `value` has been 0 since resetting. Once `value` changes, `prior` will always be one "value" behind.