### PR TITLE
show hours in rich presence when applicable

### DIFF
--- a/src/rcheevos/format.c
+++ b/src/rcheevos/format.c
@@ -64,32 +64,57 @@ int rc_parse_format(const char* format_str) {
   return RC_FORMAT_VALUE;
 }
 
+static int rc_format_value_seconds(char* buffer, int size, unsigned seconds) {
+  unsigned hours, minutes;
+
+  /* apply modulus math to split the seconds into hours/minutes/seconds */
+  minutes = seconds / 60;
+  seconds -= minutes * 60;
+  if (minutes < 60) {
+    return snprintf(buffer, size, "%u:%02u", minutes, seconds);
+  }
+
+  hours = minutes / 60;
+  minutes -= hours * 60;
+  return snprintf(buffer, size, "%u:%02u:%02u", hours, minutes, seconds);
+}
+
+static int rc_format_value_centiseconds(char* buffer, int size, unsigned centiseconds) {
+  unsigned seconds;
+  int chars, chars2;
+
+  /* modulus off the centiseconds */
+  seconds = centiseconds / 100;
+  centiseconds -= seconds * 100;
+
+  chars = rc_format_value_seconds(buffer, size, seconds);
+  if (chars > 0) {
+    chars2 = snprintf(buffer + chars, size - chars, ".%02u", centiseconds);
+    if (chars2 > 0) {
+      chars += chars2;
+    } else {
+      chars = chars2;
+    }
+  }
+
+  return chars;
+}
+
 int rc_format_value(char* buffer, int size, unsigned value, int format) {
-  unsigned a, b, c;
   int chars;
 
   switch (format) {
     case RC_FORMAT_FRAMES:
-      a = value * 10 / 6; /* centisecs */
-      b = a / 100; /* seconds */
-      a -= b * 100;
-      c = b / 60; /* minutes */
-      b -= c * 60;
-      chars = snprintf(buffer, size, "%02u:%02u.%02u", c, b, a);
+      /* 60 frames per second = 100 centiseconds / 60 frames; multiply frames by 100 / 60 */
+      chars = rc_format_value_centiseconds(buffer, size, value * 10 / 6);
       break;
 
     case RC_FORMAT_SECONDS:
-      a = value / 60; /* minutes */
-      value -= a * 60;
-      chars = snprintf(buffer, size, "%02u:%02u", a, value);
+      chars = rc_format_value_seconds(buffer, size, value);
       break;
 
     case RC_FORMAT_CENTISECS:
-      a = value / 100; /* seconds */
-      value -= a * 100;
-      b = a / 60; /* minutes */
-      a -= b * 60;
-      chars = snprintf(buffer, size, "%02u:%02u.%02u", b, a, value);
+      chars = rc_format_value_centiseconds(buffer, size, value);
       break;
 
     case RC_FORMAT_SCORE:

--- a/test/test.c
+++ b/test/test.c
@@ -2480,6 +2480,15 @@ static void parse_comp_value(const char* memaddr, memory_t* memory, unsigned exp
   assert(rc_evaluate_value(self, peek, memory, NULL) == expected_value);
 }
 
+static void test_format_value(int format, unsigned value, const char* expected) {
+    char buffer[64];
+    int result;
+
+    result = rc_format_value(buffer, sizeof(buffer), value, format);
+    assert(!strcmp(expected, buffer));
+    assert(result == strlen(expected));
+}
+
 static void test_value(void) {
   {
     /*------------------------------------------------------------------------
@@ -2503,34 +2512,18 @@ static void test_value(void) {
     TestFormatValue
     ------------------------------------------------------------------------*/
 
-    char buffer[64];
-
-    rc_format_value(buffer, sizeof(buffer), 12345, RC_FORMAT_VALUE);
-    assert(!strcmp("12345", buffer));
-
-    rc_format_value(buffer, sizeof(buffer), 12345, RC_FORMAT_OTHER);
-    assert(!strcmp("012345", buffer));
-
-    rc_format_value(buffer, sizeof(buffer), 12345, RC_FORMAT_SCORE);
-    assert(!strcmp("012345 Points", buffer));
-
-    rc_format_value(buffer, sizeof(buffer), 12345, RC_FORMAT_SECONDS);
-    assert(!strcmp("205:45", buffer));
-
-    rc_format_value(buffer, sizeof(buffer), 12345, RC_FORMAT_CENTISECS);
-    assert(!strcmp("02:03.45", buffer));
-
-    rc_format_value(buffer, sizeof(buffer), 12345, RC_FORMAT_FRAMES);
-    assert(!strcmp("03:25.75", buffer));
-
-    rc_format_value(buffer, sizeof(buffer), 345, RC_FORMAT_SECONDS);
-    assert(!strcmp("05:45", buffer));
-
-    rc_format_value(buffer, sizeof(buffer), 345, RC_FORMAT_CENTISECS);
-    assert(!strcmp("00:03.45", buffer));
-
-    rc_format_value(buffer, sizeof(buffer), 345, RC_FORMAT_FRAMES);
-    assert(!strcmp("00:05.75", buffer));
+    test_format_value(RC_FORMAT_VALUE, 12345, "12345");
+    test_format_value(RC_FORMAT_OTHER, 12345, "012345");
+    test_format_value(RC_FORMAT_SCORE, 12345, "012345 Points");
+    test_format_value(RC_FORMAT_SECONDS, 45, "0:45");
+    test_format_value(RC_FORMAT_SECONDS, 345, "5:45");
+    test_format_value(RC_FORMAT_SECONDS, 12345, "3:25:45");
+    test_format_value(RC_FORMAT_CENTISECS, 345, "0:03.45");
+    test_format_value(RC_FORMAT_CENTISECS, 12345, "2:03.45");
+    test_format_value(RC_FORMAT_CENTISECS, 1234567, "3:25:45.67");
+    test_format_value(RC_FORMAT_FRAMES, 345, "0:05.75");
+    test_format_value(RC_FORMAT_FRAMES, 12345, "3:25.75");
+    test_format_value(RC_FORMAT_FRAMES, 1234567, "5:42:56.11");
   }
 
   {
@@ -3247,13 +3240,13 @@ static void test_richpresence(void) {
 
     richpresence = parse_richpresence("Format:Frames\nFormatType=FRAMES\n\nDisplay:\n@Frames(0x 0001)", buffer);
     result = rc_evaluate_richpresence(richpresence, output, sizeof(output), peek, &memory, NULL);
-    assert(strcmp(output, "03:42.16") == 0);
-    assert(result == 8);
+    assert(strcmp(output, "3:42.16") == 0);
+    assert(result == 7);
 
     ram[1] = 20;
     result = rc_evaluate_richpresence(richpresence, output, sizeof(output), peek, &memory, NULL);
-    assert(strcmp(output, "03:42.20") == 0);
-    assert(result == 8);
+    assert(strcmp(output, "3:42.20") == 0);
+    assert(result == 7);
   }
 
   {


### PR DESCRIPTION
Modifies the `rc_format_value` function to return hours when the number of minutes exceeds 60.

Intent is to make these more readable:
![image](https://user-images.githubusercontent.com/32680403/60759652-09f73080-9fe6-11e9-8efa-e79d1f339c5c.png)

The first would display `3:29:40.68`, the second would display `6:52:17.98`, and the last would display `16:15:10.56`. Times not exceeding `59:59.99` would still be displayed without the hours portion.