### PR TITLE
add SIGNED format type

### DIFF
--- a/include/rcheevos.h
+++ b/include/rcheevos.h
@@ -338,7 +338,8 @@ enum {
   RC_FORMAT_CENTISECS,
   RC_FORMAT_SCORE,
   RC_FORMAT_VALUE,
-  RC_FORMAT_OTHER
+  RC_FORMAT_OTHER,
+  RC_FORMAT_SIGNED
 };
 
 int rc_parse_format(const char* format_str);

--- a/src/rcheevos/format.c
+++ b/src/rcheevos/format.c
@@ -26,6 +26,9 @@ int rc_parse_format(const char* format_str) {
       if (!strcmp(format_str, "ECS")) {
         return RC_FORMAT_SECONDS;
       }
+      if (!strcmp(format_str, "IGNED")) {
+        return RC_FORMAT_SIGNED;
+      }
       if (!strcmp(format_str, "CORE")) {
         return RC_FORMAT_SCORE;
       }
@@ -123,6 +126,10 @@ int rc_format_value(char* buffer, int size, unsigned value, int format) {
 
     case RC_FORMAT_VALUE:
       chars = snprintf(buffer, size, "%01u", value);
+      break;
+
+    case RC_FORMAT_SIGNED:
+      chars = snprintf(buffer, size, "%01d", (int)value);
       break;
 
     case RC_FORMAT_OTHER:

--- a/test/test.c
+++ b/test/test.c
@@ -2513,6 +2513,7 @@ static void test_value(void) {
     ------------------------------------------------------------------------*/
 
     test_format_value(RC_FORMAT_VALUE, 12345, "12345");
+    test_format_value(RC_FORMAT_VALUE, 0xFFFFFFFF, "4294967295");
     test_format_value(RC_FORMAT_OTHER, 12345, "012345");
     test_format_value(RC_FORMAT_SCORE, 12345, "012345 Points");
     test_format_value(RC_FORMAT_SECONDS, 45, "0:45");
@@ -2524,6 +2525,9 @@ static void test_value(void) {
     test_format_value(RC_FORMAT_FRAMES, 345, "0:05.75");
     test_format_value(RC_FORMAT_FRAMES, 12345, "3:25.75");
     test_format_value(RC_FORMAT_FRAMES, 1234567, "5:42:56.11");
+    test_format_value(RC_FORMAT_SIGNED, 12345, "12345");
+    test_format_value(RC_FORMAT_SIGNED, (unsigned)-12345, "-12345");
+    test_format_value(RC_FORMAT_SIGNED, 0xFFFFFFFF, "-1");
   }
 
   {
@@ -3223,6 +3227,29 @@ static void test_richpresence(void) {
     ram[1] = 20;
     result = rc_evaluate_richpresence(richpresence, output, sizeof(output), peek, &memory, NULL);
     assert(strcmp(output, "13332 Points") == 0);
+    assert(result == 12);
+  }
+
+  {
+    /*------------------------------------------------------------------------
+    TestSignedMacro
+    ------------------------------------------------------------------------*/
+    unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+    memory_t memory;
+    rc_richpresence_t* richpresence;
+    int result;
+
+    memory.ram = ram;
+    memory.size = sizeof(ram);
+
+    richpresence = parse_richpresence("Format:Points\nFormatType=SIGNED\n\nDisplay:\n@Points(0x 0001_v-10000) Points", buffer);
+    result = rc_evaluate_richpresence(richpresence, output, sizeof(output), peek, &memory, NULL);
+    assert(strcmp(output, "3330 Points") == 0);
+    assert(result == 11);
+
+    ram[2] = 10;
+    result = rc_evaluate_richpresence(richpresence, output, sizeof(output), peek, &memory, NULL);
+    assert(strcmp(output, "-7422 Points") == 0);
     assert(result == 12);
   }
 


### PR DESCRIPTION
`rc_evaluate_value` returns an unsigned int, and formatting for `SCORE`, `VALUE`, and `OTHER` types also treats the value as unsigned. There are cases (such as [this leaderboard](https://retroachievements.org/leaderboardinfo.php?i=2639)) where negative values are desired. With the rcheevos implementation, a value above `MAX_INT` was submitted and truncated to `MAX_INT`.

This solution adds a `SIGNED` format, which will cast the unsigned value back to a signed value and use a signed formatter to convert the value to a string. This will address the on-screen display, but further changes will be required in the DLL to submit a negative value to the server.

Additionally, the leaderboard editor page will need to be updated to allow specifying `SIGNED` as the format for the leaderboard.

This also opens up the `SIGNED` format for use in rich presence, with no further changes required in the DLL or website:
```
Format:Money
FormatType=SIGNED

Display:$@Money(0xx2045)
```

Note: this assumes 32-bit signed values. If reading less than 32-bits from memory, the sign bit would have to be extended:
```
Display:$@Money(0x 2045_hffff0000*0xt2046)
```
`t` is the uppermost bit of the 16-bit value, and the multiplication sets all the bits in the upper 16-bits if the test bit was set.