### PR TITLE
Support floating point value starting with decimal point.

### DIFF
--- a/src/rcheevos/operand.c
+++ b/src/rcheevos/operand.c
@@ -256,6 +256,7 @@ static int rc_parse_operand_term(rc_operand_t* self, const char** memaddr, lua_S
       }
 
       /* fall through */
+    case '.':
     case '+': case '-':
     case '1': case '2': case '3': case '4': case '5':
     case '6': case '7': case '8': case '9':

--- a/test/test.c
+++ b/test/test.c
@@ -13,7 +13,7 @@
 
 typedef struct {
   unsigned char* ram;
-  int size;
+  unsigned size;
 }
 memory_t;
 
@@ -608,6 +608,8 @@ static rc_condset_t* trigger_get_set(rc_trigger_t* trigger, int ndx) {
 }
 
 static void test_trigger(void) {
+  char buffer[2048];
+    
   {
     /*------------------------------------------------------------------------
     TestSimpleSets
@@ -617,7 +619,6 @@ static void test_trigger(void) {
     unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
     memory_t memory;
     rc_trigger_t* trigger;
-    char buffer[2048];
 
     memory.ram = ram;
     memory.size = sizeof(ram);
@@ -681,7 +682,6 @@ static void test_trigger(void) {
     unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
     memory_t memory;
     rc_trigger_t* trigger;
-    char buffer[2048];
 
     memory.ram = ram;
     memory.size = sizeof(ram);
@@ -713,7 +713,6 @@ static void test_trigger(void) {
     unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
     memory_t memory;
     rc_trigger_t* trigger;
-    char buffer[2048];
 
     memory.ram = ram;
     memory.size = sizeof(ram);
@@ -737,7 +736,6 @@ static void test_trigger(void) {
     unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
     memory_t memory;
     rc_trigger_t* trigger;
-    char buffer[2048];
 
     memory.ram = ram;
     memory.size = sizeof(ram);
@@ -765,7 +763,6 @@ static void test_trigger(void) {
     unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
     memory_t memory;
     rc_trigger_t* trigger;
-    char buffer[2048];
 
     memory.ram = ram;
     memory.size = sizeof(ram);
@@ -814,7 +811,6 @@ static void test_trigger(void) {
     unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
     memory_t memory;
     rc_trigger_t* trigger;
-    char buffer[2048];
 
     memory.ram = ram;
     memory.size = sizeof(ram);
@@ -863,7 +859,6 @@ static void test_trigger(void) {
     unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
     memory_t memory;
     rc_trigger_t* trigger;
-    char buffer[2048];
 
     memory.ram = ram;
     memory.size = sizeof(ram);
@@ -896,7 +891,6 @@ static void test_trigger(void) {
     unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
     memory_t memory;
     rc_trigger_t* trigger;
-    char buffer[2048];
 
     memory.ram = ram;
     memory.size = sizeof(ram);
@@ -938,7 +932,6 @@ static void test_trigger(void) {
     unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
     memory_t memory;
     rc_trigger_t* trigger;
-    char buffer[2048];
 
     memory.ram = ram;
     memory.size = sizeof(ram);
@@ -975,7 +968,6 @@ static void test_trigger(void) {
     unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
     memory_t memory;
     rc_trigger_t* trigger;
-    char buffer[2048];
 
     memory.ram = ram;
     memory.size = sizeof(ram);
@@ -999,7 +991,6 @@ static void test_trigger(void) {
     unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
     memory_t memory;
     rc_trigger_t* trigger;
-    char buffer[2048];
 
     memory.ram = ram;
     memory.size = sizeof(ram);
@@ -1030,7 +1021,6 @@ static void test_trigger(void) {
     unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
     memory_t memory;
     rc_trigger_t* trigger;
-    char buffer[2048];
 
     memory.ram = ram;
     memory.size = sizeof(ram);
@@ -1070,7 +1060,6 @@ static void test_trigger(void) {
     unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
     memory_t memory;
     rc_trigger_t* trigger;
-    char buffer[2048];
 
     memory.ram = ram;
     memory.size = sizeof(ram);
@@ -1107,7 +1096,6 @@ static void test_trigger(void) {
     unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
     memory_t memory;
     rc_trigger_t* trigger;
-    char buffer[2048];
 
     memory.ram = ram;
     memory.size = sizeof(ram);
@@ -1141,7 +1129,6 @@ static void test_trigger(void) {
     unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
     memory_t memory;
     rc_trigger_t* trigger;
-    char buffer[2048];
 
     memory.ram = ram;
     memory.size = sizeof(ram);
@@ -1180,7 +1167,6 @@ static void test_trigger(void) {
     unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
     memory_t memory;
     rc_trigger_t* trigger;
-    char buffer[2048];
 
     memory.ram = ram;
     memory.size = sizeof(ram);
@@ -1225,7 +1211,6 @@ static void test_trigger(void) {
     unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
     memory_t memory;
     rc_trigger_t* trigger;
-    char buffer[2048];
 
     rc_condset_t* condset;
 
@@ -1273,7 +1258,6 @@ static void test_trigger(void) {
     unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
     memory_t memory;
     rc_trigger_t* trigger;
-    char buffer[2048];
 
     memory.ram = ram;
     memory.size = sizeof(ram);
@@ -1320,7 +1304,6 @@ static void test_trigger(void) {
     unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
     memory_t memory;
     rc_trigger_t* trigger;
-    char buffer[2048];
 
     memory.ram = ram;
     memory.size = sizeof(ram);
@@ -1359,7 +1342,6 @@ static void test_trigger(void) {
     unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
     memory_t memory;
     rc_trigger_t* trigger;
-    char buffer[2048];
 
     memory.ram = ram;
     memory.size = sizeof(ram);
@@ -1397,7 +1379,6 @@ static void test_trigger(void) {
     unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
     memory_t memory;
     rc_trigger_t* trigger;
-    char buffer[2048];
 
     memory.ram = ram;
     memory.size = sizeof(ram);
@@ -1532,6 +1513,7 @@ static void test_term(void) {
     parse_comp_term_fp("0xH1234*1", RC_OPERAND_8_BITS, 0x1234U, 1.0);
     parse_comp_term_fp("0xH1234*3", RC_OPERAND_8_BITS, 0x1234U, 3.0);
     parse_comp_term_fp("0xH1234*0.5", RC_OPERAND_8_BITS, 0x1234U, 0.5);
+    parse_comp_term_fp("0xH1234*.5", RC_OPERAND_8_BITS, 0x1234U, 0.5);
     parse_comp_term_fp("0xH1234*-1", RC_OPERAND_8_BITS, 0x1234U, -1.0);
   }
 
@@ -1713,6 +1695,8 @@ static unsigned lboard_evaluate(rc_lboard_t* lboard, lboard_test_state_t* test, 
 }
 
 static void test_lboard(void) {
+  char buffer[2048];
+
   {
     /*------------------------------------------------------------------------
     TestSimpleLeaderboard
@@ -1722,7 +1706,6 @@ static void test_lboard(void) {
     memory_t memory;
     rc_lboard_t* lboard;
     lboard_test_state_t state;
-    char buffer[2048];
     unsigned value;
     
     memory.ram = ram;
@@ -1784,7 +1767,6 @@ static void test_lboard(void) {
     memory_t memory;
     rc_lboard_t* lboard;
     lboard_test_state_t state;
-    char buffer[2048];
     
     memory.ram = ram;
     memory.size = sizeof(ram);
@@ -1831,7 +1813,6 @@ static void test_lboard(void) {
     memory_t memory;
     rc_lboard_t* lboard;
     lboard_test_state_t state;
-    char buffer[2048];
     unsigned value;
     
     memory.ram = ram;
@@ -1867,7 +1848,6 @@ static void test_lboard(void) {
     memory_t memory;
     rc_lboard_t* lboard;
     lboard_test_state_t state;
-    char buffer[2048];
     unsigned value;
     
     memory.ram = ram;
@@ -1897,7 +1877,6 @@ static void test_lboard(void) {
     memory_t memory;
     rc_lboard_t* lboard;
     lboard_test_state_t state;
-    char buffer[2048];
     
     memory.ram = ram;
     memory.size = sizeof(ram);
@@ -1922,7 +1901,6 @@ static void test_lboard(void) {
     memory_t memory;
     rc_lboard_t* lboard;
     lboard_test_state_t state;
-    char buffer[2048];
     
     memory.ram = ram;
     memory.size = sizeof(ram);
@@ -1956,7 +1934,6 @@ static void test_lboard(void) {
     memory_t memory;
     rc_lboard_t* lboard;
     lboard_test_state_t state;
-    char buffer[2048];
     
     memory.ram = ram;
     memory.size = sizeof(ram);
@@ -1990,7 +1967,6 @@ static void test_lboard(void) {
     memory_t memory;
     rc_lboard_t* lboard;
     lboard_test_state_t state;
-    char buffer[2048];
     
     memory.ram = ram;
     memory.size = sizeof(ram);
@@ -2016,7 +1992,6 @@ static void test_lboard(void) {
     memory_t memory;
     rc_lboard_t* lboard;
     lboard_test_state_t state;
-    char buffer[2048];
     
     memory.ram = ram;
     memory.size = sizeof(ram);


### PR DESCRIPTION
Noticed while playing the AotW game: Zelda - Link to the Past (GBC). The Rich Presence is defined as follows:
```
@Hearts(0xha34c*.125) Hearts...
```
The ".125" was confusing the parser. Because it didn't start with a number it fell into the default case for an address, which didn't recognize the period and ignored it.