### PR TITLE
add rc_evaluate_trigger

### DIFF
--- a/include/rcheevos.h
+++ b/include/rcheevos.h
@@ -34,7 +34,8 @@ enum {
   RC_OUT_OF_MEMORY = -19,
   RC_INVALID_VALUE_FLAG = -20,
   RC_MISSING_VALUE_MEASURED = -21,
-  RC_DUPLICATED_VALUE_MEASURED = -22
+  RC_MULTIPLE_MEASURED = -22,
+  RC_INVALID_MEASURED_TARGET = -23
 };
 
 /*****************************************************************************\
@@ -214,6 +215,7 @@ struct rc_condition_t {
 
   /* The type of the condition. */
   char type;
+
   /* The comparison operator to use. */
   char oper; /* operator is a reserved word in C++. */
 
@@ -223,8 +225,6 @@ struct rc_condition_t {
   /* Whether or not the condition evaluated true on the last check */
   char is_true;
 };
-
-unsigned rc_total_hit_count(rc_condition_t* first, rc_condition_t* condition);
 
 /*****************************************************************************\
 | Condition sets                                                              |
@@ -244,9 +244,6 @@ struct rc_condset_t {
 
   /* True if the set is currently paused. */
   char is_paused;
-
-  /* True if any condition in the set has a nonzero hit target. */
-  char has_hit_targets;
 };
 
 /*****************************************************************************\
@@ -275,11 +272,11 @@ typedef struct {
   /* The current state of the MEASURED condition. */
   unsigned measured_value;
 
+  /* The target state of the MEASURED condition */
+  unsigned measured_target;
+
   /* The current state of the trigger */
   char state;
-
-  /* True if at least one condition has a reset flag and at least one condition has a hit target */
-  char can_reset;
 
   /* True if at least one condition has a non-zero hit count */
   char has_hits;

--- a/src/rcheevos/alloc.c
+++ b/src/rcheevos/alloc.c
@@ -44,6 +44,7 @@ void rc_init_parse_state(rc_parse_state_t* parse, void* buffer, lua_State* L, in
   parse->scratch.memref_size = sizeof(parse->scratch.memref_buffer) / sizeof(parse->scratch.memref_buffer[0]);
   parse->scratch.memref_count = 0;
   parse->first_memref = 0;
+  parse->measured_target = 0;
 }
 
 void rc_destroy_parse_state(rc_parse_state_t* parse)

--- a/src/rcheevos/condition.c
+++ b/src/rcheevos/condition.c
@@ -136,32 +136,3 @@ int rc_test_condition(rc_condition_t* self, rc_eval_state_t* eval_state) {
     default: return 1;
   }
 }
-
-unsigned rc_total_hit_count(rc_condition_t* first, rc_condition_t* condition) {
-  unsigned total;
-
-  total = 0;
-  for (; first != 0; first = first->next) {
-    total += first->current_hits;
-    if (first == condition)
-      return total;
-
-    switch (first->type) {
-      case RC_CONDITION_ADD_HITS:
-      case RC_CONDITION_ADD_SOURCE:
-      case RC_CONDITION_SUB_SOURCE:
-      case RC_CONDITION_AND_NEXT:
-      case RC_CONDITION_ADD_ADDRESS:
-        /* combining flag, don't reset total */
-        break;
-
-      default:
-        /* non-combining flag, reset total */
-        total = 0;
-        break;
-    }
-  }
-
-  /* condition not found */
-  return 0;
-}

--- a/src/rcheevos/condition.c
+++ b/src/rcheevos/condition.c
@@ -121,9 +121,9 @@ rc_condition_t* rc_parse_condition(const char** memaddr, rc_parse_state_t* parse
   return self;
 }
 
-int rc_test_condition(rc_condition_t* self, unsigned add_buffer, unsigned address_offset, rc_peek_t peek, void* ud, lua_State* L) {
-  unsigned value1 = rc_evaluate_operand(&self->operand1, address_offset, peek, ud, L) + add_buffer;
-  unsigned value2 = rc_evaluate_operand(&self->operand2, address_offset, peek, ud, L);
+int rc_test_condition(rc_condition_t* self, rc_eval_state_t* eval_state) {
+  unsigned value1 = rc_evaluate_operand(&self->operand1, eval_state) + eval_state->add_value;
+  unsigned value2 = rc_evaluate_operand(&self->operand2, eval_state);
 
   switch (self->oper) {
     case RC_CONDITION_EQ: return value1 == value2;

--- a/src/rcheevos/condset.c
+++ b/src/rcheevos/condset.c
@@ -246,7 +246,7 @@ int rc_test_condset(rc_condset_t* self, rc_eval_state_t* eval_state) {
   }
 
   if (self->has_pause) {
-    if (self->is_paused = rc_test_condset_internal(self, 1, eval_state)) {
+    if ((self->is_paused = rc_test_condset_internal(self, 1, eval_state))) {
       /* one or more Pause conditions exists, if any of them are true, stop processing this group */
       return 0;
     }

--- a/src/rcheevos/condset.c
+++ b/src/rcheevos/condset.c
@@ -86,14 +86,13 @@ rc_condset_t* rc_parse_condset(const char** memaddr, rc_parse_state_t* parse) {
   return self;
 }
 
-static int rc_test_condset_internal(rc_condset_t* self, int processing_pause, int* reset, rc_peek_t peek, void* ud, lua_State* L) {
+static int rc_test_condset_internal(rc_condset_t* self, int processing_pause, rc_eval_state_t* eval_state) {
   rc_condition_t* condition;
   int set_valid, cond_valid, prev_cond;
-  unsigned add_value, add_hits, add_address;
 
   set_valid = 1;
   prev_cond = 1;
-  add_value = add_hits = add_address = 0;
+  eval_state->add_value = eval_state->add_hits = eval_state->add_address = 0;
 
   for (condition = self->conditions; condition != 0; condition = condition->next) {
     if (condition->pause != processing_pause) {
@@ -102,18 +101,18 @@ static int rc_test_condset_internal(rc_condset_t* self, int processing_pause, in
 
     switch (condition->type) {
       case RC_CONDITION_ADD_SOURCE:
-        add_value += rc_evaluate_operand(&condition->operand1, add_address, peek, ud, L);
-        add_address = 0;
+        eval_state->add_value += rc_evaluate_operand(&condition->operand1, eval_state);
+        eval_state->add_address = 0;
         continue;
       
       case RC_CONDITION_SUB_SOURCE:
-        add_value -= rc_evaluate_operand(&condition->operand1, add_address, peek, ud, L);
-        add_address = 0;
+        eval_state->add_value -= rc_evaluate_operand(&condition->operand1, eval_state);
+        eval_state->add_address = 0;
         continue;
       
       case RC_CONDITION_ADD_HITS:
         /* always evaluate the condition to ensure everything is updated correctly */
-        cond_valid = rc_test_condition(condition, add_value, add_address, peek, ud, L);
+        cond_valid = rc_test_condition(condition, eval_state);
 
         /* merge AndNext value and reset it for the next condition */
         cond_valid &= prev_cond;
@@ -124,33 +123,38 @@ static int rc_test_condset_internal(rc_condset_t* self, int processing_pause, in
           if (condition->required_hits == 0 || condition->current_hits < condition->required_hits) {
             condition->current_hits++;
           }
+
+          condition->is_true = (condition->required_hits == 0 || condition->current_hits >= condition->required_hits);
+        }
+        else {
+          condition->is_true = 0;
         }
 
-        add_value = 0;
-        add_address = 0;
-        add_hits += condition->current_hits;
+        eval_state->add_value = 0;
+        eval_state->add_address = 0;
+        eval_state->add_hits += condition->current_hits;
         continue;
 
       case RC_CONDITION_AND_NEXT:
-        prev_cond &= rc_test_condition(condition, add_value, add_address, peek, ud, L);
-        add_value = 0;
-        add_address = 0;
+        prev_cond &= rc_test_condition(condition, eval_state);
+        eval_state->add_value = 0;
+        eval_state->add_address = 0;
         continue;
 
       case RC_CONDITION_ADD_ADDRESS:
-        add_address = rc_evaluate_operand(&condition->operand1, add_address, peek, ud, L);
+        eval_state->add_address = rc_evaluate_operand(&condition->operand1, eval_state);
         continue;
     }
 
     /* always evaluate the condition to ensure everything is updated correctly */
-    cond_valid = rc_test_condition(condition, add_value, add_address, peek, ud, L);
+    cond_valid = rc_test_condition(condition, eval_state);
 
     /* merge AndNext value and reset it for the next condition */
     cond_valid &= prev_cond;
     prev_cond = 1;
 
     /* if the condition has a target hit count that has already been met, it's automatically true, even if not currently true. */
-    if (condition->required_hits != 0 && (condition->current_hits + add_hits) >= condition->required_hits) {
+    if (condition->required_hits != 0 && (condition->current_hits + eval_state->add_hits) >= condition->required_hits) {
       cond_valid = 1;
     }
     else if (cond_valid) {
@@ -159,14 +163,24 @@ static int rc_test_condset_internal(rc_condset_t* self, int processing_pause, in
       if (condition->required_hits == 0) {
         /* not a hit-based requirement: ignore any additional logic! */
       }
-      else if ((condition->current_hits + add_hits) < condition->required_hits) {
+      else if ((condition->current_hits + eval_state->add_hits) < condition->required_hits) {
         /* HitCount target has not yet been met, condition is not yet valid */
         cond_valid = 0;
       }
     }
+    condition->is_true = cond_valid;
+    eval_state->has_hits = (condition->current_hits || eval_state->add_hits);
+
+    /* capture measured state */
+    if (condition->type == RC_CONDITION_MEASURED) {
+      if (condition->required_hits > 0)
+        eval_state->measured_value = condition->current_hits + eval_state->add_hits;
+      else
+        eval_state->measured_value = rc_evaluate_operand(&condition->operand1, eval_state) + eval_state->add_value;
+    }
 
     /* reset AddHits and AddSource/SubSource values */
-    add_value = add_hits = add_address = 0;
+    eval_state->add_value = eval_state->add_hits = eval_state->add_address = 0;
 
     switch (condition->type) {
       case RC_CONDITION_PAUSE_IF:
@@ -191,7 +205,7 @@ static int rc_test_condset_internal(rc_condset_t* self, int processing_pause, in
       
       case RC_CONDITION_RESET_IF:
         if (cond_valid) {
-          *reset = 1; /* let caller know to reset all hit counts */
+          eval_state->was_reset = 1; /* let caller know to reset all hit counts */
           set_valid = 0; /* cannot be valid if we've hit a reset condition */
         }
 
@@ -206,18 +220,20 @@ static int rc_test_condset_internal(rc_condset_t* self, int processing_pause, in
   return set_valid;
 }
 
-int rc_test_condset(rc_condset_t* self, int* reset, rc_peek_t peek, void* ud, lua_State* L) {
+int rc_test_condset(rc_condset_t* self, rc_eval_state_t* eval_state) {
   if (self->conditions == 0) {
     /* important: empty group must evaluate true */
     return 1;
   }
 
-  if (self->has_pause && rc_test_condset_internal(self, 1, reset, peek, ud, L)) {
-    /* one or more Pause conditions exists, if any of them are true, stop processing this group */
-    return 0;
+  if (self->has_pause) {
+    if (self->is_paused = rc_test_condset_internal(self, 1, eval_state)) {
+      /* one or more Pause conditions exists, if any of them are true, stop processing this group */
+      return 0;
+    }
   }
 
-  return rc_test_condset_internal(self, 0, reset, peek, ud, L);
+  return rc_test_condset_internal(self, 0, eval_state);
 }
 
 void rc_reset_condset(rc_condset_t* self) {

--- a/src/rcheevos/expression.c
+++ b/src/rcheevos/expression.c
@@ -27,14 +27,14 @@ rc_expression_t* rc_parse_expression(const char** memaddr, rc_parse_state_t* par
   return self;
 }
 
-int rc_evaluate_expression(rc_expression_t* self, rc_peek_t peek, void* ud, lua_State* L) {
+int rc_evaluate_expression(rc_expression_t* self, rc_eval_state_t* eval_state) {
   rc_term_t* term;
   int value;
 
   value = 0;
 
   for (term = self->terms; term != 0; term = term->next) {
-    value += rc_evaluate_term(term, peek, ud, L);
+    value += rc_evaluate_term(term, eval_state);
   }
 
   return value;

--- a/src/rcheevos/internal.h
+++ b/src/rcheevos/internal.h
@@ -50,6 +50,21 @@ typedef struct {
 rc_scratch_t;
 
 typedef struct {
+  unsigned add_value;       /* AddSource/SubSource */
+  unsigned add_hits;        /* AddHits */
+  unsigned add_address;     /* AddAddress */
+
+  rc_peek_t peek;
+  void* peek_userdata;
+  lua_State* L;
+
+  unsigned measured_value;  /* Measured */
+  char was_reset;           /* ResetIf triggered */
+  char has_hits;            /* one of more hit counts is non-zero */
+}
+rc_eval_state_t;
+
+typedef struct {
   int offset;
 
   lua_State* L;
@@ -72,25 +87,25 @@ char* rc_alloc_str(rc_parse_state_t* parse, const char* text, int length);
 rc_memref_value_t* rc_alloc_memref_value(rc_parse_state_t* parse, unsigned address, char size, char is_bcd, char is_indirect);
 void rc_update_memref_values(rc_memref_value_t* memref, rc_peek_t peek, void* ud);
 void rc_update_memref_value(rc_memref_value_t* memref, rc_peek_t peek, void* ud);
-rc_memref_value_t* rc_get_indirect_memref(rc_memref_value_t* memref, unsigned address_offset, rc_peek_t peek, void* ud);
+rc_memref_value_t* rc_get_indirect_memref(rc_memref_value_t* memref, rc_eval_state_t* eval_state);
 
 void rc_parse_trigger_internal(rc_trigger_t* self, const char** memaddr, rc_parse_state_t* parse);
 
 rc_condset_t* rc_parse_condset(const char** memaddr, rc_parse_state_t* parse);
-int rc_test_condset(rc_condset_t* self, int* reset, rc_peek_t peek, void* ud, lua_State* L);
+int rc_test_condset(rc_condset_t* self, rc_eval_state_t* eval_state);
 void rc_reset_condset(rc_condset_t* self);
 
 rc_condition_t* rc_parse_condition(const char** memaddr, rc_parse_state_t* parse, int is_indirect);
-int rc_test_condition(rc_condition_t* self, unsigned add_value, unsigned address_offset, rc_peek_t peek, void* ud, lua_State* L);
+int rc_test_condition(rc_condition_t* self, rc_eval_state_t* eval_state);
 
 int rc_parse_operand(rc_operand_t* self, const char** memaddr, int is_trigger, int is_indirect, rc_parse_state_t* parse);
-unsigned rc_evaluate_operand(rc_operand_t* self, unsigned address_offset, rc_peek_t peek, void* ud, lua_State* L);
+unsigned rc_evaluate_operand(rc_operand_t* self, rc_eval_state_t* eval_state);
 
 rc_term_t* rc_parse_term(const char** memaddr, int is_indirect, rc_parse_state_t* parse);
-int rc_evaluate_term(rc_term_t* self, rc_peek_t peek, void* ud, lua_State* L);
+int rc_evaluate_term(rc_term_t* self, rc_eval_state_t* eval_state);
 
 rc_expression_t* rc_parse_expression(const char** memaddr, rc_parse_state_t* parse);
-int rc_evaluate_expression(rc_expression_t* self, rc_peek_t peek, void* ud, lua_State* L);
+int rc_evaluate_expression(rc_expression_t* self, rc_eval_state_t* eval_state);
 
 void rc_parse_value_internal(rc_value_t* self, const char** memaddr, rc_parse_state_t* parse);
 

--- a/src/rcheevos/internal.h
+++ b/src/rcheevos/internal.h
@@ -74,6 +74,8 @@ typedef struct {
   rc_scratch_t scratch;
 
   rc_memref_value_t** first_memref;
+
+  unsigned measured_target;
 }
 rc_parse_state_t;
 

--- a/src/rcheevos/memref.c
+++ b/src/rcheevos/memref.c
@@ -257,16 +257,16 @@ void rc_init_parse_state_memrefs(rc_parse_state_t* parse, rc_memref_value_t** me
   *memrefs = 0;
 }
 
-rc_memref_value_t* rc_get_indirect_memref(rc_memref_value_t* memref, unsigned address_offset, rc_peek_t peek, void* ud) {
+rc_memref_value_t* rc_get_indirect_memref(rc_memref_value_t* memref, rc_eval_state_t* eval_state) {
   unsigned new_address;
 
-  if (address_offset == 0)
+  if (eval_state->add_address == 0)
     return memref;
 
   if (!memref->memref.is_indirect)
     return memref;
 
-  new_address = memref->memref.address + address_offset;
+  new_address = memref->memref.address + eval_state->add_address;
 
   /* an extra rc_memref_value_t is allocated for offset calculations */
   memref = memref->next;
@@ -274,7 +274,7 @@ rc_memref_value_t* rc_get_indirect_memref(rc_memref_value_t* memref, unsigned ad
   /* if the adjusted address has changed, update the record */
   if (memref->memref.address != new_address) {
     memref->memref.address = new_address;
-    rc_update_memref_value(memref, peek, ud);
+    rc_update_memref_value(memref, eval_state->peek, eval_state->peek_userdata);
   }
 
   return memref;

--- a/src/rcheevos/operand.c
+++ b/src/rcheevos/operand.c
@@ -151,6 +151,11 @@ static int rc_parse_operand_trigger(rc_operand_t* self, const char** memaddr, in
 
   switch (*aux) {
     case 'h': case 'H':
+      if (aux[2] == 'x' || aux[2] == 'X') {
+        /* H0x1234 is a typo - either H1234 or 0xH1234 was probably meant */
+        return RC_INVALID_CONST_OPERAND;
+      }
+
       value = strtoul(++aux, &end, 16);
 
       if (end == aux) {

--- a/src/rcheevos/operand.c
+++ b/src/rcheevos/operand.c
@@ -334,7 +334,7 @@ static int rc_luapeek(lua_State* L) {
 
 #endif /* RC_DISABLE_LUA */
 
-unsigned rc_evaluate_operand(rc_operand_t* self, unsigned address_offset, rc_peek_t peek, void* ud, lua_State* L) {
+unsigned rc_evaluate_operand(rc_operand_t* self, rc_eval_state_t* eval_state) {
 #ifndef RC_DISABLE_LUA
   rc_luapeek_t luapeek;
 #endif /* RC_DISABLE_LUA */
@@ -353,25 +353,25 @@ unsigned rc_evaluate_operand(rc_operand_t* self, unsigned address_offset, rc_pee
     case RC_OPERAND_LUA:
 #ifndef RC_DISABLE_LUA
 
-      if (L != 0) {
-        lua_rawgeti(L, LUA_REGISTRYINDEX, self->value.luafunc);
-        lua_pushcfunction(L, rc_luapeek);
+      if (eval_state->L != 0) {
+        lua_rawgeti(eval_state->L, LUA_REGISTRYINDEX, self->value.luafunc);
+        lua_pushcfunction(eval_state->L, rc_luapeek);
 
-        luapeek.peek = peek;
-        luapeek.ud = ud;
+        luapeek.peek = eval_state->peek;
+        luapeek.ud = eval_state->peek_userdata;
 
-        lua_pushlightuserdata(L, &luapeek);
+        lua_pushlightuserdata(eval_state->L, &luapeek);
         
-        if (lua_pcall(L, 2, 1, 0) == LUA_OK) {
-          if (lua_isboolean(L, -1)) {
-            value = lua_toboolean(L, -1);
+        if (lua_pcall(eval_state->L, 2, 1, 0) == LUA_OK) {
+          if (lua_isboolean(eval_state->L, -1)) {
+            value = lua_toboolean(eval_state->L, -1);
           }
           else {
-            value = (unsigned)lua_tonumber(L, -1);
+            value = (unsigned)lua_tonumber(eval_state->L, -1);
           }
         }
 
-        lua_pop(L, 1);
+        lua_pop(eval_state->L, 1);
       }
 
 #endif /* RC_DISABLE_LUA */
@@ -379,15 +379,15 @@ unsigned rc_evaluate_operand(rc_operand_t* self, unsigned address_offset, rc_pee
       break;
 
     case RC_OPERAND_ADDRESS:
-      value = rc_get_indirect_memref(self->value.memref, address_offset, peek, ud)->value;
+      value = rc_get_indirect_memref(self->value.memref, eval_state)->value;
       break;
 
     case RC_OPERAND_DELTA:
-      value = rc_get_indirect_memref(self->value.memref, address_offset, peek, ud)->previous;
+      value = rc_get_indirect_memref(self->value.memref, eval_state)->previous;
       break;
 
     case RC_OPERAND_PRIOR:
-      value = rc_get_indirect_memref(self->value.memref, address_offset, peek, ud)->prior;
+      value = rc_get_indirect_memref(self->value.memref, eval_state)->prior;
       break;
   }
 

--- a/src/rcheevos/term.c
+++ b/src/rcheevos/term.c
@@ -88,15 +88,15 @@ rc_term_t* rc_parse_term(const char** memaddr, int is_indirect, rc_parse_state_t
   return self;
 }
 
-int rc_evaluate_term(rc_term_t* self, rc_peek_t peek, void* ud, lua_State* L) {
+int rc_evaluate_term(rc_term_t* self, rc_eval_state_t* eval_state) {
   /* Operands are usually memory references and are always retrieved as unsigned. The floating
    * point operand is signed, and will automatically make the result signed. Otherwise, multiply
    * by the secondary operand (which is usually 1) and cast to signed.
    */
-  unsigned value = rc_evaluate_operand(&self->operand1, 0, peek, ud, L);
+  unsigned value = rc_evaluate_operand(&self->operand1, eval_state);
 
   if (self->operand2.type != RC_OPERAND_FP) {
-    return (int)(value * (rc_evaluate_operand(&self->operand2, 0, peek, ud, L) ^ self->invert));
+    return (int)(value * (rc_evaluate_operand(&self->operand2, eval_state) ^ self->invert));
   }
 
   return (int)((double)value * self->operand2.value.dbl);

--- a/src/rcheevos/trigger.c
+++ b/src/rcheevos/trigger.c
@@ -90,9 +90,9 @@ int rc_evaluate_trigger(rc_trigger_t* self, rc_peek_t peek, void* ud, lua_State*
   int ret;
   char is_paused;
 
-  /* previously triggered, do nothing */
+  /* previously triggered, do nothing - return INACTIVE so caller doesn't report a repeated trigger */
   if (self->state == RC_TRIGGER_STATE_TRIGGERED)
-      return RC_TRIGGER_STATE_TRIGGERED;
+      return RC_TRIGGER_STATE_INACTIVE;
 
   rc_update_memref_values(self->memrefs, peek, ud);
 

--- a/src/rcheevos/trigger.c
+++ b/src/rcheevos/trigger.c
@@ -36,6 +36,11 @@ void rc_parse_trigger_internal(rc_trigger_t* self, const char** memaddr, rc_pars
   
   *next = 0;
   *memaddr = aux;
+
+  self->measured_value = 0;
+  self->measured_target = parse->measured_target;
+  self->state = RC_TRIGGER_STATE_WAITING;
+  self->has_hits = 0;
 }
 
 int rc_trigger_size(const char* memaddr) {
@@ -64,53 +69,7 @@ rc_trigger_t* rc_parse_trigger(void* buffer, const char* memaddr, lua_State* L, 
   return parse.offset >= 0 ? self : 0;
 }
 
-int rc_evaluate_trigger(rc_trigger_t* self, rc_peek_t peek, void* ud, lua_State* L) {
-  rc_eval_state_t eval_state;
-  int ret, reset;
-  rc_condset_t* condset;
-
-  memset(&eval_state, 0, sizeof(eval_state));
-  eval_state.peek = peek;
-  eval_state.peek_userdata = ud;
-  eval_state.L = L;
-
-  rc_update_memref_values(self->memrefs, peek, ud);
-
-  reset = 0;
-  ret = self->requirement != 0 ? rc_test_condset(self->requirement, &eval_state) : 1;
-  condset = self->alternative;
-
-  if (condset) {
-    int sub = 0;
-
-    do {
-      sub |= rc_test_condset(condset, &eval_state);
-      condset = condset->next;
-    }
-    while (condset != 0);
-
-    ret &= sub && !eval_state.was_reset;
-  }
-
-  self->measured_value = eval_state.measured_value;
-
-  if (eval_state.was_reset) {
-    rc_reset_trigger(self);
-
-    if (self->can_reset && self->has_hits) {
-      self->has_hits = 0;
-      return RC_TRIGGER_STATE_RESET;
-    }
-  }
-
-  return ret ? RC_TRIGGER_STATE_TRIGGERED : RC_TRIGGER_STATE_ACTIVE;
-}
-
-int rc_test_trigger(rc_trigger_t* self, rc_peek_t peek, void* ud, lua_State* L) {
-  return (rc_evaluate_trigger(self, peek, ud, L) == RC_TRIGGER_STATE_TRIGGERED);
-}
-
-void rc_reset_trigger(rc_trigger_t* self) {
+static void rc_reset_trigger_hitcounts(rc_trigger_t* self) {
   rc_condset_t* condset;
 
   if (self->requirement != 0) {
@@ -123,4 +82,103 @@ void rc_reset_trigger(rc_trigger_t* self) {
     rc_reset_condset(condset);
     condset = condset->next;
   }
+}
+
+int rc_evaluate_trigger(rc_trigger_t* self, rc_peek_t peek, void* ud, lua_State* L) {
+  rc_eval_state_t eval_state;
+  rc_condset_t* condset;
+  int ret;
+  char is_paused;
+
+  /* previously triggered, do nothing */
+  if (self->state == RC_TRIGGER_STATE_TRIGGERED)
+      return RC_TRIGGER_STATE_TRIGGERED;
+
+  rc_update_memref_values(self->memrefs, peek, ud);
+
+  /* not yet active, only update the memrefs - so deltas are corrent when it becomes active */
+  if (self->state == RC_TRIGGER_STATE_INACTIVE)
+    return RC_TRIGGER_STATE_INACTIVE;
+
+  /* process the trigger */
+  memset(&eval_state, 0, sizeof(eval_state));
+  eval_state.peek = peek;
+  eval_state.peek_userdata = ud;
+  eval_state.L = L;
+
+  ret = self->requirement != 0 ? rc_test_condset(self->requirement, &eval_state) : 1;
+  condset = self->alternative;
+
+  if (condset) {
+    int sub = 0;
+
+    do {
+      sub |= rc_test_condset(condset, &eval_state);
+      condset = condset->next;
+    }
+    while (condset != 0);
+
+    ret &= sub;
+  }
+
+  self->measured_value = eval_state.measured_value;
+
+  /* if the state is WAITING and the trigger is ready to fire, ignore it and reset the hit counts */
+  /* otherwise, if the state is WAITING, proceed to activating the trigger */
+  if (self->state == RC_TRIGGER_STATE_WAITING && ret) {
+    rc_reset_trigger(self);
+    self->has_hits = 0;
+    return RC_TRIGGER_STATE_WAITING;
+  }
+
+  if (eval_state.was_reset) {
+    /* if any ResetIf condition was true, reset the hit counts */
+    rc_reset_trigger_hitcounts(self);
+
+    /* if there were hit counts to clear, return RESET, but don't change the state */
+    if (self->has_hits) {
+      self->has_hits = 0;
+      return RC_TRIGGER_STATE_RESET;
+    }
+
+    /* any hits that were tallied were just reset */
+    eval_state.has_hits = 0;
+  }
+  else if (ret) {
+    /* trigger was triggered */
+    self->state = RC_TRIGGER_STATE_TRIGGERED;
+    return RC_TRIGGER_STATE_TRIGGERED;
+  }
+
+  /* did not trigger this frame - update the information we'll need for next time */
+  self->has_hits = eval_state.has_hits;
+
+  /* check to see if the trigger is paused */
+  is_paused = (self->requirement != NULL) ? self->requirement->is_paused : 0;
+  if (!is_paused) {
+    /* if the core is not paused, all alts must be paused to count as a paused trigger */
+    is_paused = (self->alternative != NULL);
+    for (condset = self->alternative; condset != NULL; condset = condset->next) {
+      if (!condset->is_paused) {
+        is_paused = 0;
+        break;
+      }
+    }
+  }
+
+  self->state = is_paused ? RC_TRIGGER_STATE_PAUSED : RC_TRIGGER_STATE_ACTIVE;
+  return self->state;
+}
+
+int rc_test_trigger(rc_trigger_t* self, rc_peek_t peek, void* ud, lua_State* L) {
+  /* for backwards compatibilty, rc_test_trigger always assumes the achievement is active */
+  self->state = RC_TRIGGER_STATE_ACTIVE;
+
+  return (rc_evaluate_trigger(self, peek, ud, L) == RC_TRIGGER_STATE_TRIGGERED);
+}
+
+void rc_reset_trigger(rc_trigger_t* self) {
+  rc_reset_trigger_hitcounts(self);
+
+  self->state = RC_TRIGGER_STATE_WAITING;
 }

--- a/src/rcheevos/value.c
+++ b/src/rcheevos/value.c
@@ -42,7 +42,7 @@ static void rc_parse_cond_value(rc_value_t* self, const char** memaddr, rc_parse
 
       case RC_CONDITION_MEASURED:
         if (has_measured) {
-          parse->offset = RC_DUPLICATED_VALUE_MEASURED;
+          parse->offset = RC_MULTIPLE_MEASURED;
           return;
         }
         has_measured = 1;

--- a/src/rcheevos/value.c
+++ b/src/rcheevos/value.c
@@ -1,5 +1,7 @@
 #include "internal.h"
 
+#include <memory.h>
+
 static void rc_parse_cond_value(rc_value_t* self, const char** memaddr, rc_parse_state_t* parse) {
   rc_condition_t** next;
   int has_measured;
@@ -44,6 +46,8 @@ static void rc_parse_cond_value(rc_value_t* self, const char** memaddr, rc_parse
           return;
         }
         has_measured = 1;
+        if ((*next)->required_hits == 0 && (*next)->oper != RC_CONDITION_NONE)
+            (*next)->required_hits = (unsigned)-1;
         break;
 
       default:
@@ -126,68 +130,15 @@ rc_value_t* rc_parse_value(void* buffer, const char* memaddr, lua_State* L, int 
   return parse.offset >= 0 ? self : 0;
 }
 
-static unsigned rc_total_value(rc_condition_t* first, rc_condition_t* condition, rc_peek_t peek, void* ud, lua_State* L) {
-  unsigned add_value, add_address;
-
-  add_value = add_address = 0;
-
-  for (; first != 0; first = first->next) {
-    switch (first->type) {
-      case RC_CONDITION_ADD_SOURCE:
-        add_value += rc_evaluate_operand(&first->operand1, add_address, peek, ud, L);
-        add_address = 0;
-        continue;
-
-      case RC_CONDITION_SUB_SOURCE:
-        add_value -= rc_evaluate_operand(&first->operand1, add_address, peek, ud, L);
-        add_address = 0;
-        continue;
-
-      case RC_CONDITION_ADD_ADDRESS:
-        add_address = rc_evaluate_operand(&first->operand1, add_address, peek, ud, L);
-        continue;
-
-      case RC_CONDITION_MEASURED:
-        if (first == condition)
-          return rc_evaluate_operand(&first->operand1, add_address, peek, ud, L) + add_value;
-        break;
-
-    }
-
-    add_value = add_address = 0;
-  }
-
-  return 0;
-}
-
-static int rc_evaluate_cond_value(rc_value_t* self, rc_peek_t peek, void* ud, lua_State* L) {
-  rc_condition_t* condition;
-  int reset;
-
-  for (condition = self->conditions->conditions; condition != 0; condition = condition->next) {
-    if (condition->type == RC_CONDITION_MEASURED) {
-      if (condition->oper == RC_CONDITION_NONE) {
-        return rc_total_value(self->conditions->conditions, condition, peek, ud, L);
-      }
-      else {
-        rc_test_condset(self->conditions, &reset, peek, ud, L);
-        return rc_total_hit_count(self->conditions->conditions, condition);
-      }
-    }
-  }
-
-  return 0;
-}
-
-static int rc_evaluate_expr_value(rc_value_t* self, rc_peek_t peek, void* ud, lua_State* L) {
+static int rc_evaluate_expr_value(rc_value_t* self, rc_eval_state_t* eval_state) {
   rc_expression_t* exp;
   int value, max;
 
   exp = self->expressions;
-  max = rc_evaluate_expression(exp, peek, ud, L);
+  max = rc_evaluate_expression(exp, eval_state);
 
   for (exp = exp->next; exp != 0; exp = exp->next) {
-    value = rc_evaluate_expression(exp, peek, ud, L);
+    value = rc_evaluate_expression(exp, eval_state);
 
     if (value > max) {
       max = value;
@@ -198,11 +149,18 @@ static int rc_evaluate_expr_value(rc_value_t* self, rc_peek_t peek, void* ud, lu
 }
 
 int rc_evaluate_value(rc_value_t* self, rc_peek_t peek, void* ud, lua_State* L) {
+  rc_eval_state_t eval_state;
+  memset(&eval_state, 0, sizeof(eval_state));
+  eval_state.peek = peek;
+  eval_state.peek_userdata = ud;
+  eval_state.L = L;
+
   rc_update_memref_values(self->memrefs, peek, ud);
 
   if (self->expressions) {
-    return rc_evaluate_expr_value(self, peek, ud, L);
+    return rc_evaluate_expr_value(self, &eval_state);
   }
 
-  return rc_evaluate_cond_value(self, peek, ud, L);
+  rc_test_condset(self->conditions, &eval_state);
+  return (int)eval_state.measured_value;
 }

--- a/test/rcheevos-test.vcxproj
+++ b/test/rcheevos-test.vcxproj
@@ -169,6 +169,7 @@
     <ClCompile Include="test.c" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\include\rcheevos.h" />
     <ClInclude Include="..\src\rcheevos\internal.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/test/rcheevos-test.vcxproj.filters
+++ b/test/rcheevos-test.vcxproj.filters
@@ -150,5 +150,8 @@
     <ClInclude Include="..\src\rcheevos\internal.h">
       <Filter>rcheevos</Filter>
     </ClInclude>
+    <ClInclude Include="..\include\rcheevos.h">
+      <Filter>rcheevos</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/test/test.c
+++ b/test/test.c
@@ -2845,13 +2845,15 @@ static void test_trigger(void) {
     assert(condset_get_cond(trigger_get_set(trigger, 0), 1)->current_hits == 2U);
 
     /* triggered trigger remains triggered but does not increment hit counts */
-    assert(evaluate_trigger(trigger, &memory) == RC_TRIGGER_STATE_TRIGGERED);
+    assert(evaluate_trigger(trigger, &memory) == RC_TRIGGER_STATE_INACTIVE);
+    assert(trigger->state == RC_TRIGGER_STATE_TRIGGERED);
     assert(condset_get_cond(trigger_get_set(trigger, 0), 0)->current_hits == 1U);
     assert(condset_get_cond(trigger_get_set(trigger, 0), 1)->current_hits == 2U);
 
     /* triggered trigger remains triggered when no longer true */
     ram[1] = 5;
-    assert(evaluate_trigger(trigger, &memory) == RC_TRIGGER_STATE_TRIGGERED);
+    assert(evaluate_trigger(trigger, &memory) == RC_TRIGGER_STATE_INACTIVE);
+    assert(trigger->state == RC_TRIGGER_STATE_TRIGGERED);
     assert(condset_get_cond(trigger_get_set(trigger, 0), 0)->current_hits == 1U);
     assert(condset_get_cond(trigger_get_set(trigger, 0), 1)->current_hits == 2U);
 
@@ -2928,7 +2930,8 @@ static void test_trigger(void) {
 
     /* triggered trigger ignores pause */
     ram[2] = 1;
-    assert(evaluate_trigger(trigger, &memory) == RC_TRIGGER_STATE_TRIGGERED);
+    assert(evaluate_trigger(trigger, &memory) == RC_TRIGGER_STATE_INACTIVE);
+    assert(trigger->state == RC_TRIGGER_STATE_TRIGGERED);
   }
 
 }

--- a/test/test.c
+++ b/test/test.c
@@ -3247,14 +3247,14 @@ static void lboard_check(const char* memaddr, int expected_ret) {
 typedef struct {
   int active, submitted;
 }
-lboard_eval_state_t;
+lboard_test_state_t;
 
-static void lboard_reset(rc_lboard_t* lboard, lboard_eval_state_t* state) {
+static void lboard_reset(rc_lboard_t* lboard, lboard_test_state_t* state) {
   rc_reset_lboard(lboard);
   state->active = state->submitted = 0;
 }
 
-static int lboard_evaluate(rc_lboard_t* lboard, lboard_eval_state_t* test, memory_t* memory) {
+static int lboard_evaluate(rc_lboard_t* lboard, lboard_test_state_t* test, memory_t* memory) {
   int value;
 
   switch (rc_evaluate_lboard(lboard, &value, peek, memory, NULL)) {
@@ -3286,7 +3286,7 @@ static void test_lboard(void) {
     unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
     memory_t memory;
     rc_lboard_t* lboard;
-    lboard_eval_state_t state;
+    lboard_test_state_t state;
     unsigned value;
     
     memory.ram = ram;
@@ -3347,7 +3347,7 @@ static void test_lboard(void) {
     unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
     memory_t memory;
     rc_lboard_t* lboard;
-    lboard_eval_state_t state;
+    lboard_test_state_t state;
     
     memory.ram = ram;
     memory.size = sizeof(ram);
@@ -3393,7 +3393,7 @@ static void test_lboard(void) {
     unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
     memory_t memory;
     rc_lboard_t* lboard;
-    lboard_eval_state_t state;
+    lboard_test_state_t state;
     unsigned value;
     
     memory.ram = ram;
@@ -3428,7 +3428,7 @@ static void test_lboard(void) {
     unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
     memory_t memory;
     rc_lboard_t* lboard;
-    lboard_eval_state_t state;
+    lboard_test_state_t state;
     unsigned value;
     
     memory.ram = ram;
@@ -3457,7 +3457,7 @@ static void test_lboard(void) {
     unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
     memory_t memory;
     rc_lboard_t* lboard;
-    lboard_eval_state_t state;
+    lboard_test_state_t state;
     
     memory.ram = ram;
     memory.size = sizeof(ram);
@@ -3481,7 +3481,7 @@ static void test_lboard(void) {
     unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
     memory_t memory;
     rc_lboard_t* lboard;
-    lboard_eval_state_t state;
+    lboard_test_state_t state;
     
     memory.ram = ram;
     memory.size = sizeof(ram);
@@ -3514,7 +3514,7 @@ static void test_lboard(void) {
     unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
     memory_t memory;
     rc_lboard_t* lboard;
-    lboard_eval_state_t state;
+    lboard_test_state_t state;
     
     memory.ram = ram;
     memory.size = sizeof(ram);
@@ -3547,7 +3547,7 @@ static void test_lboard(void) {
     unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
     memory_t memory;
     rc_lboard_t* lboard;
-    lboard_eval_state_t state;
+    lboard_test_state_t state;
     
     memory.ram = ram;
     memory.size = sizeof(ram);
@@ -3572,7 +3572,7 @@ static void test_lboard(void) {
     unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
     memory_t memory;
     rc_lboard_t* lboard;
-    lboard_eval_state_t state;
+    lboard_test_state_t state;
     
     memory.ram = ram;
     memory.size = sizeof(ram);
@@ -3607,7 +3607,7 @@ static void test_lboard(void) {
     unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
     memory_t memory;
     rc_lboard_t* lboard;
-    lboard_eval_state_t state;
+    lboard_test_state_t state;
     unsigned value;
 
     memory.ram = ram;
@@ -3679,7 +3679,7 @@ static void test_lboard(void) {
     unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
     memory_t memory;
     rc_lboard_t* lboard;
-    lboard_eval_state_t state;
+    lboard_test_state_t state;
     unsigned value;
 
     memory.ram = ram;


### PR DESCRIPTION
Where `rc_test_trigger` can only capture whether a trigger is true or false, `rc_evaluate_trigger` can notify the caller when an achievement is paused or has been reset.
```
  RC_TRIGGER_STATE_INACTIVE,   /* achievement is not being processed */
  RC_TRIGGER_STATE_WAITING,    /* achievement cannot trigger until it has been false for at least one frame */
  RC_TRIGGER_STATE_ACTIVE,     /* achievement is active and may trigger */
  RC_TRIGGER_STATE_PAUSED,     /* achievement is currently paused and will not trigger */
  RC_TRIGGER_STATE_RESET,      /* achievement hit counts were reset */
  RC_TRIGGER_STATE_TRIGGERED   /* achievement has triggered */
```
These additional states can be reported in the toolkit. In particular, knowing that an achievement is WAITING or PAUSED should be useful to developers.

Additionally, if the trigger is in the WAITING state (default), then the trigger must be false to transition to the ACTIVE state before it can trigger. This will eliminate the duplicated logic that provides that functionality in the toolkit and RetroArch. 

`rc_test_trigger` still works the same way - it either returns 1 or 0, indicating whether the trigger has triggered. This provides backwards compatibility until the clients are updated to call `rc_evaluate_trigger`.

Under the hood, the increasing number of parameters being passed around when evaluating conditions have been encapsulated in a struct, and the measured value is stored as it's calculated instead of needing to be recalculated when it's used.
