### PR TITLE
Prevent null reference if rich presence macro doesn't have a parameter

### DIFF
--- a/src/rcheevos/richpresence.c
+++ b/src/rcheevos/richpresence.c
@@ -103,6 +103,11 @@ rc_richpresence_display_t* rc_parse_richpresence_display_internal(void* buffer, 
       while (ptr < endline && *ptr != '(')
         ++ptr;
 
+      if (ptr == endline) {
+        *ret = RC_MISSING_VALUE;
+        return 0;
+      }
+
       if (ptr > line) {
         if (!buffer) {
           /* just calculating size, can't confirm lookup exists */
@@ -314,6 +319,8 @@ void rc_parse_richpresence_internal(rc_richpresence_t* self, int* ret, void* buf
 
       if (ptr < endline) {
         *nextdisplay = rc_parse_richpresence_display_internal(buffer, ret, scratch, ptr + 1, endline, L, funcs_ndx, self);
+        if (*ret < 0)
+          return;
         rc_parse_trigger_internal(&((*nextdisplay)->trigger), ret, buffer, scratch, &line, L, funcs_ndx);
         if (*ret < 0)
           return;
@@ -335,7 +342,7 @@ void rc_parse_richpresence_internal(rc_richpresence_t* self, int* ret, void* buf
   /* finalize */
   *nextdisplay = 0;
 
-  if (!hasdisplay && ret > 0)
+  if (!hasdisplay && *ret > 0)
     *ret = RC_MISSING_DISPLAY_STRING;
 }
 

--- a/test/test.c
+++ b/test/test.c
@@ -3183,6 +3183,31 @@ static void test_richpresence(void) {
 
   {
     /*------------------------------------------------------------------------
+    TestLookupInvalid
+    ------------------------------------------------------------------------*/
+    int result;
+
+    result = rc_richpresence_size("Lookup:Location\nOx0=Zero\n1=One\n\nDisplay:\nAt @Location(0xH0000)");
+    assert(result == RC_INVALID_CONST_OPERAND);
+
+    result = rc_richpresence_size("Lookup:Location\n0xO=Zero\n1=One\n\nDisplay:\nAt @Location(0xH0000)");
+    assert(result == RC_INVALID_CONST_OPERAND);
+
+    result = rc_richpresence_size("Lookup:Location\nZero=Zero\n1=One\n\nDisplay:\nAt @Location(0xH0000)");
+    assert(result == RC_INVALID_CONST_OPERAND);
+
+    result = rc_richpresence_size("Lookup:Location\n0=Zero\n1=One\n\nDisplay:\nAt @Location");
+    assert(result == RC_MISSING_VALUE);
+
+    result = rc_richpresence_size("Lookup:Location\n0=Zero\n1=One\n\nDisplay:\nAt @Location()");
+    assert(result == RC_INVALID_MEMORY_OPERAND);
+
+    result = rc_richpresence_size("Lookup:Location\n0=Zero\n1=One\n\nDisplay:\nAt @Location(Zero)");
+    assert(result == RC_INVALID_MEMORY_OPERAND);
+  }
+
+  {
+    /*------------------------------------------------------------------------
     TestRandomTextBetweenSections
     ------------------------------------------------------------------------*/
     unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };

--- a/test/test.c
+++ b/test/test.c
@@ -2807,6 +2807,36 @@ static void test_richpresence(void) {
 
   {
     /*------------------------------------------------------------------------
+    TestMacroWithNoParameter
+    ------------------------------------------------------------------------*/
+    unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+    memory_t memory;
+    int result;
+
+    memory.ram = ram;
+    memory.size = sizeof(ram);
+
+    result = rc_richpresence_size("Format:Points\nFormatType=VALUE\n\nDisplay:\n@Points Points");
+    assert(result == RC_MISSING_VALUE);
+  }
+
+  {
+    /*------------------------------------------------------------------------
+    TestConditionalDisplayMacroWithNoParameter
+    ------------------------------------------------------------------------*/
+    unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+    memory_t memory;
+    int result;
+
+    memory.ram = ram;
+    memory.size = sizeof(ram);
+
+    result = rc_richpresence_size("Format:Points\nFormatType=VALUE\n\nDisplay:\n?0x0h0001=1?@Points Points\nDefault");
+    assert(result == RC_MISSING_VALUE);
+  }
+
+  {
+    /*------------------------------------------------------------------------
     TestEscapedMacro
     ------------------------------------------------------------------------*/
     unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };

--- a/test/test.c
+++ b/test/test.c
@@ -1128,6 +1128,32 @@ static void test_trigger(void) {
 
   {
     /*------------------------------------------------------------------------
+    TestAddHitsNoHitCount
+    Odd use case: AddHits a=1
+                          b=1
+    Since b=1 doesn't have a hitcount, it ignores the hits tallied by a=1
+    ------------------------------------------------------------------------*/
+
+    unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+    memory_t memory;
+    rc_trigger_t* trigger;
+
+    memory.ram = ram;
+    memory.size = sizeof(ram);
+
+    parse_trigger(&trigger, buffer, "C:0xH0001=18_0xH0000=1");
+    comp_trigger(trigger, &memory, 0);
+    assert(condset_get_cond(trigger_get_set(trigger, 0), 0)->current_hits == 1U);
+    assert(condset_get_cond(trigger_get_set(trigger, 0), 1)->current_hits == 0U);
+
+    ram[0] = 1;
+    comp_trigger(trigger, &memory, 1);
+    assert(condset_get_cond(trigger_get_set(trigger, 0), 0)->current_hits == 2U);
+    assert(condset_get_cond(trigger_get_set(trigger, 0), 1)->current_hits == 1U);
+  }
+
+  {
+    /*------------------------------------------------------------------------
     TestHitCountPauseIfResetIf
     Verifies that PauseIf prevents ResetIf processing
     ------------------------------------------------------------------------*/


### PR DESCRIPTION
Found with a Display string similar to this: `@Points Points`
Expected would be: `@Points(0xh1234) Points`

Also generates an error if a lookup has an invalid key: i.e. `ox1234=Happy` instead of `0x1234=Happy`. Previously would assign Happy to 0.