### PR TITLE
make rc_evaluate_value return signed int

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ rc_value_t* rc_parse_value(void* buffer, const char* memaddr, lua_State* L, int 
 To compute the value, use `rc_evaluate_value`:
 
 ```c
-unsigned rc_evaluate_value(rc_value_t* value, rc_peek_t peek, void* ud, lua_State* L);
+int rc_evaluate_value(rc_value_t* value, rc_peek_t peek, void* ud, lua_State* L);
 ```
 
 `value` is the value to compute the value of, and `peek`, `ud`, and `L`, are as in [`rc_test_trigger`](#rc_test_trigger).
@@ -404,7 +404,7 @@ rc_lboard_t* rc_parse_lboard(void* buffer, const char* memaddr, lua_State* L, in
 A leaderboard can be evaluated with the `rc_evaluate_lboard` function:
 
 ```c
-int rc_evaluate_lboard(rc_lboard_t* lboard, unsigned* value, rc_peek_t peek, void* peek_ud, lua_State* L);
+int rc_evaluate_lboard(rc_lboard_t* lboard, int* value, rc_peek_t peek, void* peek_ud, lua_State* L);
 ```
 
 The function returns an action that must be performed by the caller, and `value` contains the value to be used for that action when the function returns. The action can be one of:
@@ -460,10 +460,10 @@ enum {
 `rc_format_value` can be used to format the given value into the provided buffer:
 
 ```c
-void rc_format_value(char* buffer, int size, unsigned value, int format);
+int rc_format_value(char* buffer, int size, int value, int format);
 ```
 
-`buffer` receives `value` formatted according to `format`. No more than `size` characters will be written to `buffer`. 32 characters are enough to hold any valid value with any format.
+`buffer` receives `value` formatted according to `format`. No more than `size` characters will be written to `buffer`. 32 characters are enough to hold any valid value with any format. The returned value is the number of characters written.
 
 # **rurl**
 

--- a/include/rcheevos.h
+++ b/include/rcheevos.h
@@ -294,7 +294,7 @@ rc_value_t;
 
 int rc_value_size(const char* memaddr);
 rc_value_t* rc_parse_value(void* buffer, const char* memaddr, lua_State* L, int funcs_ndx);
-unsigned rc_evaluate_value(rc_value_t* value, rc_peek_t peek, void* ud, lua_State* L);
+int rc_evaluate_value(rc_value_t* value, rc_peek_t peek, void* ud, lua_State* L);
 
 /*****************************************************************************\
 | Leaderboards                                                                |
@@ -324,7 +324,7 @@ rc_lboard_t;
 
 int rc_lboard_size(const char* memaddr);
 rc_lboard_t* rc_parse_lboard(void* buffer, const char* memaddr, lua_State* L, int funcs_ndx);
-int rc_evaluate_lboard(rc_lboard_t* lboard, unsigned* value, rc_peek_t peek, void* peek_ud, lua_State* L);
+int rc_evaluate_lboard(rc_lboard_t* lboard, int* value, rc_peek_t peek, void* peek_ud, lua_State* L);
 void rc_reset_lboard(rc_lboard_t* lboard);
 
 /*****************************************************************************\
@@ -342,7 +342,7 @@ enum {
 };
 
 int rc_parse_format(const char* format_str);
-int rc_format_value(char* buffer, int size, unsigned value, int format);
+int rc_format_value(char* buffer, int size, int value, int format);
 
 /*****************************************************************************\
 | Rich Presence                                                               |

--- a/src/rcheevos/expression.c
+++ b/src/rcheevos/expression.c
@@ -27,9 +27,9 @@ rc_expression_t* rc_parse_expression(const char** memaddr, rc_parse_state_t* par
   return self;
 }
 
-unsigned rc_evaluate_expression(rc_expression_t* self, rc_peek_t peek, void* ud, lua_State* L) {
+int rc_evaluate_expression(rc_expression_t* self, rc_peek_t peek, void* ud, lua_State* L) {
   rc_term_t* term;
-  unsigned value;
+  int value;
 
   value = 0;
 

--- a/src/rcheevos/format.c
+++ b/src/rcheevos/format.c
@@ -100,7 +100,7 @@ static int rc_format_value_centiseconds(char* buffer, int size, unsigned centise
   return chars;
 }
 
-int rc_format_value(char* buffer, int size, unsigned value, int format) {
+int rc_format_value(char* buffer, int size, int value, int format) {
   int chars;
 
   switch (format) {
@@ -118,16 +118,16 @@ int rc_format_value(char* buffer, int size, unsigned value, int format) {
       break;
 
     case RC_FORMAT_SCORE:
-      chars = snprintf(buffer, size, "%06u Points", value);
+      chars = snprintf(buffer, size, "%06d Points", value);
       break;
 
     case RC_FORMAT_VALUE:
-      chars = snprintf(buffer, size, "%01u", value);
+      chars = snprintf(buffer, size, "%01d", value);
       break;
 
     case RC_FORMAT_OTHER:
     default:
-      chars = snprintf(buffer, size, "%06u", value);
+      chars = snprintf(buffer, size, "%06d", value);
       break;
   }
 

--- a/src/rcheevos/internal.h
+++ b/src/rcheevos/internal.h
@@ -85,10 +85,10 @@ int rc_parse_operand(rc_operand_t* self, const char** memaddr, int is_trigger, r
 unsigned rc_evaluate_operand(rc_operand_t* self, rc_peek_t peek, void* ud, lua_State* L);
 
 rc_term_t* rc_parse_term(const char** memaddr, rc_parse_state_t* parse);
-unsigned rc_evaluate_term(rc_term_t* self, rc_peek_t peek, void* ud, lua_State* L);
+int rc_evaluate_term(rc_term_t* self, rc_peek_t peek, void* ud, lua_State* L);
 
 rc_expression_t* rc_parse_expression(const char** memaddr, rc_parse_state_t* parse);
-unsigned rc_evaluate_expression(rc_expression_t* self, rc_peek_t peek, void* ud, lua_State* L);
+int rc_evaluate_expression(rc_expression_t* self, rc_peek_t peek, void* ud, lua_State* L);
 
 void rc_parse_value_internal(rc_value_t* self, const char** memaddr, rc_parse_state_t* parse);
 

--- a/src/rcheevos/lboard.c
+++ b/src/rcheevos/lboard.c
@@ -162,7 +162,7 @@ rc_lboard_t* rc_parse_lboard(void* buffer, const char* memaddr, lua_State* L, in
   return parse.offset >= 0 ? self : 0;
 }
 
-int rc_evaluate_lboard(rc_lboard_t* self, unsigned* value, rc_peek_t peek, void* peek_ud, lua_State* L) {
+int rc_evaluate_lboard(rc_lboard_t* self, int* value, rc_peek_t peek, void* peek_ud, lua_State* L) {
   int start_ok, cancel_ok, submit_ok;
   int action = -1;
 

--- a/src/rcheevos/term.c
+++ b/src/rcheevos/term.c
@@ -88,12 +88,16 @@ rc_term_t* rc_parse_term(const char** memaddr, rc_parse_state_t* parse) {
   return self;
 }
 
-unsigned rc_evaluate_term(rc_term_t* self, rc_peek_t peek, void* ud, lua_State* L) {
+int rc_evaluate_term(rc_term_t* self, rc_peek_t peek, void* ud, lua_State* L) {
+  /* Operands are usually memory references and are always retrieved as unsigned. The floating
+   * point operand is signed, and will automatically make the result signed. Otherwise, multiply
+   * by the secondary operand (which is usually 1) and cast to signed.
+   */
   unsigned value = rc_evaluate_operand(&self->operand1, peek, ud, L);
 
   if (self->operand2.type != RC_OPERAND_FP) {
-    return value * (rc_evaluate_operand(&self->operand2, peek, ud, L) ^ self->invert);
+    return (int)(value * (rc_evaluate_operand(&self->operand2, peek, ud, L) ^ self->invert));
   }
 
-  return (unsigned)((double)value * self->operand2.value.dbl);
+  return (int)((double)value * self->operand2.value.dbl);
 }

--- a/src/rcheevos/value.c
+++ b/src/rcheevos/value.c
@@ -50,9 +50,9 @@ rc_value_t* rc_parse_value(void* buffer, const char* memaddr, lua_State* L, int 
   return parse.offset >= 0 ? self : 0;
 }
 
-unsigned rc_evaluate_value(rc_value_t* self, rc_peek_t peek, void* ud, lua_State* L) {
+int rc_evaluate_value(rc_value_t* self, rc_peek_t peek, void* ud, lua_State* L) {
   rc_expression_t* exp;
-  unsigned value, max;
+  int value, max;
 
   rc_update_memref_values(self->memrefs, peek, ud);
 


### PR DESCRIPTION
Since both the database and PHP codebase currently only support signed 32-bit values for leaderboard entries, it doesn't make sense to calculate them as unsigned 32-bit values. 

The result is that negative values get converted to very large positive values and then clamped to MAX_INT as seen in [this leaderboard](https://retroachievements.org/leaderboardinfo.php?i=2639). The negative value is a valid entry from before the 0.75 DLL was released (0.75 is the first DLL to include rcheevos). The 2147483647 value was submitted after the 0.75 DLL was released. The player who achieved that entry posted on the game wall indicating his final score was negative. The bug was traced to `rc_evaluate_value` returning an unsigned int, which the DLL blindly passed to the server. This PR changes `rc_evaluate_value` to return a signed int. Further changes will be made in the DLL to ensure it's also passed to the server as a signed int.

`rc_format_value` and several helper functions are also affected. `rc_evaluate_operand` still returns an unsigned int as it's a raw un-typed memory read.

As a side note, `rc_evaluate_value` is also used to evaluate Rich Presence parameters.
```
Format:Money
FormatType=VALUE

Display:$@Money(0xx2045)
```
This change allows money to be displayed as a negative value. However, it relies on the result of the calculation being a signed 32-bit value. In this case, a 32-bit value is read from memory. If a smaller value were read, it would have to somehow be converted to a signed 32-bit value. Here's an example for sign-extending a 16-bit read:
```
Display:$@Money(0x 2045_hffff0000*0xt2046)
```
If the 15th bit (`0xt2046`) is set, the 16 upper bits of the 32-bit value (`hffff0000`) will also be set.