### PR TITLE
fix 24-bit memory read

### DIFF
--- a/src/rcheevos/memref.c
+++ b/src/rcheevos/memref.c
@@ -149,6 +149,7 @@ static unsigned rc_memref_get_value(rc_memref_t* self, rc_peek_t peek, void* ud)
       break;
 
     case RC_MEMSIZE_24_BITS:
+      /* peek 4 bytes - don't expect the caller to understand 24-bit numbers */
       value = peek(self->address, 4, ud);
 
       if (self->is_bcd) {
@@ -158,6 +159,8 @@ static unsigned rc_memref_get_value(rc_memref_t* self, rc_peek_t peek, void* ud)
               + ((value >> 8) & 0x0f) * 100
               + ((value >> 4) & 0x0f) * 10
               + ((value >> 0) & 0x0f) * 1;
+      } else {
+        value &= 0x00FFFFFF;
       }
 
       break;

--- a/test/test.c
+++ b/test/test.c
@@ -466,6 +466,11 @@ static void test_operand(void) {
     parse_comp_operand_value("0x 3", &memory, 0x56ABU);
     parse_comp_operand_value("0x 4", &memory, 0x0056U); /* out of range */
 
+    /* twenty-four-bit */
+    parse_comp_operand_value("0xw0", &memory, 0x341200U);
+    parse_comp_operand_value("0xw2", &memory, 0x56AB34U);
+    parse_comp_operand_value("0xw3", &memory, 0x0056ABU); /* out of range */
+
     /* thirty-two-bit */
     parse_comp_operand_value("0xx0", &memory, 0xAB341200U);
     parse_comp_operand_value("0xx1", &memory, 0x56AB3412U);
@@ -493,6 +498,14 @@ static void test_operand(void) {
     parse_comp_operand_value("0xs3", &memory, 0x0U);
     parse_comp_operand_value("0xt3", &memory, 0x1U);
     parse_comp_operand_value("0xm5", &memory, 0x0U); /* out of range */
+
+    /* BCD */
+    ram[3] = 0x56;
+    parse_comp_operand_value("b0xh0", &memory, 00U);
+    parse_comp_operand_value("b0xh1", &memory, 12U);
+    parse_comp_operand_value("b0x 1", &memory, 3412U);
+    parse_comp_operand_value("b0xw1", &memory, 563412U);
+    parse_comp_operand_value("b0xx1", &memory, 56563412U);
   }
 
   {


### PR DESCRIPTION
The code is asking for 4 bytes, which is 32-bits. If we want 24-bits, we should ask for 3 bytes. However, both RetroArch and RAIntegration only handle peek requests of 1, 2, or 4 bytes, so asking for 3 wouldn't help. Instead, ask for 4, and mask off the 4th one.