### PR TITLE
Move runtime into rcheevos

### DIFF
--- a/include/rcheevos.h
+++ b/include/rcheevos.h
@@ -409,7 +409,7 @@ int rc_evaluate_richpresence(rc_richpresence_t* richpresence, char* buffer, unsi
 \*****************************************************************************/
 
 typedef struct rc_runtime_trigger_t {
-  int id;
+  unsigned id;
   rc_trigger_t* trigger;
   void* buffer;
   unsigned char md5[16];
@@ -418,7 +418,7 @@ typedef struct rc_runtime_trigger_t {
 rc_runtime_trigger_t;
 
 typedef struct rc_runtime_lboard_t {
-  int id;
+  unsigned id;
   int value;
   rc_lboard_t* lboard;
   void* buffer;
@@ -451,14 +451,14 @@ void rc_runtime_destroy(rc_runtime_t* runtime);
 
 int rc_runtime_activate_achievement(rc_runtime_t* runtime, unsigned id, const char* memaddr, lua_State* L, int funcs_idx);
 void rc_runtime_deactivate_achievement(rc_runtime_t* runtime, unsigned id);
-rc_trigger_t* rc_runtime_get_achievement(rc_runtime_t* runtime, unsigned id);
+rc_trigger_t* rc_runtime_get_achievement(const rc_runtime_t* runtime, unsigned id);
 
 int rc_runtime_activate_lboard(rc_runtime_t* runtime, unsigned id, const char* memaddr, lua_State* L, int funcs_idx);
 void rc_runtime_deactivate_lboard(rc_runtime_t* runtime, unsigned id);
-rc_lboard_t* rc_runtime_get_lboard(rc_runtime_t* runtime, unsigned id);
+rc_lboard_t* rc_runtime_get_lboard(const rc_runtime_t* runtime, unsigned id);
 
 int rc_runtime_activate_richpresence(rc_runtime_t* runtime, const char* script, lua_State* L, int funcs_idx);
-const char* rc_runtime_get_richpresence(rc_runtime_t* runtime);
+const char* rc_runtime_get_richpresence(const rc_runtime_t* runtime);
 
 enum {
   RC_RUNTIME_EVENT_ACHIEVEMENT_ACTIVATED, /* from WAITING or PAUSED to ACTIVE */

--- a/include/rcheevos.h
+++ b/include/rcheevos.h
@@ -427,6 +427,14 @@ typedef struct rc_runtime_lboard_t {
 }
 rc_runtime_lboard_t;
 
+typedef struct rc_runtime_richpresence_t {
+  rc_richpresence_t* richpresence;
+  void* buffer;
+  struct rc_runtime_richpresence_t* previous;
+  char owns_memrefs;
+}
+rc_runtime_richpresence_t;
+
 typedef struct rc_runtime_t {
   rc_runtime_trigger_t* triggers;
   unsigned trigger_count;
@@ -436,8 +444,7 @@ typedef struct rc_runtime_t {
   unsigned lboard_count;
   unsigned lboard_capacity;
 
-  rc_richpresence_t* richpresence;
-  void* richpresence_buffer;
+  rc_runtime_richpresence_t* richpresence;
   char* richpresence_display_buffer;
   char  richpresence_update_timer;
 

--- a/src/rcheevos/runtime.c
+++ b/src/rcheevos/runtime.c
@@ -422,7 +422,7 @@ int rc_runtime_activate_richpresence(rc_runtime_t* self, const char* script, lua
       display = display->next;
     }
 
-    rc_evaluate_richpresence(self->richpresence->richpresence, self->richpresence_display_buffer, RC_RICHPRESENCE_DISPLAY_BUFFER_SIZE - 1, NULL, L, funcs_idx);
+    rc_evaluate_richpresence(self->richpresence->richpresence, self->richpresence_display_buffer, RC_RICHPRESENCE_DISPLAY_BUFFER_SIZE - 1, NULL, NULL, L);
   }
   else {
     /* static rich presence - copy the static string */

--- a/src/rcheevos/runtime.c
+++ b/src/rcheevos/runtime.c
@@ -1,0 +1,550 @@
+#include "internal.h"
+
+#ifdef RARCH_INTERNAL
+ #include <libretro-common/include/rhash.h>
+ #define md5_state_t MD5_CTX
+ #define md5_byte_t unsigned char
+ #define md5_init(state) MD5_Init(state)
+ #define md5_append(state, buffer, size) MD5_Update(state, buffer, size)
+ #define md5_finish(state, hash) MD5_Final(hash, state)
+#else
+ #include "..\rhash\md5.h"
+#endif
+
+#include <stdlib.h>
+#include <string.h>
+
+#define RC_RICHPRESENCE_DISPLAY_BUFFER_SIZE 128
+
+void rc_runtime_init(rc_runtime_t* self) {
+  memset(self, 0, sizeof(rc_runtime_t));
+  self->next_memref = &self->memrefs;
+}
+
+void rc_runtime_destroy(rc_runtime_t* self) {
+  if (self->triggers) {
+    for (unsigned i = 0; i < self->trigger_count; ++i)
+      free(self->triggers[i].buffer);
+
+    free(self->triggers);
+    self->triggers = NULL;
+
+    self->trigger_count = self->trigger_capacity = 0;
+  }
+
+  if (self->lboards) {
+    free(self->lboards);
+    self->lboards = NULL;
+   
+    self->lboard_count = self->lboard_capacity = 0;
+  }
+  
+  if (self->richpresence_buffer) {
+    free(self->richpresence_buffer);
+    self->richpresence_buffer = NULL;
+  }
+  
+  if (self->richpresence_display_buffer) {
+    free(self->richpresence_display_buffer);
+    self->richpresence_display_buffer = NULL;
+  }
+  
+  self->richpresence = 0;
+  self->memrefs = 0;
+}
+
+static void rc_runtime_checksum(const char* memaddr, unsigned char* md5) {
+  md5_state_t state;
+  md5_init(&state);
+  md5_append(&state, (unsigned char*)memaddr, strlen(memaddr));
+  md5_finish(&state, md5);  
+}
+
+static void rc_runtime_deactivate_trigger_by_index(rc_runtime_t* self, unsigned index) {
+  if (self->triggers[index].owns_memrefs) {
+    /* if the trigger has one or more memrefs in its buffer, we can't free the buffer.
+     * just null out the trigger so the runtime processor will skip it
+     */
+    rc_reset_trigger(self->triggers[index].trigger);
+    self->triggers[index].trigger = NULL;
+  }
+  else {
+    /* trigger doesn't own any memrefs, go ahead and free it, then replace it with the last trigger */
+    free(self->triggers[index].buffer);
+
+    if (--self->trigger_count > index)
+      memcpy(&self->triggers[index], &self->triggers[self->trigger_count], sizeof(rc_runtime_trigger_t));
+  }
+}
+
+void rc_runtime_deactivate_achievement(rc_runtime_t* self, unsigned id) {
+  for (unsigned i = 0; i < self->trigger_count; ++i) {
+    if (self->triggers[i].id == id && self->triggers[i].trigger != NULL)
+      rc_runtime_deactivate_trigger_by_index(self, i);
+  }
+}
+
+int rc_runtime_activate_achievement(rc_runtime_t* self, unsigned id, const char* memaddr, lua_State* L, int funcs_idx) {
+  void* trigger_buffer;
+  rc_trigger_t* trigger;
+  rc_parse_state_t parse;
+  unsigned char md5[16];
+  int size;
+  char owns_memref;
+
+  if (memaddr == NULL)
+    return RC_INVALID_MEMORY_OPERAND;
+
+  rc_runtime_checksum(memaddr, md5);
+
+  /* check to see if the id is already registered with an active trigger */
+  for (unsigned i = 0; i < self->trigger_count; ++i) {
+    if (self->triggers[i].id == id && self->triggers[i].trigger != NULL) {
+      if (memcmp(self->triggers[i].md5, md5, 16) == 0) {
+        /* if the checksum hasn't changed, we can reuse the existing item */
+        rc_reset_trigger(self->triggers[i].trigger);
+        return RC_OK;
+      }
+
+      /* checksum has changed, deactivate the the item */
+      rc_runtime_deactivate_trigger_by_index(self, i);
+
+      /* deactivate may reorder the list so we should continue from the current index. however, we
+       * assume that only one trigger is active per id, so having found that, just stop scanning.
+       */
+      break;
+    }
+  }
+
+  /* check to see if a disabled trigger for the specific id matches the trigger being registered */
+  for (unsigned i = 0; i < self->trigger_count; ++i) {
+    if (self->triggers[i].id == id && memcmp(self->triggers[i].md5, md5, 16) == 0) {
+      /* retrieve the trigger pointer from the buffer */
+      size = 0;
+      trigger = (rc_trigger_t*)rc_alloc(self->triggers[i].buffer, &size, sizeof(rc_trigger_t), RC_ALIGNOF(rc_trigger_t), 0);
+      self->triggers[i].trigger = trigger;
+
+      rc_reset_trigger(trigger);
+      return RC_OK;
+    }
+  }
+
+  /* item has not been previously registered, determine how much space we need for it, and allocate it */
+  size = rc_trigger_size(memaddr);
+  if (size < 0)
+    return size;
+
+  trigger_buffer = malloc(size);
+  if (!trigger_buffer)
+    return RC_OUT_OF_MEMORY;
+  
+  /* populate the item, using the communal memrefs pool */
+  rc_init_parse_state(&parse, trigger_buffer, L, funcs_idx);
+  parse.first_memref = &self->memrefs;
+  trigger = RC_ALLOC(rc_trigger_t, &parse);
+  rc_parse_trigger_internal(trigger, &memaddr, &parse);
+  rc_destroy_parse_state(&parse);
+
+  if (parse.offset < 0) {
+    free(trigger_buffer);
+    *self->next_memref = NULL; /* disassociate any memrefs allocated by the failed parse */
+    return parse.offset;
+  }
+
+  /* if at least one memref was allocated within the trigger, we can't free the buffer when the trigger is deactivated */
+  owns_memref = (*self->next_memref != NULL);
+  if (owns_memref) {
+    /* advance through the new memrefs so we're ready for the next allocation */
+    do {
+      self->next_memref = &(*self->next_memref)->next;
+    } while (*self->next_memref != NULL);
+  }
+
+  /* grow the trigger buffer if necessary */
+  if (self->trigger_count == self->trigger_capacity) {
+    self->trigger_capacity += 32;
+    if (!self->triggers)
+      self->triggers = (rc_runtime_trigger_t*)malloc(self->trigger_capacity * sizeof(rc_runtime_trigger_t));
+    else
+      self->triggers = (rc_runtime_trigger_t*)realloc(self->triggers, self->trigger_capacity * sizeof(rc_runtime_trigger_t));
+  }
+
+  /* assign the new trigger */
+  self->triggers[self->trigger_count].id = id;
+  self->triggers[self->trigger_count].trigger = trigger;
+  self->triggers[self->trigger_count].buffer = trigger_buffer;
+  memcpy(self->triggers[self->trigger_count].md5, md5, 16);
+  self->triggers[self->trigger_count].owns_memrefs = owns_memref;
+  ++self->trigger_count;
+
+  /* reset it, and return it */
+  trigger->memrefs = NULL;
+  rc_reset_trigger(trigger);
+  return RC_OK;
+}
+
+rc_trigger_t* rc_runtime_get_achievement(rc_runtime_t* self, unsigned id)
+{
+  for (unsigned i = 0; i < self->trigger_count; ++i) {
+    if (self->triggers[i].id == id && self->triggers[i].trigger != NULL)
+      return self->triggers[i].trigger;
+  }
+
+  return NULL;
+}
+
+static void rc_runtime_deactivate_lboard_by_index(rc_runtime_t* self, unsigned index) {
+  if (self->lboards[index].owns_memrefs) {
+    /* if the lboard has one or more memrefs in its buffer, we can't free the buffer.
+     * just null out the lboard so the runtime processor will skip it
+     */
+    rc_reset_lboard(self->lboards[index].lboard);
+    self->lboards[index].lboard = NULL;
+  }
+  else {
+    /* lboard doesn't own any memrefs, go ahead and free it, then replace it with the last lboard */
+    free(self->lboards[index].buffer);
+
+    if (--self->lboard_count > index)
+      memcpy(&self->lboards[index], &self->lboards[self->lboard_count], sizeof(rc_runtime_lboard_t));
+  }
+}
+
+void rc_runtime_deactivate_lboard(rc_runtime_t* self, unsigned id) {
+  for (unsigned i = 0; i < self->lboard_count; ++i) {
+    if (self->lboards[i].id == id && self->lboards[i].lboard != NULL)
+      rc_runtime_deactivate_lboard_by_index(self, i);
+  }
+}
+
+int rc_runtime_activate_lboard(rc_runtime_t* self, unsigned id, const char* memaddr, lua_State* L, int funcs_idx) {
+  void* lboard_buffer;
+  unsigned char md5[16];
+  rc_lboard_t* lboard;
+  rc_parse_state_t parse;
+  int size;
+  char owns_memref;
+
+  if (memaddr == 0)
+    return RC_INVALID_MEMORY_OPERAND;
+
+  rc_runtime_checksum(memaddr, md5);
+
+  /* check to see if the id is already registered with an active lboard */
+  for (unsigned i = 0; i < self->lboard_count; ++i) {
+    if (self->lboards[i].id == id && self->lboards[i].lboard != NULL) {
+      if (memcmp(self->lboards[i].md5, md5, 16) == 0) {
+        /* if the checksum hasn't changed, we can reuse the existing item */
+        rc_reset_lboard(self->lboards[i].lboard);
+        return RC_OK;
+      }
+
+      /* checksum has changed, deactivate the the item */
+      rc_runtime_deactivate_lboard_by_index(self, i);
+
+      /* deactivate may reorder the list so we should continue from the current index. however, we
+       * assume that only one trigger is active per id, so having found that, just stop scanning.
+       */
+      break;
+    }
+  }
+
+  /* check to see if a disabled lboard for the specific id matches the lboard being registered */
+  for (unsigned i = 0; i < self->trigger_count; ++i) {
+    if (self->lboards[i].id == id && memcmp(self->lboards[i].md5, md5, 16) == 0) {
+      /* retrieve the lboard pointer from the buffer */
+      size = 0;
+      lboard = (rc_lboard_t*)rc_alloc(self->lboards[i].buffer, &size, sizeof(rc_lboard_t), RC_ALIGNOF(rc_lboard_t), 0);
+      self->lboards[i].lboard = lboard;
+
+      rc_reset_lboard(lboard);
+      return RC_OK;
+    }
+  }
+  
+  /* item has not been previously registered, determine how much space we need for it, and allocate it */
+  size = rc_lboard_size(memaddr);
+  if (size < 0)
+    return size;
+
+  lboard_buffer = malloc(size);
+  if (!lboard_buffer)
+    return RC_OUT_OF_MEMORY;
+  
+  /* populate the item, using the communal memrefs pool */
+  rc_init_parse_state(&parse, lboard_buffer, L, funcs_idx);
+  lboard = RC_ALLOC(rc_lboard_t, &parse);
+  parse.first_memref = &self->memrefs;
+  rc_parse_lboard_internal(lboard, memaddr, &parse);
+  rc_destroy_parse_state(&parse);
+
+  if (parse.offset < 0) {
+    free(lboard_buffer);
+    *self->next_memref = NULL; /* disassociate any memrefs allocated by the failed parse */
+    return parse.offset;
+  }
+
+  /* if at least one memref was allocated within the trigger, we can't free the buffer when the trigger is deactivated */
+  owns_memref = (*self->next_memref != NULL);
+  if (owns_memref) {
+    /* advance through the new memrefs so we're ready for the next allocation */
+    do {
+      self->next_memref = &(*self->next_memref)->next;
+    } while (*self->next_memref != NULL);
+  }
+  
+  /* grow the lboard buffer if necessary */
+  if (self->lboard_count == self->lboard_capacity) {
+    self->lboard_capacity += 16;
+    if (!self->lboards)
+      self->lboards = (rc_runtime_lboard_t*)malloc(self->lboard_capacity * sizeof(rc_runtime_lboard_t));
+    else
+      self->lboards = (rc_runtime_lboard_t*)realloc(self->lboards, self->lboard_capacity * sizeof(rc_runtime_lboard_t));
+  }
+
+  /* assign the new lboard */
+  self->lboards[self->lboard_count].id = id;
+  self->lboards[self->lboard_count].value = 0;
+  self->lboards[self->lboard_count].lboard = lboard;
+  self->lboards[self->lboard_count].buffer = lboard_buffer;
+  memcpy(self->lboards[self->lboard_count].md5, md5, 16);
+  self->lboards[self->lboard_count].owns_memrefs = owns_memref;
+  ++self->lboard_count;
+
+  /* reset it, and return it */
+  lboard->memrefs = NULL;
+  rc_reset_lboard(lboard);
+  return RC_OK;
+}
+
+rc_lboard_t* rc_runtime_get_lboard(rc_runtime_t* self, unsigned id)
+{
+  for (unsigned i = 0; i < self->lboard_count; ++i) {
+    if (self->lboards[i].id == id && self->lboards[i].lboard != NULL)
+      return self->lboards[i].lboard;
+  }
+
+  return NULL;
+}
+
+int rc_runtime_activate_richpresence(rc_runtime_t* self, const char* script, lua_State* L, int funcs_idx) {
+  rc_richpresence_t* richpresence;
+  rc_richpresence_display_t* display;
+  rc_parse_state_t parse;
+  int size;
+
+  if (script == NULL)
+    return RC_MISSING_DISPLAY_STRING;
+
+  size = rc_richpresence_size(script);
+  if (size < 0)
+    return size;
+
+  if (!self->richpresence_display_buffer) {
+    self->richpresence_display_buffer = (char*)malloc(RC_RICHPRESENCE_DISPLAY_BUFFER_SIZE * sizeof(char));
+    if (!self->richpresence_display_buffer)
+      return RC_OUT_OF_MEMORY;
+  }
+  self->richpresence_display_buffer[0] = '\0';
+
+  if (self->richpresence_buffer)
+    free(self->richpresence_buffer);
+  self->richpresence_buffer = malloc(size);
+  if (!self->richpresence_buffer)
+    return RC_OUT_OF_MEMORY;
+  
+  rc_init_parse_state(&parse, self->richpresence_buffer, L, funcs_idx);
+  richpresence = RC_ALLOC(rc_richpresence_t, &parse);
+  parse.first_memref = &self->memrefs;
+  rc_parse_richpresence_internal(richpresence, script, &parse);
+  rc_destroy_parse_state(&parse);
+
+  if (parse.offset < 0) {
+    self->richpresence = NULL;
+    free(self->richpresence_buffer);
+    self->richpresence_buffer = NULL;
+    *self->next_memref = NULL; /* disassociate any memrefs allocated by the failed parse */
+    return parse.offset;
+  }
+
+  /* advance through the new memrefs so we're ready for the next allocation */
+  while (*self->next_memref != NULL)
+    self->next_memref = &(*self->next_memref)->next;
+
+  richpresence->memrefs = NULL;
+  self->richpresence = richpresence;
+  self->richpresence_update_timer = 0;
+
+  if (!richpresence->first_display || !richpresence->first_display->display) {
+    /* non-existant rich presence, treat like static empty string */
+    *self->richpresence_display_buffer = '\0';
+    self->richpresence = NULL;
+  } 
+  else if (richpresence->first_display->next || richpresence->first_display->trigger.requirement ||
+      richpresence->first_display->display->value.conditions || richpresence->first_display->display->value.expressions) {
+    /* dynamic rich presence - reset all of the conditions */
+    display = richpresence->first_display;
+    while (display != NULL) {
+      rc_reset_trigger(&display->trigger);
+      display = display->next;
+    }
+  }
+  else {
+    /* static rich presence - copy the static string */
+    const char* src = richpresence->first_display->display->text;
+    char* dst = self->richpresence_display_buffer;
+    const char* end = dst + RC_RICHPRESENCE_DISPLAY_BUFFER_SIZE - 1;
+    while (*src && dst < end)
+      *dst++ = *src++;
+    *dst = '\0';
+
+    /* by setting self->richpresence to null, it won't be evaluated in do_frame() */
+    self->richpresence = NULL;
+  }
+
+  return RC_OK;
+}
+
+const char* rc_runtime_get_richpresence(rc_runtime_t* self)
+{
+  if (self->richpresence_display_buffer)
+    return self->richpresence_display_buffer;
+
+  return "";
+}
+
+void rc_runtime_do_frame(rc_runtime_t* self, rc_runtime_event_handler_t event_handler, rc_peek_t peek, void* ud, lua_State* L) {
+  rc_runtime_event_t runtime_event;
+  runtime_event.value = 0;
+
+  rc_update_memref_values(self->memrefs, peek, ud);
+
+  for (unsigned i = 0; i < self->trigger_count; ++i) {
+    rc_trigger_t* trigger = self->triggers[i].trigger;
+    int trigger_state;
+
+    if (!trigger)
+      continue;
+    
+    trigger_state = trigger->state;
+    
+    switch (rc_evaluate_trigger(trigger, peek, ud, L))
+    {
+      case RC_TRIGGER_STATE_RESET:
+        runtime_event.type = RC_RUNTIME_EVENT_ACHIEVEMENT_RESET;
+        runtime_event.id = self->triggers[i].id;
+        event_handler(&runtime_event);
+        break;
+        
+      case RC_TRIGGER_STATE_TRIGGERED:
+        runtime_event.type = RC_RUNTIME_EVENT_ACHIEVEMENT_TRIGGERED;
+        runtime_event.id = self->triggers[i].id;
+        event_handler(&runtime_event);
+        break;
+
+      case RC_TRIGGER_STATE_PAUSED:
+        if (trigger_state != RC_TRIGGER_STATE_PAUSED) {
+          runtime_event.type = RC_RUNTIME_EVENT_ACHIEVEMENT_PAUSED;
+          runtime_event.id = self->triggers[i].id;
+          event_handler(&runtime_event);
+        }
+        break;
+        
+      case RC_TRIGGER_STATE_ACTIVE:
+        if (trigger_state != RC_TRIGGER_STATE_ACTIVE) {
+          runtime_event.type = RC_RUNTIME_EVENT_ACHIEVEMENT_ACTIVATED;
+          runtime_event.id = self->triggers[i].id;
+          event_handler(&runtime_event);
+        }
+        break;
+    }
+  }
+  
+  for (unsigned i = 0; i < self->lboard_count; ++i) {
+    rc_lboard_t* lboard = self->lboards[i].lboard;
+    int lboard_state = lboard->state;
+
+    if (!lboard)
+      continue;
+    
+    switch (rc_evaluate_lboard(lboard, &runtime_event.value, peek, ud, L))
+    {
+      case RC_LBOARD_STATE_STARTED: /* leaderboard is running */
+        if (lboard_state != RC_LBOARD_STATE_STARTED) {
+          self->lboards[i].value = runtime_event.value;
+            
+          runtime_event.type = RC_RUNTIME_EVENT_LBOARD_STARTED;
+          runtime_event.id = self->lboards[i].id;
+          event_handler(&runtime_event);
+        }
+        else if (runtime_event.value != self->lboards[i].value) {
+          self->lboards[i].value = runtime_event.value;
+          
+          runtime_event.type = RC_RUNTIME_EVENT_LBOARD_UPDATED;
+          runtime_event.id = self->lboards[i].id;
+          event_handler(&runtime_event);        
+        }
+        break;
+        
+      case RC_LBOARD_STATE_CANCELED:
+        if (lboard_state != RC_LBOARD_STATE_CANCELED) {
+          runtime_event.type = RC_RUNTIME_EVENT_LBOARD_CANCELED;
+          runtime_event.id = self->lboards[i].id;
+          event_handler(&runtime_event);
+        }
+        break;
+        
+      case RC_LBOARD_STATE_TRIGGERED:
+        if (lboard_state != RC_RUNTIME_EVENT_LBOARD_TRIGGERED) {
+          runtime_event.type = RC_RUNTIME_EVENT_LBOARD_TRIGGERED;
+          runtime_event.id = self->lboards[i].id;
+          event_handler(&runtime_event);
+        }
+        break;
+    }
+  }
+
+  if (self->richpresence) {
+    if (self->richpresence_update_timer == 0) {
+      /* generate into a temporary buffer so we don't get a partially updated string if it's read while its being updated */
+      char buffer[RC_RICHPRESENCE_DISPLAY_BUFFER_SIZE];
+      int len = rc_evaluate_richpresence(self->richpresence, buffer, RC_RICHPRESENCE_DISPLAY_BUFFER_SIZE - 1, peek, ud, L);
+
+      /* copy into the real buffer - write the 0 terminator first to ensure reads don't overflow the buffer */
+      buffer[RC_RICHPRESENCE_DISPLAY_BUFFER_SIZE - 1] = '\0';
+      memcpy(self->richpresence_display_buffer, buffer, RC_RICHPRESENCE_DISPLAY_BUFFER_SIZE);
+
+      /* schedule the next update for 60 frames later - most systems use a 60 fps framerate (some use more 50 or 75)
+       * since we're only sending to the server every two minutes, that's only every 7200 frames while active, which
+       * is evenly divisible by 50, 60, and 75.
+       */
+      self->richpresence_update_timer = 59;
+    }
+    else
+      self->richpresence_update_timer--;
+  }
+}
+
+void rc_runtime_reset(rc_runtime_t* self) {
+  for (unsigned i = 0; i < self->trigger_count; ++i) {
+    if (self->triggers[i].trigger)
+      rc_reset_trigger(self->triggers[i].trigger);
+  }
+
+  for (unsigned i = 0; i < self->lboard_count; ++i) {
+    if (self->lboards[i].lboard)
+      rc_reset_lboard(self->lboards[i].lboard);
+  }
+    
+  if (self->richpresence) {
+    rc_richpresence_display_t* display = self->richpresence->first_display;
+    while (display != 0) {
+      rc_reset_trigger(&display->trigger);
+      display = display->next;
+    }
+  }
+}
+
+// TODO: char* rc_runtime_serialize_progress(rc_runtime_t* runtime)
+//       returns malloc'd string to be written to disk
+// TODO: int rc_runtime_deserialize_progress(rc_runtime_t* runtime, const char* serialized)

--- a/src/rcheevos/runtime.c
+++ b/src/rcheevos/runtime.c
@@ -421,6 +421,8 @@ int rc_runtime_activate_richpresence(rc_runtime_t* self, const char* script, lua
       rc_reset_trigger(&display->trigger);
       display = display->next;
     }
+
+    rc_evaluate_richpresence(self->richpresence->richpresence, self->richpresence_display_buffer, RC_RICHPRESENCE_DISPLAY_BUFFER_SIZE - 1, NULL, L, funcs_idx);
   }
   else {
     /* static rich presence - copy the static string */

--- a/src/rcheevos/runtime.c
+++ b/src/rcheevos/runtime.c
@@ -22,8 +22,10 @@ void rc_runtime_init(rc_runtime_t* self) {
 }
 
 void rc_runtime_destroy(rc_runtime_t* self) {
+  unsigned i;
+
   if (self->triggers) {
-    for (unsigned i = 0; i < self->trigger_count; ++i)
+    for (i = 0; i < self->trigger_count; ++i)
       free(self->triggers[i].buffer);
 
     free(self->triggers);
@@ -78,7 +80,9 @@ static void rc_runtime_deactivate_trigger_by_index(rc_runtime_t* self, unsigned 
 }
 
 void rc_runtime_deactivate_achievement(rc_runtime_t* self, unsigned id) {
-  for (unsigned i = 0; i < self->trigger_count; ++i) {
+  unsigned i;
+
+  for (i = 0; i < self->trigger_count; ++i) {
     if (self->triggers[i].id == id && self->triggers[i].trigger != NULL)
       rc_runtime_deactivate_trigger_by_index(self, i);
   }
@@ -91,6 +95,7 @@ int rc_runtime_activate_achievement(rc_runtime_t* self, unsigned id, const char*
   unsigned char md5[16];
   int size;
   char owns_memref;
+  unsigned i;
 
   if (memaddr == NULL)
     return RC_INVALID_MEMORY_OPERAND;
@@ -98,7 +103,7 @@ int rc_runtime_activate_achievement(rc_runtime_t* self, unsigned id, const char*
   rc_runtime_checksum(memaddr, md5);
 
   /* check to see if the id is already registered with an active trigger */
-  for (unsigned i = 0; i < self->trigger_count; ++i) {
+  for (i = 0; i < self->trigger_count; ++i) {
     if (self->triggers[i].id == id && self->triggers[i].trigger != NULL) {
       if (memcmp(self->triggers[i].md5, md5, 16) == 0) {
         /* if the checksum hasn't changed, we can reuse the existing item */
@@ -117,7 +122,7 @@ int rc_runtime_activate_achievement(rc_runtime_t* self, unsigned id, const char*
   }
 
   /* check to see if a disabled trigger for the specific id matches the trigger being registered */
-  for (unsigned i = 0; i < self->trigger_count; ++i) {
+  for (i = 0; i < self->trigger_count; ++i) {
     if (self->triggers[i].id == id && memcmp(self->triggers[i].md5, md5, 16) == 0) {
       /* retrieve the trigger pointer from the buffer */
       size = 0;
@@ -185,7 +190,9 @@ int rc_runtime_activate_achievement(rc_runtime_t* self, unsigned id, const char*
 
 rc_trigger_t* rc_runtime_get_achievement(const rc_runtime_t* self, unsigned id)
 {
-  for (unsigned i = 0; i < self->trigger_count; ++i) {
+  unsigned i;
+
+  for (i = 0; i < self->trigger_count; ++i) {
     if (self->triggers[i].id == id && self->triggers[i].trigger != NULL)
       return self->triggers[i].trigger;
   }
@@ -211,7 +218,9 @@ static void rc_runtime_deactivate_lboard_by_index(rc_runtime_t* self, unsigned i
 }
 
 void rc_runtime_deactivate_lboard(rc_runtime_t* self, unsigned id) {
-  for (unsigned i = 0; i < self->lboard_count; ++i) {
+  unsigned i;
+
+  for (i = 0; i < self->lboard_count; ++i) {
     if (self->lboards[i].id == id && self->lboards[i].lboard != NULL)
       rc_runtime_deactivate_lboard_by_index(self, i);
   }
@@ -224,6 +233,7 @@ int rc_runtime_activate_lboard(rc_runtime_t* self, unsigned id, const char* mema
   rc_parse_state_t parse;
   int size;
   char owns_memref;
+  unsigned i;
 
   if (memaddr == 0)
     return RC_INVALID_MEMORY_OPERAND;
@@ -231,7 +241,7 @@ int rc_runtime_activate_lboard(rc_runtime_t* self, unsigned id, const char* mema
   rc_runtime_checksum(memaddr, md5);
 
   /* check to see if the id is already registered with an active lboard */
-  for (unsigned i = 0; i < self->lboard_count; ++i) {
+  for (i = 0; i < self->lboard_count; ++i) {
     if (self->lboards[i].id == id && self->lboards[i].lboard != NULL) {
       if (memcmp(self->lboards[i].md5, md5, 16) == 0) {
         /* if the checksum hasn't changed, we can reuse the existing item */
@@ -250,7 +260,7 @@ int rc_runtime_activate_lboard(rc_runtime_t* self, unsigned id, const char* mema
   }
 
   /* check to see if a disabled lboard for the specific id matches the lboard being registered */
-  for (unsigned i = 0; i < self->trigger_count; ++i) {
+  for (i = 0; i < self->trigger_count; ++i) {
     if (self->lboards[i].id == id && memcmp(self->lboards[i].md5, md5, 16) == 0) {
       /* retrieve the lboard pointer from the buffer */
       size = 0;
@@ -319,7 +329,9 @@ int rc_runtime_activate_lboard(rc_runtime_t* self, unsigned id, const char* mema
 
 rc_lboard_t* rc_runtime_get_lboard(const rc_runtime_t* self, unsigned id)
 {
-  for (unsigned i = 0; i < self->lboard_count; ++i) {
+  unsigned i;
+
+  for (i = 0; i < self->lboard_count; ++i) {
     if (self->lboards[i].id == id && self->lboards[i].lboard != NULL)
       return self->lboards[i].lboard;
   }
@@ -415,11 +427,13 @@ const char* rc_runtime_get_richpresence(const rc_runtime_t* self)
 
 void rc_runtime_do_frame(rc_runtime_t* self, rc_runtime_event_handler_t event_handler, rc_peek_t peek, void* ud, lua_State* L) {
   rc_runtime_event_t runtime_event;
+  unsigned i;
+
   runtime_event.value = 0;
 
   rc_update_memref_values(self->memrefs, peek, ud);
 
-  for (unsigned i = 0; i < self->trigger_count; ++i) {
+  for (i = 0; i < self->trigger_count; ++i) {
     rc_trigger_t* trigger = self->triggers[i].trigger;
     int trigger_state;
 
@@ -460,7 +474,7 @@ void rc_runtime_do_frame(rc_runtime_t* self, rc_runtime_event_handler_t event_ha
     }
   }
   
-  for (unsigned i = 0; i < self->lboard_count; ++i) {
+  for (i = 0; i < self->lboard_count; ++i) {
     rc_lboard_t* lboard = self->lboards[i].lboard;
     int lboard_state;
 
@@ -512,8 +526,10 @@ void rc_runtime_do_frame(rc_runtime_t* self, rc_runtime_event_handler_t event_ha
       int len = rc_evaluate_richpresence(self->richpresence, buffer, RC_RICHPRESENCE_DISPLAY_BUFFER_SIZE - 1, peek, ud, L);
 
       /* copy into the real buffer - write the 0 terminator first to ensure reads don't overflow the buffer */
-      buffer[RC_RICHPRESENCE_DISPLAY_BUFFER_SIZE - 1] = '\0';
-      memcpy(self->richpresence_display_buffer, buffer, RC_RICHPRESENCE_DISPLAY_BUFFER_SIZE);
+      if (len > 0) {
+        buffer[RC_RICHPRESENCE_DISPLAY_BUFFER_SIZE - 1] = '\0';
+        memcpy(self->richpresence_display_buffer, buffer, RC_RICHPRESENCE_DISPLAY_BUFFER_SIZE);
+      }
 
       /* schedule the next update for 60 frames later - most systems use a 60 fps framerate (some use more 50 or 75)
        * since we're only sending to the server every two minutes, that's only every 7200 frames while active, which
@@ -527,12 +543,14 @@ void rc_runtime_do_frame(rc_runtime_t* self, rc_runtime_event_handler_t event_ha
 }
 
 void rc_runtime_reset(rc_runtime_t* self) {
-  for (unsigned i = 0; i < self->trigger_count; ++i) {
+  unsigned i;
+
+  for (i = 0; i < self->trigger_count; ++i) {
     if (self->triggers[i].trigger)
       rc_reset_trigger(self->triggers[i].trigger);
   }
 
-  for (unsigned i = 0; i < self->lboard_count; ++i) {
+  for (i = 0; i < self->lboard_count; ++i) {
     if (self->lboards[i].lboard)
       rc_reset_lboard(self->lboards[i].lboard);
   }
@@ -546,7 +564,9 @@ void rc_runtime_reset(rc_runtime_t* self) {
   }
 }
 
-// TODO: char* rc_runtime_serialize_progress(rc_runtime_t* runtime)
-//       returns malloc'd string to be written to disk
-//       make sure to include measured_value and state in serialized format (only serialize active and paused)
-// TODO: int rc_runtime_deserialize_progress(rc_runtime_t* runtime, const char* serialized)
+/*
+ * TODO: char* rc_runtime_serialize_progress(rc_runtime_t* runtime)
+ *       returns malloc'd string to be written to disk
+ *       make sure to include measured_value and state in serialized format (only serialize active and paused)
+ * TODO: int rc_runtime_deserialize_progress(rc_runtime_t* runtime, const char* serialized)
+*/

--- a/src/rcheevos/runtime.c
+++ b/src/rcheevos/runtime.c
@@ -56,7 +56,7 @@ void rc_runtime_destroy(rc_runtime_t* self) {
 static void rc_runtime_checksum(const char* memaddr, unsigned char* md5) {
   md5_state_t state;
   md5_init(&state);
-  md5_append(&state, (unsigned char*)memaddr, strlen(memaddr));
+  md5_append(&state, (unsigned char*)memaddr, (int)strlen(memaddr));
   md5_finish(&state, md5);  
 }
 
@@ -183,7 +183,7 @@ int rc_runtime_activate_achievement(rc_runtime_t* self, unsigned id, const char*
   return RC_OK;
 }
 
-rc_trigger_t* rc_runtime_get_achievement(rc_runtime_t* self, unsigned id)
+rc_trigger_t* rc_runtime_get_achievement(const rc_runtime_t* self, unsigned id)
 {
   for (unsigned i = 0; i < self->trigger_count; ++i) {
     if (self->triggers[i].id == id && self->triggers[i].trigger != NULL)
@@ -317,7 +317,7 @@ int rc_runtime_activate_lboard(rc_runtime_t* self, unsigned id, const char* mema
   return RC_OK;
 }
 
-rc_lboard_t* rc_runtime_get_lboard(rc_runtime_t* self, unsigned id)
+rc_lboard_t* rc_runtime_get_lboard(const rc_runtime_t* self, unsigned id)
 {
   for (unsigned i = 0; i < self->lboard_count; ++i) {
     if (self->lboards[i].id == id && self->lboards[i].lboard != NULL)
@@ -405,7 +405,7 @@ int rc_runtime_activate_richpresence(rc_runtime_t* self, const char* script, lua
   return RC_OK;
 }
 
-const char* rc_runtime_get_richpresence(rc_runtime_t* self)
+const char* rc_runtime_get_richpresence(const rc_runtime_t* self)
 {
   if (self->richpresence_display_buffer)
     return self->richpresence_display_buffer;
@@ -462,11 +462,12 @@ void rc_runtime_do_frame(rc_runtime_t* self, rc_runtime_event_handler_t event_ha
   
   for (unsigned i = 0; i < self->lboard_count; ++i) {
     rc_lboard_t* lboard = self->lboards[i].lboard;
-    int lboard_state = lboard->state;
+    int lboard_state;
 
     if (!lboard)
       continue;
     
+    lboard_state = lboard->state;
     switch (rc_evaluate_lboard(lboard, &runtime_event.value, peek, ud, L))
     {
       case RC_LBOARD_STATE_STARTED: /* leaderboard is running */
@@ -547,4 +548,5 @@ void rc_runtime_reset(rc_runtime_t* self) {
 
 // TODO: char* rc_runtime_serialize_progress(rc_runtime_t* runtime)
 //       returns malloc'd string to be written to disk
+//       make sure to include measured_value and state in serialized format (only serialize active and paused)
 // TODO: int rc_runtime_deserialize_progress(rc_runtime_t* runtime, const char* serialized)

--- a/src/rcheevos/trigger.c
+++ b/src/rcheevos/trigger.c
@@ -1,7 +1,7 @@
 #include "internal.h"
 
 #include <stddef.h>
-#include <string.h> // memset
+#include <string.h> /* memset */
 
 void rc_parse_trigger_internal(rc_trigger_t* self, const char** memaddr, rc_parse_state_t* parse) {
   rc_condset_t** next;

--- a/src/rcheevos/trigger.c
+++ b/src/rcheevos/trigger.c
@@ -96,7 +96,7 @@ int rc_evaluate_trigger(rc_trigger_t* self, rc_peek_t peek, void* ud, lua_State*
 
   rc_update_memref_values(self->memrefs, peek, ud);
 
-  /* not yet active, only update the memrefs - so deltas are corrent when it becomes active */
+  /* not yet active, only update the memrefs - so deltas are correct when it becomes active */
   if (self->state == RC_TRIGGER_STATE_INACTIVE)
     return RC_TRIGGER_STATE_INACTIVE;
 

--- a/src/rcheevos/trigger.c
+++ b/src/rcheevos/trigger.c
@@ -182,4 +182,5 @@ void rc_reset_trigger(rc_trigger_t* self) {
   rc_reset_trigger_hitcounts(self);
 
   self->state = RC_TRIGGER_STATE_WAITING;
+  self->has_hits = 0;
 }

--- a/src/rcheevos/value.c
+++ b/src/rcheevos/value.c
@@ -1,6 +1,6 @@
 #include "internal.h"
 
-#include <string.h> // memset
+#include <string.h> /* memset */
 
 static void rc_parse_cond_value(rc_value_t* self, const char** memaddr, rc_parse_state_t* parse) {
   rc_condition_t** next;

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,11 +1,12 @@
 RC_SRC=../src/rcheevos
 RC_URL_SRC=../src/rurl
+RC_HASH_SRC=../src/rhash
 LUA_SRC=lua/src
 
 OBJ=$(RC_SRC)/trigger.o $(RC_SRC)/condset.o $(RC_SRC)/condition.o $(RC_SRC)/operand.o \
     $(RC_SRC)/term.o $(RC_SRC)/expression.o $(RC_SRC)/value.o $(RC_SRC)/lboard.o \
     $(RC_SRC)/alloc.o $(RC_SRC)/memref.o $(RC_SRC)/format.o $(RC_SRC)/richpresence.o \
-    $(RC_URL_SRC)/url.o \
+    $(RC_SRC)/runtime.o $(RC_HASH_SRC)/md5.o $(RC_URL_SRC)/url.o \
     $(LUA_SRC)/lapi.o $(LUA_SRC)/lcode.o $(LUA_SRC)/lctype.o $(LUA_SRC)/ldebug.o \
     $(LUA_SRC)/ldo.o $(LUA_SRC)/ldump.o $(LUA_SRC)/lfunc.o $(LUA_SRC)/lgc.o $(LUA_SRC)/llex.o \
     $(LUA_SRC)/lmem.o $(LUA_SRC)/lobject.o $(LUA_SRC)/lopcodes.o $(LUA_SRC)/lparser.o \

--- a/test/rcheevos-test.vcxproj
+++ b/test/rcheevos-test.vcxproj
@@ -130,9 +130,11 @@
     <ClCompile Include="..\src\rcheevos\memref.c" />
     <ClCompile Include="..\src\rcheevos\operand.c" />
     <ClCompile Include="..\src\rcheevos\richpresence.c" />
+    <ClCompile Include="..\src\rcheevos\runtime.c" />
     <ClCompile Include="..\src\rcheevos\term.c" />
     <ClCompile Include="..\src\rcheevos\trigger.c" />
     <ClCompile Include="..\src\rcheevos\value.c" />
+    <ClCompile Include="..\src\rhash\md5.c" />
     <ClCompile Include="lua\src\lapi.c" />
     <ClCompile Include="lua\src\lauxlib.c" />
     <ClCompile Include="lua\src\lbaselib.c" />

--- a/test/rcheevos-test.vcxproj.filters
+++ b/test/rcheevos-test.vcxproj.filters
@@ -145,6 +145,12 @@
     <ClCompile Include="..\src\rcheevos\memref.c">
       <Filter>rcheevos</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\rcheevos\runtime.c">
+      <Filter>rcheevos</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\rhash\md5.c">
+      <Filter>rcheevos</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\src\rcheevos\internal.h">

--- a/test/test.c
+++ b/test/test.c
@@ -7,7 +7,7 @@
 #include <stddef.h>
 #include <string.h>
 #include <assert.h>
-#include <string.h> // memset
+#include <string.h> /* memset */
 
 #include "lua.h"
 #include "lauxlib.h"
@@ -3081,12 +3081,7 @@ static void test_trigger(void) {
     Verifies a single memref is used for multiple bit references to the same byte
     ------------------------------------------------------------------------*/
 
-    unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
-    memory_t memory;
     rc_trigger_t* trigger;
-
-    memory.ram = ram;
-    memory.size = sizeof(ram);
 
     parse_trigger(&trigger, buffer, "0xM0001=1_0xN0x0001=0_0xO0x0001=1");
 
@@ -3105,12 +3100,7 @@ static void test_trigger(void) {
     Verifies a single memref is used for multiple bit references to the same byte
     ------------------------------------------------------------------------*/
 
-    unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
-    memory_t memory;
     rc_trigger_t* trigger;
-
-    memory.ram = ram;
-    memory.size = sizeof(ram);
 
     parse_trigger(&trigger, buffer, "0xH1234=1_0xX1234>d0xX1234");
 
@@ -4788,7 +4778,9 @@ static void event_handler(const rc_runtime_event_t* e)
 
 static void assert_event(char type, int id, int value)
 {
-  for (int i = 0; i < event_count; ++i) {
+  int i;
+
+  for (i = 0; i < event_count; ++i) {
     if (events[i].id == id && events[i].type == type && events[i].value == value)
       return;
   }
@@ -5343,7 +5335,6 @@ static void test_runtime(void) {
     unsigned char ram[] = { 2, 10, 10 };
     memory_t memory;
     rc_runtime_t runtime;
-    int frame_count = 0;
 
     memory.ram = ram;
     memory.size = sizeof(ram);

--- a/test/test.c
+++ b/test/test.c
@@ -3427,6 +3427,7 @@ static rc_lboard_t* parse_lboard(const char* memaddr, void* buffer) {
   assert(self != NULL);
   assert(*((int*)((char*)buffer + ret)) == 0xEEEEEEEE);
 
+  self->state = RC_LBOARD_STATE_ACTIVE;
   return self;
 }
 
@@ -3449,15 +3450,15 @@ static int lboard_evaluate(rc_lboard_t* lboard, lboard_test_state_t* test, memor
   int value;
 
   switch (rc_evaluate_lboard(lboard, &value, peek, memory, NULL)) {
-    case RC_LBOARD_STARTED:
+    case RC_LBOARD_STATE_STARTED:
       test->active = 1;
       break;
 
-    case RC_LBOARD_CANCELED:
+    case RC_LBOARD_STATE_CANCELED:
       test->active = 0;
       break;
 
-    case RC_LBOARD_TRIGGERED:
+    case RC_LBOARD_STATE_TRIGGERED:
       test->active = 0;
       test->submitted = 1;
       break;
@@ -3722,6 +3723,7 @@ static void test_lboard(void) {
 
     ram[2] = 0; /* second part of cancel condition is false */
     lboard_reset(lboard, &state);
+    lboard->state = RC_LBOARD_STATE_ACTIVE;
     lboard_evaluate(lboard, &state, &memory);
     assert(state.active);
 
@@ -3781,6 +3783,7 @@ static void test_lboard(void) {
 
     ram[3] = 0;
     lboard_reset(lboard, &state);
+    lboard->state = RC_LBOARD_STATE_ACTIVE;
     lboard_evaluate(lboard, &state, &memory);
     assert(state.active);
 
@@ -4775,6 +4778,595 @@ static void test_richpresence(void) {
   }
 }
 
+static rc_runtime_event_t events[16];
+static int event_count = 0;
+
+static void event_handler(const rc_runtime_event_t* e)
+{
+  memcpy(&events[event_count++], e, sizeof(rc_runtime_event_t));
+}
+
+static void assert_event(char type, int id, int value)
+{
+  for (int i = 0; i < event_count; ++i) {
+    if (events[i].id == id && events[i].type == type && events[i].value == value)
+      return;
+  }
+
+  assert(!"expected event not found");
+}
+
+static void test_runtime(void) {
+  {
+    /*------------------------------------------------------------------------
+    TestRuntimeTwoAchievementsActivateAndTrigger
+    ------------------------------------------------------------------------*/
+    unsigned char ram[] = { 0, 10, 10 };
+    memory_t memory;
+    rc_runtime_t runtime;
+
+    memory.ram = ram;
+    memory.size = sizeof(ram);
+
+    rc_runtime_init(&runtime);
+
+    assert(rc_runtime_activate_achievement(&runtime, 1, "0xH0001=10", NULL, 0) == RC_OK);
+    assert(rc_runtime_activate_achievement(&runtime, 2, "0xH0002=10", NULL, 0) == RC_OK);
+
+    /* both achievements are true, should remain in waiting state */
+    event_count = 0;
+    rc_runtime_do_frame(&runtime, event_handler, peek, &memory, NULL);
+    assert(event_count == 0);
+    assert(runtime.triggers[0].trigger->state == RC_TRIGGER_STATE_WAITING);
+    assert(runtime.triggers[1].trigger->state == RC_TRIGGER_STATE_WAITING);
+
+    /* both achievements are false, should activate */
+    event_count = 0;
+    ram[1] = ram[2] = 9;
+    rc_runtime_do_frame(&runtime, event_handler, peek, &memory, NULL);
+    assert(runtime.triggers[0].trigger->state == RC_TRIGGER_STATE_ACTIVE);
+    assert(runtime.triggers[1].trigger->state == RC_TRIGGER_STATE_ACTIVE);
+    assert(event_count == 2);
+    assert_event(RC_RUNTIME_EVENT_ACHIEVEMENT_ACTIVATED, 1, 0);
+    assert_event(RC_RUNTIME_EVENT_ACHIEVEMENT_ACTIVATED, 2, 0);
+
+    /* second achievement is true, should trigger */
+    event_count = 0;
+    ram[2] = 10;
+    rc_runtime_do_frame(&runtime, event_handler, peek, &memory, NULL);
+    assert(runtime.triggers[0].trigger->state == RC_TRIGGER_STATE_ACTIVE);
+    assert(runtime.triggers[1].trigger->state == RC_TRIGGER_STATE_TRIGGERED);
+    assert(event_count == 1);
+    assert_event(RC_RUNTIME_EVENT_ACHIEVEMENT_TRIGGERED, 2, 0);
+
+    /* first achievement is true, should trigger. second is already triggered */
+    event_count = 0;
+    ram[1] = 10;
+    rc_runtime_do_frame(&runtime, event_handler, peek, &memory, NULL);
+    assert(runtime.triggers[0].trigger->state == RC_TRIGGER_STATE_TRIGGERED);
+    assert(runtime.triggers[1].trigger->state == RC_TRIGGER_STATE_TRIGGERED);
+    assert(event_count == 1);
+    assert_event(RC_RUNTIME_EVENT_ACHIEVEMENT_TRIGGERED, 1, 0);
+
+    /* reset second achievement, should go back to waiting and stay there */
+    event_count = 0;
+    rc_reset_trigger(runtime.triggers[1].trigger);
+    rc_runtime_do_frame(&runtime, event_handler, peek, &memory, NULL);
+    assert(runtime.triggers[0].trigger->state == RC_TRIGGER_STATE_TRIGGERED);
+    assert(runtime.triggers[1].trigger->state == RC_TRIGGER_STATE_WAITING);
+    assert(event_count == 0);
+
+    /* both achievements are false again, second should activate, first should be ignored */
+    event_count = 0;
+    ram[1] = ram[2] = 9;
+    rc_runtime_do_frame(&runtime, event_handler, peek, &memory, NULL);
+    assert(runtime.triggers[0].trigger->state == RC_TRIGGER_STATE_TRIGGERED);
+    assert(runtime.triggers[1].trigger->state == RC_TRIGGER_STATE_ACTIVE);
+    assert(event_count == 1);
+    assert_event(RC_RUNTIME_EVENT_ACHIEVEMENT_ACTIVATED, 2, 0);
+
+    rc_runtime_destroy(&runtime);
+  }
+
+  {
+    /*------------------------------------------------------------------------
+    TestRuntimeDeactivateAchievements
+    ------------------------------------------------------------------------*/
+    unsigned char ram[] = { 0, 10, 10 };
+    memory_t memory;
+    rc_runtime_t runtime;
+
+    memory.ram = ram;
+    memory.size = sizeof(ram);
+
+    rc_runtime_init(&runtime);
+
+    assert(rc_runtime_activate_achievement(&runtime, 1, "0xH0001=10", NULL, 0) == RC_OK);
+    assert(rc_runtime_activate_achievement(&runtime, 2, "0xH0002=10", NULL, 0) == RC_OK);
+
+    /* both achievements are true, should remain in waiting state */
+    event_count = 0;
+    rc_runtime_do_frame(&runtime, event_handler, peek, &memory, NULL);
+    assert(event_count == 0);
+    assert(runtime.triggers[0].trigger->state == RC_TRIGGER_STATE_WAITING);
+    assert(runtime.triggers[1].trigger->state == RC_TRIGGER_STATE_WAITING);
+
+    /* deactivate the first one - has memrefs, can't be deallocated */
+    rc_runtime_deactivate_achievement(&runtime, 1);
+    assert(runtime.trigger_count == 2);
+    assert(runtime.triggers[0].trigger == NULL);
+    assert(runtime.triggers[1].trigger->state == RC_TRIGGER_STATE_WAITING);
+
+    /* both achievements are false, only active one should activate */
+    event_count = 0;
+    ram[1] = ram[2] = 9;
+    rc_runtime_do_frame(&runtime, event_handler, peek, &memory, NULL);
+    assert(event_count == 1);
+    assert_event(RC_RUNTIME_EVENT_ACHIEVEMENT_ACTIVATED, 2, 0);
+
+    /* both achievements are true, only active one should trigger */
+    event_count = 0;
+    ram[1] = ram[2] = 10;
+    rc_runtime_do_frame(&runtime, event_handler, peek, &memory, NULL);
+    assert(event_count == 1);
+    assert_event(RC_RUNTIME_EVENT_ACHIEVEMENT_TRIGGERED, 2, 0);
+
+    /* reactivate achievement. definition didn't change, just reactivate in-place */
+    assert(rc_runtime_activate_achievement(&runtime, 1, "0xH0001=10", NULL, 0) == RC_OK);
+    assert(runtime.trigger_count == 2);
+    assert(runtime.triggers[0].trigger->state == RC_TRIGGER_STATE_WAITING);
+    assert(runtime.triggers[1].trigger->state == RC_TRIGGER_STATE_TRIGGERED);
+
+    /* reactivated achievement is waiting, should not trigger */
+    event_count = 0;
+    rc_runtime_do_frame(&runtime, event_handler, peek, &memory, NULL);
+    assert(runtime.triggers[0].trigger->state == RC_TRIGGER_STATE_WAITING);
+    assert(runtime.triggers[1].trigger->state == RC_TRIGGER_STATE_TRIGGERED);
+    assert(event_count == 0);
+
+    /* both achievements are false again, first should activate, second should be ignored */
+    event_count = 0;
+    ram[1] = ram[2] = 9;
+    rc_runtime_do_frame(&runtime, event_handler, peek, &memory, NULL);
+    assert(runtime.triggers[0].trigger->state == RC_TRIGGER_STATE_ACTIVE);
+    assert(runtime.triggers[1].trigger->state == RC_TRIGGER_STATE_TRIGGERED);
+    assert(event_count == 1);
+    assert_event(RC_RUNTIME_EVENT_ACHIEVEMENT_ACTIVATED, 1, 0);
+
+    rc_runtime_destroy(&runtime);
+  }
+
+  {
+    /*------------------------------------------------------------------------
+    TestRuntimeSharedMemRef
+    ------------------------------------------------------------------------*/
+    unsigned char ram[] = { 0, 10, 10 };
+    memory_t memory;
+    rc_runtime_t runtime;
+
+    memory.ram = ram;
+    memory.size = sizeof(ram);
+
+    rc_runtime_init(&runtime);
+
+    assert(rc_runtime_activate_achievement(&runtime, 1, "0xH0001=10", NULL, 0) == RC_OK);
+    assert(rc_runtime_activate_achievement(&runtime, 2, "0xH0001=12", NULL, 0) == RC_OK);
+
+    assert(condset_get_cond(trigger_get_set(runtime.triggers[0].trigger, 0), 0)->operand1.value.memref ==
+           condset_get_cond(trigger_get_set(runtime.triggers[1].trigger, 0), 0)->operand1.value.memref);
+
+    /* first is true, should remain waiting, second should activate */
+    event_count = 0;
+    rc_runtime_do_frame(&runtime, event_handler, peek, &memory, NULL);
+    assert(event_count == 1);
+    assert(runtime.triggers[0].trigger->state == RC_TRIGGER_STATE_WAITING);
+    assert(runtime.triggers[1].trigger->state == RC_TRIGGER_STATE_ACTIVE);
+    assert_event(RC_RUNTIME_EVENT_ACHIEVEMENT_ACTIVATED, 2, 0);
+
+    /* deactivate second one. it doesn't have any unique memrefs, so can be free'd */
+    rc_runtime_deactivate_achievement(&runtime, 2);
+    assert(runtime.trigger_count == 1);
+    assert(runtime.triggers[0].trigger->state == RC_TRIGGER_STATE_WAITING);
+
+    /* second is true, but no longer in runtime. first should activate, expect nothing from second */
+    event_count = 0;
+    ram[1] = 12;
+    rc_runtime_do_frame(&runtime, event_handler, peek, &memory, NULL);
+    assert(event_count == 1);
+    assert_event(RC_RUNTIME_EVENT_ACHIEVEMENT_ACTIVATED, 1, 0);
+
+    /* first is true and should trigger */
+    event_count = 0;
+    ram[1] = 10;
+    rc_runtime_do_frame(&runtime, event_handler, peek, &memory, NULL);
+    assert(event_count == 1);
+    assert_event(RC_RUNTIME_EVENT_ACHIEVEMENT_TRIGGERED, 1, 0);
+
+    /* reactivate achievement. old definition was free'd, so should be recreated */
+    assert(rc_runtime_activate_achievement(&runtime, 2, "0xH0001=12", NULL, 0) == RC_OK);
+    assert(runtime.trigger_count == 2);
+    assert(runtime.triggers[0].trigger->state == RC_TRIGGER_STATE_TRIGGERED);
+    assert(runtime.triggers[1].trigger->state == RC_TRIGGER_STATE_WAITING);
+
+    /* reactivated achievement is waiting and false, should activate */
+    event_count = 0;
+    rc_runtime_do_frame(&runtime, event_handler, peek, &memory, NULL);
+    assert(event_count == 1);
+    assert_event(RC_RUNTIME_EVENT_ACHIEVEMENT_ACTIVATED, 2, 0);
+
+    /* deactive first achievement, memrefs used by second - cannot be free'd */
+    rc_runtime_deactivate_achievement(&runtime, 1);
+    assert(runtime.trigger_count == 2);
+    assert(runtime.triggers[0].trigger == NULL);
+    assert(runtime.triggers[1].trigger->state == RC_TRIGGER_STATE_ACTIVE);
+
+    /* second achievement is true, should activate using memrefs from first */
+    event_count = 0;
+    ram[1] = 12;
+    rc_runtime_do_frame(&runtime, event_handler, peek, &memory, NULL);
+    assert(event_count == 1);
+    assert_event(RC_RUNTIME_EVENT_ACHIEVEMENT_TRIGGERED, 2, 0);
+
+    rc_runtime_destroy(&runtime);
+  }
+
+  {
+    /*------------------------------------------------------------------------
+    TestRuntimeReplaceActiveTrigger
+    ------------------------------------------------------------------------*/
+    unsigned char ram[] = { 0, 10, 10 };
+    memory_t memory;
+    rc_runtime_t runtime;
+
+    memory.ram = ram;
+    memory.size = sizeof(ram);
+
+    rc_runtime_init(&runtime);
+
+    assert(rc_runtime_activate_achievement(&runtime, 1, "0xH0001=10", NULL, 0) == RC_OK);
+    assert(rc_runtime_activate_achievement(&runtime, 1, "0xH0002=10", NULL, 0) == RC_OK);
+
+    /* both are true, but first should have been overridden by second */
+    event_count = 0;
+    rc_runtime_do_frame(&runtime, event_handler, peek, &memory, NULL);
+    assert(runtime.trigger_count == 2);
+    assert(runtime.triggers[0].trigger == NULL);
+    assert(runtime.triggers[1].trigger->state == RC_TRIGGER_STATE_WAITING);
+    assert(event_count == 0);
+
+    /* both are false, but only second should be getting processed, expect single event */
+    event_count = 0;
+    ram[1] = ram[2] = 9;
+    rc_runtime_do_frame(&runtime, event_handler, peek, &memory, NULL);
+    assert(event_count == 1);
+    assert_event(RC_RUNTIME_EVENT_ACHIEVEMENT_ACTIVATED, 1, 0);
+
+    /* first is true, but should not trigger */
+    event_count = 0;
+    ram[1] = 10;
+    rc_runtime_do_frame(&runtime, event_handler, peek, &memory, NULL);
+    assert(event_count == 0);
+
+    /* second is true, and should trigger */
+    event_count = 0;
+    ram[2] = 10;
+    rc_runtime_do_frame(&runtime, event_handler, peek, &memory, NULL);
+    assert(event_count == 1);
+    assert_event(RC_RUNTIME_EVENT_ACHIEVEMENT_TRIGGERED, 1, 0);
+
+    /* switch back to original definition, since memref kept buffer alive, buffer should be reused */
+    assert(rc_runtime_activate_achievement(&runtime, 1, "0xH0001=10", NULL, 0) == RC_OK);
+    assert(runtime.trigger_count == 2);
+    assert(runtime.triggers[0].trigger->state == RC_TRIGGER_STATE_WAITING);
+    assert(runtime.triggers[1].trigger == NULL);
+
+    rc_runtime_destroy(&runtime);
+  }
+
+  {
+    /*------------------------------------------------------------------------
+    TestRuntimeResetIf
+    ------------------------------------------------------------------------*/
+    unsigned char ram[] = { 0, 10, 10 };
+    memory_t memory;
+    rc_runtime_t runtime;
+
+    memory.ram = ram;
+    memory.size = sizeof(ram);
+
+    rc_runtime_init(&runtime);
+
+    assert(rc_runtime_activate_achievement(&runtime, 1, "0xH0001=10.2._R:0xH0002=10", NULL, 0) == RC_OK);
+    rc_condition_t* cond = condset_get_cond(trigger_get_set(runtime.triggers[0].trigger, 0), 0);
+
+    /* reset is true, so achievement is false, it should activate, but not notify reset */
+    event_count = 0;
+    rc_runtime_do_frame(&runtime, event_handler, peek, &memory, NULL);
+    assert(event_count == 1);
+    assert_event(RC_RUNTIME_EVENT_ACHIEVEMENT_ACTIVATED, 1, 0);
+    assert(cond->current_hits == 0);
+
+    /* reset is still true, but no hits accumulated, so no event */
+    event_count = 0;
+    rc_runtime_do_frame(&runtime, event_handler, peek, &memory, NULL);
+    assert(event_count == 0);
+
+    /* reset is not true, hits should increment */
+    event_count = 0;
+    ram[2] = 9;
+    rc_runtime_do_frame(&runtime, event_handler, peek, &memory, NULL);
+    assert(event_count == 0);
+    assert(cond->current_hits == 1);
+
+    /* reset is true, hits should reset, expect event */
+    event_count = 0;
+    ram[2] = 10;
+    rc_runtime_do_frame(&runtime, event_handler, peek, &memory, NULL);
+    assert(event_count == 1);
+    assert_event(RC_RUNTIME_EVENT_ACHIEVEMENT_RESET, 1, 0);
+    assert(cond->current_hits == 0);
+
+    /* reset is still true, but no hits accumulated, so no event */
+    event_count = 0;
+    rc_runtime_do_frame(&runtime, event_handler, peek, &memory, NULL);
+    assert(event_count == 0);
+
+    /* reset is not true, hits should increment */
+    event_count = 0;
+    ram[2] = 9;
+    rc_runtime_do_frame(&runtime, event_handler, peek, &memory, NULL);
+    assert(event_count == 0);
+    assert(cond->current_hits == 1);
+
+    /* reset is not true, hits should increment and trigger should fire */
+    event_count = 0;
+    rc_runtime_do_frame(&runtime, event_handler, peek, &memory, NULL);
+    assert(event_count == 1);
+    assert_event(RC_RUNTIME_EVENT_ACHIEVEMENT_TRIGGERED, 1, 0);
+    assert(cond->current_hits == 2);
+
+    /* reset is true, but shouldn't be processed as trigger previously fired */
+    event_count = 0;
+    ram[2] = 10;
+    rc_runtime_do_frame(&runtime, event_handler, peek, &memory, NULL);
+    assert(event_count == 0);
+    assert(cond->current_hits == 2);
+
+    rc_runtime_destroy(&runtime);
+  }
+
+  {
+    /*------------------------------------------------------------------------
+    TestRuntimePauseIf
+    ------------------------------------------------------------------------*/
+    unsigned char ram[] = { 0, 10, 10 };
+    memory_t memory;
+    rc_runtime_t runtime;
+
+    memory.ram = ram;
+    memory.size = sizeof(ram);
+
+    rc_runtime_init(&runtime);
+
+    assert(rc_runtime_activate_achievement(&runtime, 1, "0xH0001=10.2._P:0xH0002=10", NULL, 0) == RC_OK);
+
+    /* pause is true, so achievement is false, it should activate, but only notify pause */
+    event_count = 0;
+    rc_runtime_do_frame(&runtime, event_handler, peek, &memory, NULL);
+    assert(event_count == 1);
+    assert_event(RC_RUNTIME_EVENT_ACHIEVEMENT_PAUSED, 1, 0);
+
+    /* pause is still true, but previously paused, so no event */
+    event_count = 0;
+    rc_runtime_do_frame(&runtime, event_handler, peek, &memory, NULL);
+    assert(event_count == 0);
+
+    /* pause is not true, expect activate event */
+    event_count = 0;
+    ram[2] = 9;
+    rc_runtime_do_frame(&runtime, event_handler, peek, &memory, NULL);
+    assert(event_count == 1);
+    assert_event(RC_RUNTIME_EVENT_ACHIEVEMENT_ACTIVATED, 1, 0);
+
+    /* pause is true, expect event */
+    event_count = 0;
+    ram[2] = 10;
+    rc_runtime_do_frame(&runtime, event_handler, peek, &memory, NULL);
+    assert(event_count == 1);
+    assert_event(RC_RUNTIME_EVENT_ACHIEVEMENT_PAUSED, 1, 0);
+
+    /* pause is still true, but previously paused, so no event */
+    event_count = 0;
+    rc_runtime_do_frame(&runtime, event_handler, peek, &memory, NULL);
+    assert(event_count == 0);
+
+    /* pause is not true, expect trigger */
+    event_count = 0;
+    ram[2] = 9;
+    rc_runtime_do_frame(&runtime, event_handler, peek, &memory, NULL);
+    assert(event_count == 1);
+    assert_event(RC_RUNTIME_EVENT_ACHIEVEMENT_TRIGGERED, 1, 0);
+
+    /* reset is true, but shouldn't be processed as trigger previously fired */
+    event_count = 0;
+    ram[2] = 10;
+    rc_runtime_do_frame(&runtime, event_handler, peek, &memory, NULL);
+    assert(event_count == 0);
+
+    rc_runtime_destroy(&runtime);
+  }
+
+  {
+    /*------------------------------------------------------------------------
+    TestRuntimeTwoLeaderboardsActivateAndTrigger
+    ------------------------------------------------------------------------*/
+    unsigned char ram[] = { 2, 10, 10 };
+    memory_t memory;
+    rc_runtime_t runtime;
+
+    memory.ram = ram;
+    memory.size = sizeof(ram);
+
+    rc_runtime_init(&runtime);
+
+    assert(rc_runtime_activate_lboard(&runtime, 1, "STA:0xH0001=10::SUB:0xH0001=11::CAN:0xH0001=12::VAL:0xH0000", NULL, 0) == RC_OK);
+    assert(rc_runtime_activate_lboard(&runtime, 2, "STA:0xH0002=10::SUB:0xH0002=11::CAN:0xH0002=12::VAL:0xH0000*2", NULL, 0) == RC_OK);
+
+    /* both start conditions are true, leaderboards will not be active */
+    event_count = 0;
+    rc_runtime_do_frame(&runtime, event_handler, peek, &memory, NULL);
+    assert(runtime.lboards[0].lboard->state == RC_LBOARD_STATE_WAITING);
+    assert(runtime.lboards[1].lboard->state == RC_LBOARD_STATE_WAITING);
+    assert(event_count == 0);
+
+    /* both start conditions are false, leaderboards will activate */
+    event_count = 0;
+    ram[1] = ram[2] = 9;
+    rc_runtime_do_frame(&runtime, event_handler, peek, &memory, NULL);
+    assert(runtime.lboards[0].lboard->state == RC_LBOARD_STATE_ACTIVE);
+    assert(runtime.lboards[1].lboard->state == RC_LBOARD_STATE_ACTIVE);
+    assert(event_count == 0);
+
+    /* both start conditions are true, leaderboards will start */
+    event_count = 0;
+    ram[1] = ram[2] = 10;
+    rc_runtime_do_frame(&runtime, event_handler, peek, &memory, NULL);
+    assert(runtime.lboards[0].lboard->state == RC_LBOARD_STATE_STARTED);
+    assert(runtime.lboards[1].lboard->state == RC_LBOARD_STATE_STARTED);
+    assert(event_count == 2);
+    assert_event(RC_RUNTIME_EVENT_LBOARD_STARTED, 1, 2);
+    assert_event(RC_RUNTIME_EVENT_LBOARD_STARTED, 2, 4);
+
+    /* start condition no longer true, leaderboard should continue processing */
+    event_count = 0;
+    ram[1] = ram[2] = 9;
+    rc_runtime_do_frame(&runtime, event_handler, peek, &memory, NULL);
+    assert(runtime.lboards[0].lboard->state == RC_LBOARD_STATE_STARTED);
+    assert(runtime.lboards[1].lboard->state == RC_LBOARD_STATE_STARTED);
+    assert(event_count == 0);
+
+    /* value changed */
+    event_count = 0;
+    ram[0] = 3;
+    rc_runtime_do_frame(&runtime, event_handler, peek, &memory, NULL);
+    assert(runtime.lboards[0].lboard->state == RC_LBOARD_STATE_STARTED);
+    assert(runtime.lboards[1].lboard->state == RC_LBOARD_STATE_STARTED);
+    assert(event_count == 2);
+    assert_event(RC_RUNTIME_EVENT_LBOARD_UPDATED, 1, 3);
+    assert_event(RC_RUNTIME_EVENT_LBOARD_UPDATED, 2, 6);
+
+    /* value changed; first leaderboard submit, second canceled - expect events for submit and cancel, none for update */
+    event_count = 0;
+    ram[0] = 4;
+    ram[1] = 11;
+    ram[2] = 12;
+    rc_runtime_do_frame(&runtime, event_handler, peek, &memory, NULL);
+    assert(runtime.lboards[0].lboard->state == RC_LBOARD_STATE_TRIGGERED);
+    assert(runtime.lboards[1].lboard->state == RC_LBOARD_STATE_CANCELED);
+    assert(event_count == 2);
+    assert_event(RC_RUNTIME_EVENT_LBOARD_TRIGGERED, 1, 4);
+    assert_event(RC_RUNTIME_EVENT_LBOARD_CANCELED, 2, 0);
+
+    /* both start conditions are true, leaderboards will not be active */
+    event_count = 0;
+    ram[1] = ram[2] = 10;
+    rc_runtime_do_frame(&runtime, event_handler, peek, &memory, NULL);
+    assert(runtime.lboards[0].lboard->state == RC_LBOARD_STATE_TRIGGERED);
+    assert(runtime.lboards[1].lboard->state == RC_LBOARD_STATE_CANCELED);
+    assert(event_count == 0);
+
+    /* both start conditions are false, leaderboards will re-activate */
+    event_count = 0;
+    ram[1] = ram[2] = 9;
+    rc_runtime_do_frame(&runtime, event_handler, peek, &memory, NULL);
+    assert(runtime.lboards[0].lboard->state == RC_LBOARD_STATE_ACTIVE);
+    assert(runtime.lboards[1].lboard->state == RC_LBOARD_STATE_ACTIVE);
+    assert(event_count == 0);
+
+    /* both start conditions are true, leaderboards will start */
+    event_count = 0;
+    ram[1] = ram[2] = 10;
+    rc_runtime_do_frame(&runtime, event_handler, peek, &memory, NULL);
+    assert(runtime.lboards[0].lboard->state == RC_LBOARD_STATE_STARTED);
+    assert(runtime.lboards[1].lboard->state == RC_LBOARD_STATE_STARTED);
+    assert(event_count == 2);
+    assert_event(RC_RUNTIME_EVENT_LBOARD_STARTED, 1, 4);
+    assert_event(RC_RUNTIME_EVENT_LBOARD_STARTED, 2, 8);
+
+    rc_runtime_destroy(&runtime);
+  }
+
+  {
+    /*------------------------------------------------------------------------
+    TestRuntimeRichPresence
+    ------------------------------------------------------------------------*/
+    unsigned char ram[] = { 2, 10, 10 };
+    memory_t memory;
+    rc_runtime_t runtime;
+    int frame_count = 0;
+
+    memory.ram = ram;
+    memory.size = sizeof(ram);
+
+    rc_runtime_init(&runtime);
+
+    /* initial value */
+    assert(strcmp(rc_runtime_get_richpresence(&runtime), "") == 0);
+
+    /* loading does not update display string */
+    assert(rc_runtime_activate_richpresence(&runtime, 
+        "Format:Points\nFormatType=VALUE\n\nDisplay:\n@Points(0x 0001) Points", NULL, 0) == RC_OK);
+    assert(strcmp(rc_runtime_get_richpresence(&runtime), "") == 0);
+
+    /* first frame should update display string */
+    rc_runtime_do_frame(&runtime, event_handler, peek, &memory, NULL);
+    assert(strcmp(rc_runtime_get_richpresence(&runtime), "2570 Points") == 0);
+
+    /* display string should not update for 60 frames */
+    ram[1] = 20;
+    for (frame_count = 0; frame_count < 59; ++frame_count) {
+      rc_runtime_do_frame(&runtime, event_handler, peek, &memory, NULL);
+      assert(strcmp(rc_runtime_get_richpresence(&runtime), "2570 Points") == 0);
+    }
+
+    /* string should update on 60th frame */
+    rc_runtime_do_frame(&runtime, event_handler, peek, &memory, NULL);
+    assert(strcmp(rc_runtime_get_richpresence(&runtime), "2580 Points") == 0);
+
+    rc_runtime_destroy(&runtime);
+  }
+
+  {
+    /*------------------------------------------------------------------------
+    TestRuntimeStaticRichPresence
+    ------------------------------------------------------------------------*/
+    unsigned char ram[] = { 2, 10, 10 };
+    memory_t memory;
+    rc_runtime_t runtime;
+    int frame_count = 0;
+
+    memory.ram = ram;
+    memory.size = sizeof(ram);
+
+    rc_runtime_init(&runtime);
+
+    /* initial value */
+    assert(strcmp(rc_runtime_get_richpresence(&runtime), "") == 0);
+
+    /* static string will be set on first frame */
+    assert(rc_runtime_activate_richpresence(&runtime, 
+        "Display:\nHello, world!", NULL, 0) == RC_OK);
+    assert(strcmp(rc_runtime_get_richpresence(&runtime), "Hello, world!") == 0);
+
+    /* first frame should not update display string */
+    rc_runtime_do_frame(&runtime, event_handler, peek, &memory, NULL);
+    assert(strcmp(rc_runtime_get_richpresence(&runtime), "Hello, world!") == 0);
+    assert(runtime.richpresence == NULL); /* this ensures the static string isn't evaluated */
+
+    rc_runtime_destroy(&runtime);
+  }
+}
+
 static void test_lua(void) {
   {
     /*------------------------------------------------------------------------
@@ -4816,6 +5408,7 @@ int main(void) {
   test_value();
   test_lboard();
   test_richpresence();
+  test_runtime();
   test_lua();
 
   return 0;


### PR DESCRIPTION
provides common event-driven runtime for use by dll and retroarch

allows sharing of memrefs across active triggers for improved performance (fewer lookups every frame)