### PR TITLE
fix overflow truncation when sizeof(long) is not 4

### DIFF
--- a/src/rcheevos/operand.c
+++ b/src/rcheevos/operand.c
@@ -219,6 +219,7 @@ static int rc_parse_operand_term(rc_operand_t* self, const char** memaddr, rc_pa
   char* end;
   int ret;
   unsigned long value;
+  long svalue;
 
   switch (*aux) {
     case 'h': case 'H':
@@ -239,18 +240,18 @@ static int rc_parse_operand_term(rc_operand_t* self, const char** memaddr, rc_pa
       break;
     
     case 'v': case 'V':
-      value = strtoul(++aux, &end, 10);
+      svalue = strtol(++aux, &end, 10);
 
       if (end == aux) {
         return RC_INVALID_CONST_OPERAND;
       }
 
-      if (value > 0xffffffffU) {
-        value = 0xffffffffU;
+      if (svalue > 0xffffffffU) {
+        svalue = 0xffffffffU;
       }
 
       self->type = RC_OPERAND_CONST;
-      self->value.num = (unsigned)value;
+      self->value.num = (unsigned)svalue;
 
       aux = end;
       break;

--- a/test/rcheevos-test.vcxproj
+++ b/test/rcheevos-test.vcxproj
@@ -88,6 +88,7 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\include;$(ProjectDir)..\src\rcheevos;$(ProjectDir)lua\src</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">

--- a/test/test.c
+++ b/test/test.c
@@ -2564,7 +2564,8 @@ static void parse_comp_value(const char* memaddr, memory_t* memory, int expected
   assert(self != NULL);
   assert(*((int*)((char*)buffer + ret)) == 0xEEEEEEEE);
 
-  assert(rc_evaluate_value(self, peek, memory, NULL) == expected_value);
+  ret = rc_evaluate_value(self, peek, memory, NULL);
+  assert(ret == expected_value);
 }
 
 static void test_format_value(int format, int value, const char* expected) {
@@ -2594,6 +2595,8 @@ static void test_value(void) {
     parse_comp_value("0xH0001_0xH0004*3$0xH0002*0xL0003", &memory, 0x34 * 0xB);/* TestMaximumComplex */
     parse_comp_value("0xH0001_V-20", &memory, 0x12 - 20);
     parse_comp_value("0xH0001_H10", &memory, 0x12 + 0x10);
+
+    parse_comp_value("0xh0000*-1_99_0xh0001*-100_5900", &memory, 4199);
   }
 
   {


### PR DESCRIPTION
Appears as an issue when evaluating `V-10` on 64-bit android. `strtoul` returns `0xFFFFFFFFFFFFFFF6`, which is greater than `0xFFFFFFFF`, so it is clamped to `0xFFFFFFFF` assuming the user just typed in a number larger than a 32-bit number. The end result is the `V-10` is converted to `V-1`.

On 64-bit Windows, `strtoul` still return a 32-bit long: `0xFFFFFFF6`, so everything is fine there. Tested/verified by using `strtoull` temporarily.