### PR TITLE
make unit tests more verbose

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -15,6 +15,7 @@ OBJ=$(RC_SRC)/trigger.o $(RC_SRC)/condset.o $(RC_SRC)/condition.o $(RC_SRC)/oper
     $(LUA_SRC)/lbaselib.o $(LUA_SRC)/lbitlib.o $(LUA_SRC)/lcorolib.o $(LUA_SRC)/ldblib.o \
     $(LUA_SRC)/liolib.o $(LUA_SRC)/lmathlib.o $(LUA_SRC)/loslib.o $(LUA_SRC)/lstrlib.o \
     $(LUA_SRC)/ltablib.o $(LUA_SRC)/lutf8lib.o $(LUA_SRC)/loadlib.o $(LUA_SRC)/linit.o \
+    rcheevos/test_operand.o \
     test.o
 
 all: test

--- a/test/Makefile
+++ b/test/Makefile
@@ -15,6 +15,7 @@ OBJ=$(RC_SRC)/trigger.o $(RC_SRC)/condset.o $(RC_SRC)/condition.o $(RC_SRC)/oper
     $(LUA_SRC)/lbaselib.o $(LUA_SRC)/lbitlib.o $(LUA_SRC)/lcorolib.o $(LUA_SRC)/ldblib.o \
     $(LUA_SRC)/liolib.o $(LUA_SRC)/lmathlib.o $(LUA_SRC)/loslib.o $(LUA_SRC)/lstrlib.o \
     $(LUA_SRC)/ltablib.o $(LUA_SRC)/lutf8lib.o $(LUA_SRC)/loadlib.o $(LUA_SRC)/linit.o \
+    rcheevos/test_memref.o \
     rcheevos/test_operand.o \
     test.o
 

--- a/test/rcheevos-test.vcxproj
+++ b/test/rcheevos-test.vcxproj
@@ -168,6 +168,7 @@
     <ClCompile Include="lua\src\lutf8lib.c" />
     <ClCompile Include="lua\src\lvm.c" />
     <ClCompile Include="lua\src\lzio.c" />
+    <ClCompile Include="rcheevos\test_memref.c" />
     <ClCompile Include="rcheevos\test_operand.c" />
     <ClCompile Include="test.c" />
   </ItemGroup>

--- a/test/rcheevos-test.vcxproj
+++ b/test/rcheevos-test.vcxproj
@@ -168,11 +168,14 @@
     <ClCompile Include="lua\src\lutf8lib.c" />
     <ClCompile Include="lua\src\lvm.c" />
     <ClCompile Include="lua\src\lzio.c" />
+    <ClCompile Include="rcheevos\test_operand.c" />
     <ClCompile Include="test.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\include\rcheevos.h" />
     <ClInclude Include="..\src\rcheevos\internal.h" />
+    <ClInclude Include="rcheevos\mock_memory.h" />
+    <ClInclude Include="test_framework.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/test/rcheevos-test.vcxproj.filters
+++ b/test/rcheevos-test.vcxproj.filters
@@ -168,6 +168,9 @@
     <ClCompile Include="test.c">
       <Filter>tests</Filter>
     </ClCompile>
+    <ClCompile Include="rcheevos\test_memref.c">
+      <Filter>tests\rcheevos</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\src\rcheevos\internal.h">

--- a/test/rcheevos-test.vcxproj.filters
+++ b/test/rcheevos-test.vcxproj.filters
@@ -1,163 +1,186 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <Filter Include="rcheevos">
+    <Filter Include="src">
+      <UniqueIdentifier>{c1b8966b-c711-43ce-ac8a-1dcca6b41ff3}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="src\lua">
+      <UniqueIdentifier>{9d6d4e6d-a0b7-4181-b536-93e34de1e625}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="src\rcheevos">
       <UniqueIdentifier>{43b6b53b-c37e-453e-97bf-df56c515f1a7}</UniqueIdentifier>
     </Filter>
-    <Filter Include="lua">
-      <UniqueIdentifier>{9d6d4e6d-a0b7-4181-b536-93e34de1e625}</UniqueIdentifier>
+    <Filter Include="src\rhash">
+      <UniqueIdentifier>{9060be9f-a1f8-4940-a6e6-8ada5c89ae94}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="tests">
+      <UniqueIdentifier>{faf643ae-e095-4db5-a701-3ea9ed343cc0}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="tests\rcheevos">
+      <UniqueIdentifier>{f890b4f1-8de5-4730-b612-3a7dbf65ca74}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\src\rcheevos\format.c">
-      <Filter>rcheevos</Filter>
+      <Filter>src\rcheevos</Filter>
     </ClCompile>
     <ClCompile Include="..\src\rcheevos\lboard.c">
-      <Filter>rcheevos</Filter>
+      <Filter>src\rcheevos</Filter>
     </ClCompile>
     <ClCompile Include="..\src\rcheevos\operand.c">
-      <Filter>rcheevos</Filter>
+      <Filter>src\rcheevos</Filter>
     </ClCompile>
     <ClCompile Include="..\src\rcheevos\term.c">
-      <Filter>rcheevos</Filter>
+      <Filter>src\rcheevos</Filter>
     </ClCompile>
     <ClCompile Include="..\src\rcheevos\trigger.c">
-      <Filter>rcheevos</Filter>
+      <Filter>src\rcheevos</Filter>
     </ClCompile>
     <ClCompile Include="..\src\rcheevos\value.c">
-      <Filter>rcheevos</Filter>
+      <Filter>src\rcheevos</Filter>
     </ClCompile>
     <ClCompile Include="..\src\rcheevos\alloc.c">
-      <Filter>rcheevos</Filter>
+      <Filter>src\rcheevos</Filter>
     </ClCompile>
     <ClCompile Include="..\src\rcheevos\condition.c">
-      <Filter>rcheevos</Filter>
+      <Filter>src\rcheevos</Filter>
     </ClCompile>
     <ClCompile Include="..\src\rcheevos\condset.c">
-      <Filter>rcheevos</Filter>
+      <Filter>src\rcheevos</Filter>
     </ClCompile>
     <ClCompile Include="..\src\rcheevos\expression.c">
-      <Filter>rcheevos</Filter>
+      <Filter>src\rcheevos</Filter>
     </ClCompile>
     <ClCompile Include="lua\src\lapi.c">
-      <Filter>lua</Filter>
+      <Filter>src\lua</Filter>
     </ClCompile>
     <ClCompile Include="lua\src\lauxlib.c">
-      <Filter>lua</Filter>
+      <Filter>src\lua</Filter>
     </ClCompile>
     <ClCompile Include="lua\src\lbaselib.c">
-      <Filter>lua</Filter>
+      <Filter>src\lua</Filter>
     </ClCompile>
     <ClCompile Include="lua\src\lbitlib.c">
-      <Filter>lua</Filter>
+      <Filter>src\lua</Filter>
     </ClCompile>
     <ClCompile Include="lua\src\lcode.c">
-      <Filter>lua</Filter>
+      <Filter>src\lua</Filter>
     </ClCompile>
     <ClCompile Include="lua\src\lcorolib.c">
-      <Filter>lua</Filter>
+      <Filter>src\lua</Filter>
     </ClCompile>
     <ClCompile Include="lua\src\lctype.c">
-      <Filter>lua</Filter>
+      <Filter>src\lua</Filter>
     </ClCompile>
     <ClCompile Include="lua\src\ldblib.c">
-      <Filter>lua</Filter>
+      <Filter>src\lua</Filter>
     </ClCompile>
     <ClCompile Include="lua\src\ldebug.c">
-      <Filter>lua</Filter>
+      <Filter>src\lua</Filter>
     </ClCompile>
     <ClCompile Include="lua\src\ldo.c">
-      <Filter>lua</Filter>
+      <Filter>src\lua</Filter>
     </ClCompile>
     <ClCompile Include="lua\src\ldump.c">
-      <Filter>lua</Filter>
+      <Filter>src\lua</Filter>
     </ClCompile>
     <ClCompile Include="lua\src\lfunc.c">
-      <Filter>lua</Filter>
+      <Filter>src\lua</Filter>
     </ClCompile>
     <ClCompile Include="lua\src\lgc.c">
-      <Filter>lua</Filter>
+      <Filter>src\lua</Filter>
     </ClCompile>
     <ClCompile Include="lua\src\linit.c">
-      <Filter>lua</Filter>
+      <Filter>src\lua</Filter>
     </ClCompile>
     <ClCompile Include="lua\src\liolib.c">
-      <Filter>lua</Filter>
+      <Filter>src\lua</Filter>
     </ClCompile>
     <ClCompile Include="lua\src\llex.c">
-      <Filter>lua</Filter>
+      <Filter>src\lua</Filter>
     </ClCompile>
     <ClCompile Include="lua\src\lmathlib.c">
-      <Filter>lua</Filter>
+      <Filter>src\lua</Filter>
     </ClCompile>
     <ClCompile Include="lua\src\lmem.c">
-      <Filter>lua</Filter>
+      <Filter>src\lua</Filter>
     </ClCompile>
     <ClCompile Include="lua\src\loadlib.c">
-      <Filter>lua</Filter>
+      <Filter>src\lua</Filter>
     </ClCompile>
     <ClCompile Include="lua\src\lobject.c">
-      <Filter>lua</Filter>
+      <Filter>src\lua</Filter>
     </ClCompile>
     <ClCompile Include="lua\src\lopcodes.c">
-      <Filter>lua</Filter>
+      <Filter>src\lua</Filter>
     </ClCompile>
     <ClCompile Include="lua\src\loslib.c">
-      <Filter>lua</Filter>
+      <Filter>src\lua</Filter>
     </ClCompile>
     <ClCompile Include="lua\src\lparser.c">
-      <Filter>lua</Filter>
+      <Filter>src\lua</Filter>
     </ClCompile>
     <ClCompile Include="lua\src\lstate.c">
-      <Filter>lua</Filter>
+      <Filter>src\lua</Filter>
     </ClCompile>
     <ClCompile Include="lua\src\lstring.c">
-      <Filter>lua</Filter>
+      <Filter>src\lua</Filter>
     </ClCompile>
     <ClCompile Include="lua\src\lstrlib.c">
-      <Filter>lua</Filter>
+      <Filter>src\lua</Filter>
     </ClCompile>
     <ClCompile Include="lua\src\ltable.c">
-      <Filter>lua</Filter>
+      <Filter>src\lua</Filter>
     </ClCompile>
     <ClCompile Include="lua\src\ltablib.c">
-      <Filter>lua</Filter>
+      <Filter>src\lua</Filter>
     </ClCompile>
     <ClCompile Include="lua\src\ltm.c">
-      <Filter>lua</Filter>
+      <Filter>src\lua</Filter>
     </ClCompile>
     <ClCompile Include="lua\src\lundump.c">
-      <Filter>lua</Filter>
+      <Filter>src\lua</Filter>
     </ClCompile>
     <ClCompile Include="lua\src\lutf8lib.c">
-      <Filter>lua</Filter>
+      <Filter>src\lua</Filter>
     </ClCompile>
     <ClCompile Include="lua\src\lvm.c">
-      <Filter>lua</Filter>
+      <Filter>src\lua</Filter>
     </ClCompile>
     <ClCompile Include="lua\src\lzio.c">
-      <Filter>lua</Filter>
+      <Filter>src\lua</Filter>
     </ClCompile>
-    <ClCompile Include="test.c" />
     <ClCompile Include="..\src\rcheevos\richpresence.c">
-      <Filter>rcheevos</Filter>
+      <Filter>src\rcheevos</Filter>
     </ClCompile>
     <ClCompile Include="..\src\rcheevos\memref.c">
-      <Filter>rcheevos</Filter>
+      <Filter>src\rcheevos</Filter>
     </ClCompile>
     <ClCompile Include="..\src\rcheevos\runtime.c">
-      <Filter>rcheevos</Filter>
+      <Filter>src\rcheevos</Filter>
     </ClCompile>
     <ClCompile Include="..\src\rhash\md5.c">
-      <Filter>rcheevos</Filter>
+      <Filter>src\rhash</Filter>
+    </ClCompile>
+    <ClCompile Include="rcheevos\test_operand.c">
+      <Filter>tests\rcheevos</Filter>
+    </ClCompile>
+    <ClCompile Include="test.c">
+      <Filter>tests</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\src\rcheevos\internal.h">
-      <Filter>rcheevos</Filter>
+      <Filter>src\rcheevos</Filter>
     </ClInclude>
     <ClInclude Include="..\include\rcheevos.h">
-      <Filter>rcheevos</Filter>
+      <Filter>src\rcheevos</Filter>
+    </ClInclude>
+    <ClInclude Include="rcheevos\mock_memory.h">
+      <Filter>tests\rcheevos</Filter>
+    </ClInclude>
+    <ClInclude Include="test_framework.h">
+      <Filter>tests</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/test/rcheevos/mock_memory.h
+++ b/test/rcheevos/mock_memory.h
@@ -1,0 +1,32 @@
+#ifndef MOCK_MEMORY_H
+#define MOCK_MEMORY_H
+
+typedef struct {
+  unsigned char* ram;
+  unsigned size;
+}
+memory_t;
+
+static unsigned peekb(unsigned address, memory_t* memory) {
+  return address < memory->size ? memory->ram[address] : 0;
+}
+
+static unsigned peek(unsigned address, unsigned num_bytes, void* ud) {
+  memory_t* memory = (memory_t*)ud;
+
+  switch (num_bytes) {
+    case 1: return peekb(address, memory);
+
+    case 2: return peekb(address, memory) |
+      peekb(address + 1, memory) << 8;
+
+    case 4: return peekb(address, memory) |
+      peekb(address + 1, memory) << 8 |
+      peekb(address + 2, memory) << 16 |
+      peekb(address + 3, memory) << 24;
+  }
+
+  return 0;
+}
+
+#endif /* MOCK_MEMORY_H */

--- a/test/rcheevos/test_memref.c
+++ b/test/rcheevos/test_memref.c
@@ -1,0 +1,186 @@
+#include "internal.h"
+
+#include "..\test_framework.h"
+#include "mock_memory.h"
+
+static void test_allocate_shared_address() {
+  char buffer[512];
+  rc_parse_state_t parse;
+  rc_init_parse_state(&parse, buffer, 0, 0);
+
+  rc_alloc_memref_value(&parse, 1, RC_MEMSIZE_8_BITS, 0);
+  ASSERT_NUM_EQUALS(parse.scratch.memref_count, 1);
+
+  rc_alloc_memref_value(&parse, 1, RC_MEMSIZE_16_BITS, 0); /* differing size will not match */
+  ASSERT_NUM_EQUALS(parse.scratch.memref_count, 2);
+
+  rc_alloc_memref_value(&parse, 1, RC_MEMSIZE_LOW, 0); /* differing size will not match */
+  ASSERT_NUM_EQUALS(parse.scratch.memref_count, 3);
+
+  rc_alloc_memref_value(&parse, 1, RC_MEMSIZE_BIT_2, 0); /* differing size will not match */
+  ASSERT_NUM_EQUALS(parse.scratch.memref_count, 4);
+
+  rc_alloc_memref_value(&parse, 2, RC_MEMSIZE_8_BITS, 0); /* differing address will not match */
+  ASSERT_NUM_EQUALS(parse.scratch.memref_count, 5);
+
+  rc_alloc_memref_value(&parse, 1, RC_MEMSIZE_8_BITS, 0); /* match */
+  ASSERT_NUM_EQUALS(parse.scratch.memref_count, 5);
+
+  rc_alloc_memref_value(&parse, 1, RC_MEMSIZE_16_BITS, 0); /* match */
+  ASSERT_NUM_EQUALS(parse.scratch.memref_count, 5);
+
+  rc_alloc_memref_value(&parse, 1, RC_MEMSIZE_BIT_2, 0); /* match */
+  ASSERT_NUM_EQUALS(parse.scratch.memref_count, 5);
+
+  rc_alloc_memref_value(&parse, 2, RC_MEMSIZE_8_BITS, 0); /* match */
+  ASSERT_NUM_EQUALS(parse.scratch.memref_count, 5);
+
+  rc_destroy_parse_state(&parse);
+}
+
+static void test_allocate_shared_address2() {
+  char buffer[512];
+  rc_parse_state_t parse;
+  rc_memref_value_t* memrefs;
+  rc_memref_value_t* memref1;
+  rc_memref_value_t* memref2;
+  rc_memref_value_t* memref3;
+  rc_memref_value_t* memref4;
+  rc_memref_value_t* memref5;
+  rc_memref_value_t* memrefX;
+  rc_init_parse_state(&parse, buffer, 0, 0);
+  rc_init_parse_state_memrefs(&parse, &memrefs);
+
+  memref1 = rc_alloc_memref_value(&parse, 1, RC_MEMSIZE_8_BITS, 0);
+  ASSERT_NUM_EQUALS(memref1->memref.address, 1);
+  ASSERT_NUM_EQUALS(memref1->memref.size, RC_MEMSIZE_8_BITS);
+  ASSERT_NUM_EQUALS(memref1->memref.is_indirect, 0);
+  ASSERT_NUM_EQUALS(memref1->value, 0);
+  ASSERT_NUM_EQUALS(memref1->previous, 0);
+  ASSERT_NUM_EQUALS(memref1->prior, 0);
+  ASSERT_PTR_EQUALS(memref1->next, 0);
+
+  memref2 = rc_alloc_memref_value(&parse, 1, RC_MEMSIZE_16_BITS, 0); /* differing size will not match */
+  memref3 = rc_alloc_memref_value(&parse, 1, RC_MEMSIZE_LOW, 0); /* differing size will not match */
+  memref4 = rc_alloc_memref_value(&parse, 1, RC_MEMSIZE_BIT_2, 0); /* differing size will not match */
+  memref5 = rc_alloc_memref_value(&parse, 2, RC_MEMSIZE_8_BITS, 0); /* differing address will not match */
+
+  memrefX = rc_alloc_memref_value(&parse, 1, RC_MEMSIZE_8_BITS, 0); /* match */
+  ASSERT_PTR_EQUALS(memrefX, memref1);
+
+  memrefX = rc_alloc_memref_value(&parse, 1, RC_MEMSIZE_16_BITS, 0); /* match */
+  ASSERT_PTR_EQUALS(memrefX, memref2);
+
+  memrefX = rc_alloc_memref_value(&parse, 1, RC_MEMSIZE_LOW, 0); /* match */
+  ASSERT_PTR_EQUALS(memrefX, memref3);
+
+  memrefX = rc_alloc_memref_value(&parse, 1, RC_MEMSIZE_BIT_2, 0); /* match */
+  ASSERT_PTR_EQUALS(memrefX, memref4);
+
+  memrefX = rc_alloc_memref_value(&parse, 2, RC_MEMSIZE_8_BITS, 0); /* match */
+  ASSERT_PTR_EQUALS(memrefX, memref5);
+
+  rc_destroy_parse_state(&parse);
+}
+
+static void test_sizing_mode_grow_buffer() {
+  char buffer[512];
+  int i;
+  rc_parse_state_t parse;
+  rc_init_parse_state(&parse, buffer, 0, 0);
+
+  /* memrefs are allocated 16 at a time */
+  for (i = 0; i < 100; i++) {
+      rc_alloc_memref_value(&parse, i, RC_MEMSIZE_8_BITS, 0);
+  }
+  ASSERT_NUM_EQUALS(parse.scratch.memref_count, 100);
+
+  /* 100 have been allocated, make sure we can still access items at various addresses without allocating more */
+  rc_alloc_memref_value(&parse, 1, RC_MEMSIZE_8_BITS, 0);
+  ASSERT_NUM_EQUALS(parse.scratch.memref_count, 100);
+
+  rc_alloc_memref_value(&parse, 25, RC_MEMSIZE_8_BITS, 0);
+  ASSERT_NUM_EQUALS(parse.scratch.memref_count, 100);
+
+  rc_alloc_memref_value(&parse, 50, RC_MEMSIZE_8_BITS, 0);
+  ASSERT_NUM_EQUALS(parse.scratch.memref_count, 100);
+
+  rc_alloc_memref_value(&parse, 75, RC_MEMSIZE_8_BITS, 0);
+  ASSERT_NUM_EQUALS(parse.scratch.memref_count, 100);
+
+  rc_alloc_memref_value(&parse, 99, RC_MEMSIZE_8_BITS, 0);
+  ASSERT_NUM_EQUALS(parse.scratch.memref_count, 100);
+
+  rc_destroy_parse_state(&parse);
+}
+
+static void test_update_memref_values() {
+  char buffer[512];
+  rc_parse_state_t parse;
+  rc_memref_value_t* memrefs;
+  rc_memref_value_t* memref1;
+  rc_memref_value_t* memref2;
+
+  unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  memory_t memory;
+  memory.ram = ram;
+  memory.size = sizeof(ram);
+
+  rc_init_parse_state(&parse, buffer, 0, 0);
+  rc_init_parse_state_memrefs(&parse, &memrefs);
+
+  memref1 = rc_alloc_memref_value(&parse, 1, RC_MEMSIZE_8_BITS, 0);
+  memref2 = rc_alloc_memref_value(&parse, 2, RC_MEMSIZE_8_BITS, 0);
+
+  rc_update_memref_values(memrefs, peek, &memory);
+
+  ASSERT_NUM_EQUALS(memref1->value, 0x12);
+  ASSERT_NUM_EQUALS(memref1->previous, 0);
+  ASSERT_NUM_EQUALS(memref1->prior, 0);
+  ASSERT_NUM_EQUALS(memref2->value, 0x34);
+  ASSERT_NUM_EQUALS(memref2->previous, 0);
+  ASSERT_NUM_EQUALS(memref2->prior, 0);
+
+  ram[1] = 3;
+  rc_update_memref_values(memrefs, peek, &memory);
+
+  ASSERT_NUM_EQUALS(memref1->value, 3);
+  ASSERT_NUM_EQUALS(memref1->previous, 0x12);
+  ASSERT_NUM_EQUALS(memref1->prior, 0x12);
+  ASSERT_NUM_EQUALS(memref2->value, 0x34);
+  ASSERT_NUM_EQUALS(memref2->previous, 0x34);
+  ASSERT_NUM_EQUALS(memref2->prior, 0);
+
+  ram[1] = 5;
+  rc_update_memref_values(memrefs, peek, &memory);
+
+  ASSERT_NUM_EQUALS(memref1->value, 5);
+  ASSERT_NUM_EQUALS(memref1->previous, 3);
+  ASSERT_NUM_EQUALS(memref1->prior, 3);
+  ASSERT_NUM_EQUALS(memref2->value, 0x34);
+  ASSERT_NUM_EQUALS(memref2->previous, 0x34);
+  ASSERT_NUM_EQUALS(memref2->prior, 0);
+
+  ram[2] = 7;
+  rc_update_memref_values(memrefs, peek, &memory);
+
+  ASSERT_NUM_EQUALS(memref1->value, 5);
+  ASSERT_NUM_EQUALS(memref1->previous, 5);
+  ASSERT_NUM_EQUALS(memref1->prior, 3);
+  ASSERT_NUM_EQUALS(memref2->value, 7);
+  ASSERT_NUM_EQUALS(memref2->previous, 0x34);
+  ASSERT_NUM_EQUALS(memref2->prior, 0x34);
+
+  rc_destroy_parse_state(&parse);
+}
+
+void test_memref(void) {
+  TEST_SUITE_BEGIN();
+
+  TEST(test_allocate_shared_address);
+  TEST(test_allocate_shared_address2);
+  TEST(test_sizing_mode_grow_buffer);
+  TEST(test_update_memref_values);
+
+  TEST_SUITE_END();
+}

--- a/test/rcheevos/test_operand.c
+++ b/test/rcheevos/test_operand.c
@@ -1,0 +1,422 @@
+#include "internal.h"
+
+#include "..\test_framework.h"
+#include "mock_memory.h"
+
+static void parse_operand(rc_operand_t* self, const char** memaddr) {
+  rc_parse_state_t parse;
+  char buffer[256];
+  rc_memref_value_t* memrefs;
+  int ret;
+
+  rc_init_parse_state(&parse, buffer, 0, 0);   
+  rc_init_parse_state_memrefs(&parse, &memrefs);
+  ret = rc_parse_operand(self, memaddr, 1, 0, &parse);
+  rc_destroy_parse_state(&parse);
+
+  ASSERT_NUM_GREATER_EQUALS(ret, 0);
+  ASSERT_NUM_EQUALS(**memaddr, 0);
+}
+
+static void assert_operand(rc_operand_t* self, char expected_type, char expected_size, unsigned expected_address) {
+  ASSERT_NUM_EQUALS(expected_type, self->type);
+  switch (expected_type) {
+    case RC_OPERAND_ADDRESS:
+    case RC_OPERAND_DELTA:
+    case RC_OPERAND_PRIOR:
+      ASSERT_NUM_EQUALS(expected_size, self->size);
+      ASSERT_UNUM_EQUALS(expected_address, self->value.memref->memref.address);
+      break;
+
+    case RC_OPERAND_CONST:
+      ASSERT_UNUM_EQUALS(expected_address, self->value.num);
+      break;
+  }
+}
+
+static void test_parse_operand(const char* memaddr, char expected_type, char expected_size, unsigned expected_value) {
+  rc_operand_t self;
+  parse_operand(&self, &memaddr);
+  assert_operand(&self, expected_type, expected_size, expected_value);
+}
+
+static void test_parse_operand_fp(const char* memaddr, char expected_type, double expected_value) {
+  rc_operand_t self;
+  parse_operand(&self, &memaddr);
+
+  ASSERT_NUM_EQUALS(expected_type, self.type);
+  switch (expected_type) {
+    case RC_OPERAND_CONST:
+      ASSERT_DBL_EQUALS(expected_value, self.value.num);
+      break;
+    case RC_OPERAND_FP:
+      ASSERT_DBL_EQUALS(expected_value, self.value.dbl);
+      break;
+  }
+}
+
+static void test_parse_error_operand(const char* memaddr, int valid_chars, int expected_error) {
+  rc_operand_t self;
+  rc_parse_state_t parse;
+  int ret;
+  const char* begin = memaddr;
+  rc_memref_value_t* memrefs;
+
+  rc_init_parse_state(&parse, 0, 0, 0);
+  rc_init_parse_state_memrefs(&parse, &memrefs);
+  ret = rc_parse_operand(&self, &memaddr, 1, 0, &parse);
+  rc_destroy_parse_state(&parse);
+
+  ASSERT_NUM_EQUALS(expected_error, ret);
+  ASSERT_NUM_EQUALS(memaddr - begin, valid_chars);
+}
+
+static unsigned evaluate_operand(rc_operand_t* op, memory_t* memory, rc_memref_value_t* memrefs)
+{
+  rc_eval_state_t eval_state;
+
+  memset(&eval_state, 0, sizeof(eval_state));
+  eval_state.peek = peek;
+  eval_state.peek_userdata = memory;
+
+  rc_update_memref_values(memrefs, peek, memory);
+  return rc_evaluate_operand(op, &eval_state);
+}
+
+static void test_evaluate_operand(const char* memaddr, memory_t* memory, unsigned expected_value) {
+  rc_operand_t self;
+  rc_parse_state_t parse;
+  rc_memref_value_t* memrefs;
+  char buffer[512];
+  unsigned value;
+
+  rc_init_parse_state(&parse, buffer, 0, 0);
+  rc_init_parse_state_memrefs(&parse, &memrefs);
+  rc_parse_operand(&self, &memaddr, 1, 0, &parse);
+  rc_destroy_parse_state(&parse);
+
+  value = evaluate_operand(&self, memory, memrefs);
+  ASSERT_NUM_EQUALS(value, expected_value);
+}
+
+static void test_parse_memory_references() {
+  /* sizes */
+  TEST_PARAMS4(test_parse_operand, "0xH1234", RC_OPERAND_ADDRESS, RC_MEMSIZE_8_BITS, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "0xH1234", RC_OPERAND_ADDRESS, RC_MEMSIZE_8_BITS, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "0x 1234", RC_OPERAND_ADDRESS, RC_MEMSIZE_16_BITS, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "0x1234", RC_OPERAND_ADDRESS, RC_MEMSIZE_16_BITS, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "0xW1234", RC_OPERAND_ADDRESS, RC_MEMSIZE_24_BITS, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "0xX1234", RC_OPERAND_ADDRESS, RC_MEMSIZE_32_BITS, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "0xL1234", RC_OPERAND_ADDRESS, RC_MEMSIZE_LOW, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "0xU1234", RC_OPERAND_ADDRESS, RC_MEMSIZE_HIGH, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "0xM1234", RC_OPERAND_ADDRESS, RC_MEMSIZE_BIT_0, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "0xN1234", RC_OPERAND_ADDRESS, RC_MEMSIZE_BIT_1, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "0xO1234", RC_OPERAND_ADDRESS, RC_MEMSIZE_BIT_2, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "0xP1234", RC_OPERAND_ADDRESS, RC_MEMSIZE_BIT_3, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "0xQ1234", RC_OPERAND_ADDRESS, RC_MEMSIZE_BIT_4, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "0xR1234", RC_OPERAND_ADDRESS, RC_MEMSIZE_BIT_5, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "0xS1234", RC_OPERAND_ADDRESS, RC_MEMSIZE_BIT_6, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "0xT1234", RC_OPERAND_ADDRESS, RC_MEMSIZE_BIT_7, 0x1234U);
+
+  /* sizes (ignore case) */
+  TEST_PARAMS4(test_parse_operand, "0Xh1234", RC_OPERAND_ADDRESS, RC_MEMSIZE_8_BITS, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "0xx1234", RC_OPERAND_ADDRESS, RC_MEMSIZE_32_BITS, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "0xl1234", RC_OPERAND_ADDRESS, RC_MEMSIZE_LOW, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "0xu1234", RC_OPERAND_ADDRESS, RC_MEMSIZE_HIGH, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "0xm1234", RC_OPERAND_ADDRESS, RC_MEMSIZE_BIT_0, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "0xn1234", RC_OPERAND_ADDRESS, RC_MEMSIZE_BIT_1, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "0xo1234", RC_OPERAND_ADDRESS, RC_MEMSIZE_BIT_2, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "0xp1234", RC_OPERAND_ADDRESS, RC_MEMSIZE_BIT_3, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "0xq1234", RC_OPERAND_ADDRESS, RC_MEMSIZE_BIT_4, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "0xr1234", RC_OPERAND_ADDRESS, RC_MEMSIZE_BIT_5, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "0xs1234", RC_OPERAND_ADDRESS, RC_MEMSIZE_BIT_6, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "0xt1234", RC_OPERAND_ADDRESS, RC_MEMSIZE_BIT_7, 0x1234U);
+
+  /* addresses */
+  TEST_PARAMS4(test_parse_operand, "0xH0000", RC_OPERAND_ADDRESS, RC_MEMSIZE_8_BITS, 0x0000U);
+  TEST_PARAMS4(test_parse_operand, "0xH12345678", RC_OPERAND_ADDRESS, RC_MEMSIZE_8_BITS, 0x12345678U);
+  TEST_PARAMS4(test_parse_operand, "0xHABCD", RC_OPERAND_ADDRESS, RC_MEMSIZE_8_BITS, 0xABCDU);
+  TEST_PARAMS4(test_parse_operand, "0xhabcd", RC_OPERAND_ADDRESS, RC_MEMSIZE_8_BITS, 0xABCDU);
+}
+
+static void test_parse_delta_memory_references() {
+  /* sizes */
+  TEST_PARAMS4(test_parse_operand, "d0xH1234", RC_OPERAND_DELTA, RC_MEMSIZE_8_BITS, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "d0x 1234", RC_OPERAND_DELTA, RC_MEMSIZE_16_BITS, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "d0x1234", RC_OPERAND_DELTA, RC_MEMSIZE_16_BITS, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "d0xW1234", RC_OPERAND_DELTA, RC_MEMSIZE_24_BITS, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "d0xX1234", RC_OPERAND_DELTA, RC_MEMSIZE_32_BITS, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "d0xL1234", RC_OPERAND_DELTA, RC_MEMSIZE_LOW, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "d0xU1234", RC_OPERAND_DELTA, RC_MEMSIZE_HIGH, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "d0xM1234", RC_OPERAND_DELTA, RC_MEMSIZE_BIT_0, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "d0xN1234", RC_OPERAND_DELTA, RC_MEMSIZE_BIT_1, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "d0xO1234", RC_OPERAND_DELTA, RC_MEMSIZE_BIT_2, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "d0xP1234", RC_OPERAND_DELTA, RC_MEMSIZE_BIT_3, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "d0xQ1234", RC_OPERAND_DELTA, RC_MEMSIZE_BIT_4, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "d0xR1234", RC_OPERAND_DELTA, RC_MEMSIZE_BIT_5, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "d0xS1234", RC_OPERAND_DELTA, RC_MEMSIZE_BIT_6, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "d0xT1234", RC_OPERAND_DELTA, RC_MEMSIZE_BIT_7, 0x1234U);
+
+  /* ignores case */
+  TEST_PARAMS4(test_parse_operand, "D0Xh1234", RC_OPERAND_DELTA, RC_MEMSIZE_8_BITS, 0x1234U);
+
+  /* addresses */
+  TEST_PARAMS4(test_parse_operand, "d0xH0000", RC_OPERAND_DELTA, RC_MEMSIZE_8_BITS, 0x0000U);
+  TEST_PARAMS4(test_parse_operand, "d0xH12345678", RC_OPERAND_DELTA, RC_MEMSIZE_8_BITS, 0x12345678U);
+  TEST_PARAMS4(test_parse_operand, "d0xHABCD", RC_OPERAND_DELTA, RC_MEMSIZE_8_BITS, 0xABCDU);
+  TEST_PARAMS4(test_parse_operand, "d0xhabcd", RC_OPERAND_DELTA, RC_MEMSIZE_8_BITS, 0xABCDU);
+}
+
+static void test_parse_prior_memory_references() {
+  /* sizes */
+  TEST_PARAMS4(test_parse_operand, "p0xH1234", RC_OPERAND_PRIOR, RC_MEMSIZE_8_BITS, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "p0x 1234", RC_OPERAND_PRIOR, RC_MEMSIZE_16_BITS, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "p0x1234", RC_OPERAND_PRIOR, RC_MEMSIZE_16_BITS, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "p0xW1234", RC_OPERAND_PRIOR, RC_MEMSIZE_24_BITS, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "p0xX1234", RC_OPERAND_PRIOR, RC_MEMSIZE_32_BITS, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "p0xL1234", RC_OPERAND_PRIOR, RC_MEMSIZE_LOW, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "p0xU1234", RC_OPERAND_PRIOR, RC_MEMSIZE_HIGH, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "p0xM1234", RC_OPERAND_PRIOR, RC_MEMSIZE_BIT_0, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "p0xN1234", RC_OPERAND_PRIOR, RC_MEMSIZE_BIT_1, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "p0xO1234", RC_OPERAND_PRIOR, RC_MEMSIZE_BIT_2, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "p0xP1234", RC_OPERAND_PRIOR, RC_MEMSIZE_BIT_3, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "p0xQ1234", RC_OPERAND_PRIOR, RC_MEMSIZE_BIT_4, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "p0xR1234", RC_OPERAND_PRIOR, RC_MEMSIZE_BIT_5, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "p0xS1234", RC_OPERAND_PRIOR, RC_MEMSIZE_BIT_6, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "p0xT1234", RC_OPERAND_PRIOR, RC_MEMSIZE_BIT_7, 0x1234U);
+
+  /* ignores case */
+  TEST_PARAMS4(test_parse_operand, "P0Xh1234", RC_OPERAND_PRIOR, RC_MEMSIZE_8_BITS, 0x1234U);
+
+  /* addresses */
+  TEST_PARAMS4(test_parse_operand, "p0xH0000", RC_OPERAND_PRIOR, RC_MEMSIZE_8_BITS, 0x0000U);
+  TEST_PARAMS4(test_parse_operand, "p0xH12345678", RC_OPERAND_PRIOR, RC_MEMSIZE_8_BITS, 0x12345678U);
+  TEST_PARAMS4(test_parse_operand, "p0xHABCD", RC_OPERAND_PRIOR, RC_MEMSIZE_8_BITS, 0xABCDU);
+  TEST_PARAMS4(test_parse_operand, "p0xhabcd", RC_OPERAND_PRIOR, RC_MEMSIZE_8_BITS, 0xABCDU);
+}
+
+static void test_parse_bcd_memory_references() {
+  /* sizes */
+  TEST_PARAMS4(test_parse_operand, "b0xH1234", RC_OPERAND_ADDRESS, RC_MEMSIZE_8_BITS_BCD, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "b0x 1234", RC_OPERAND_ADDRESS, RC_MEMSIZE_16_BITS_BCD, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "b0x1234", RC_OPERAND_ADDRESS, RC_MEMSIZE_16_BITS_BCD, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "b0xW1234", RC_OPERAND_ADDRESS, RC_MEMSIZE_24_BITS_BCD, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "b0xX1234", RC_OPERAND_ADDRESS, RC_MEMSIZE_32_BITS_BCD, 0x1234U);
+
+  /* sizes less than 8-bit don't need a BCD conversion */
+  TEST_PARAMS4(test_parse_operand, "b0xL1234", RC_OPERAND_ADDRESS, RC_MEMSIZE_LOW, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "b0xU1234", RC_OPERAND_ADDRESS, RC_MEMSIZE_HIGH, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "b0xM1234", RC_OPERAND_ADDRESS, RC_MEMSIZE_BIT_0, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "b0xN1234", RC_OPERAND_ADDRESS, RC_MEMSIZE_BIT_1, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "b0xO1234", RC_OPERAND_ADDRESS, RC_MEMSIZE_BIT_2, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "b0xP1234", RC_OPERAND_ADDRESS, RC_MEMSIZE_BIT_3, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "b0xQ1234", RC_OPERAND_ADDRESS, RC_MEMSIZE_BIT_4, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "b0xR1234", RC_OPERAND_ADDRESS, RC_MEMSIZE_BIT_5, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "b0xS1234", RC_OPERAND_ADDRESS, RC_MEMSIZE_BIT_6, 0x1234U);
+  TEST_PARAMS4(test_parse_operand, "b0xT1234", RC_OPERAND_ADDRESS, RC_MEMSIZE_BIT_7, 0x1234U);
+}
+
+static void test_parse_values() {
+  /* decimal - values don't actually have size, default is RC_MEMSIZE_8_BITS */
+  TEST_PARAMS4(test_parse_operand, "123", RC_OPERAND_CONST, RC_MEMSIZE_8_BITS, 123U);
+  TEST_PARAMS4(test_parse_operand, "123456", RC_OPERAND_CONST, RC_MEMSIZE_8_BITS, 123456U);
+  TEST_PARAMS4(test_parse_operand, "0", RC_OPERAND_CONST, RC_MEMSIZE_8_BITS, 0U);
+  TEST_PARAMS4(test_parse_operand, "0000000000", RC_OPERAND_CONST, RC_MEMSIZE_8_BITS, 0U);
+  TEST_PARAMS4(test_parse_operand, "4294967295", RC_OPERAND_CONST, RC_MEMSIZE_8_BITS, 4294967295U);
+
+  /* hex - 'H' prefix, not '0x'! */
+  TEST_PARAMS4(test_parse_operand, "H123", RC_OPERAND_CONST, RC_MEMSIZE_8_BITS, 0x123U);
+  TEST_PARAMS4(test_parse_operand, "HABCD", RC_OPERAND_CONST, RC_MEMSIZE_8_BITS, 0xABCDU);
+  TEST_PARAMS4(test_parse_operand, "h123", RC_OPERAND_CONST, RC_MEMSIZE_8_BITS, 0x123U);
+  TEST_PARAMS4(test_parse_operand, "habcd", RC_OPERAND_CONST, RC_MEMSIZE_8_BITS, 0xABCDU);
+  TEST_PARAMS4(test_parse_operand, "HFFFFFFFF", RC_OPERAND_CONST, RC_MEMSIZE_8_BITS, 4294967295U);
+
+  /* floating point - 'F' prefix */
+  TEST_PARAMS3(test_parse_operand_fp, "f0.5", RC_OPERAND_FP, 0.5);
+  TEST_PARAMS3(test_parse_operand_fp, "F0.5", RC_OPERAND_FP, 0.5);
+  TEST_PARAMS3(test_parse_operand_fp, "f+0.5", RC_OPERAND_FP, 0.5);
+  TEST_PARAMS3(test_parse_operand_fp, "f-0.5", RC_OPERAND_FP, -0.5);
+  TEST_PARAMS3(test_parse_operand_fp, "f1.0", RC_OPERAND_CONST, 1.0);
+  TEST_PARAMS3(test_parse_operand_fp, "f1", RC_OPERAND_CONST, 1.0);
+  TEST_PARAMS3(test_parse_operand_fp, "f0.666666", RC_OPERAND_FP, 0.666666);
+
+  /* NOTE: cannot test floating point without a prefix ("0.5") as the "0" will be parsed successfuly 
+   * and the ".5" ignored - this case is handled in the TestParseCondition test */
+
+  /* '0x' is an address */
+  TEST_PARAMS4(test_parse_operand, "0x123", RC_OPERAND_ADDRESS, RC_MEMSIZE_16_BITS, 0x123U);
+
+  /* hex without prefix */
+  TEST_PARAMS3(test_parse_error_operand, "ABCD", 0, RC_INVALID_MEMORY_OPERAND);
+
+  /* more than 32-bits (error), will be constrained to 32-bits */
+  TEST_PARAMS4(test_parse_operand, "4294967296", RC_OPERAND_CONST, RC_MEMSIZE_8_BITS, 4294967295U);
+
+  /* negative value (error), will be "wrapped around": -1 = 0x100000000 - 1 = 0xFFFFFFFF = 4294967295 */
+  TEST_PARAMS4(test_parse_operand, "-1", RC_OPERAND_CONST, RC_MEMSIZE_8_BITS, 4294967295U);
+}
+
+static void test_evaluate_memory_references() {
+  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  memory_t memory;
+  memory.ram = ram;
+  memory.size = sizeof(ram);
+
+  /* value */
+  TEST_PARAMS3(test_evaluate_operand, "0", &memory, 0x00U);
+
+  /* eight-bit */
+  TEST_PARAMS3(test_evaluate_operand, "0xh0", &memory, 0x00U);
+  TEST_PARAMS3(test_evaluate_operand, "0xh1", &memory, 0x12U);
+  TEST_PARAMS3(test_evaluate_operand, "0xh4", &memory, 0x56U);
+  TEST_PARAMS3(test_evaluate_operand, "0xh5", &memory, 0x00U); /* out of range */
+
+  /* sixteen-bit */
+  TEST_PARAMS3(test_evaluate_operand, "0x 0", &memory, 0x1200U);
+  TEST_PARAMS3(test_evaluate_operand, "0x 3", &memory, 0x56ABU);
+  TEST_PARAMS3(test_evaluate_operand, "0x 4", &memory, 0x0056U); /* out of range */
+
+  /* twenty-four-bit */
+  TEST_PARAMS3(test_evaluate_operand, "0xw0", &memory, 0x341200U);
+  TEST_PARAMS3(test_evaluate_operand, "0xw2", &memory, 0x56AB34U);
+  TEST_PARAMS3(test_evaluate_operand, "0xw3", &memory, 0x0056ABU); /* out of range */
+
+  /* thirty-two-bit */
+  TEST_PARAMS3(test_evaluate_operand, "0xx0", &memory, 0xAB341200U);
+  TEST_PARAMS3(test_evaluate_operand, "0xx1", &memory, 0x56AB3412U);
+  TEST_PARAMS3(test_evaluate_operand, "0xx3", &memory, 0x000056ABU); /* out of range */
+
+  /* nibbles */
+  TEST_PARAMS3(test_evaluate_operand, "0xu0", &memory, 0x0U);
+  TEST_PARAMS3(test_evaluate_operand, "0xu1", &memory, 0x1U);
+  TEST_PARAMS3(test_evaluate_operand, "0xu4", &memory, 0x5U);
+  TEST_PARAMS3(test_evaluate_operand, "0xu5", &memory, 0x0U); /* out of range */
+
+  TEST_PARAMS3(test_evaluate_operand, "0xl0", &memory, 0x0U);
+  TEST_PARAMS3(test_evaluate_operand, "0xl1", &memory, 0x2U);
+  TEST_PARAMS3(test_evaluate_operand, "0xl4", &memory, 0x6U);
+  TEST_PARAMS3(test_evaluate_operand, "0xl5", &memory, 0x0U); /* out of range */
+
+  /* bits */
+  TEST_PARAMS3(test_evaluate_operand, "0xm0", &memory, 0x0U);
+  TEST_PARAMS3(test_evaluate_operand, "0xm3", &memory, 0x1U);
+  TEST_PARAMS3(test_evaluate_operand, "0xn3", &memory, 0x1U);
+  TEST_PARAMS3(test_evaluate_operand, "0xo3", &memory, 0x0U);
+  TEST_PARAMS3(test_evaluate_operand, "0xp3", &memory, 0x1U);
+  TEST_PARAMS3(test_evaluate_operand, "0xq3", &memory, 0x0U);
+  TEST_PARAMS3(test_evaluate_operand, "0xr3", &memory, 0x1U);
+  TEST_PARAMS3(test_evaluate_operand, "0xs3", &memory, 0x0U);
+  TEST_PARAMS3(test_evaluate_operand, "0xt3", &memory, 0x1U);
+  TEST_PARAMS3(test_evaluate_operand, "0xm5", &memory, 0x0U); /* out of range */
+
+  /* bit count */
+  TEST_PARAMS3(test_evaluate_operand, "0xc0", &memory, 0x0U); /* 0 bits in 0x00 */
+  TEST_PARAMS3(test_evaluate_operand, "0xc1", &memory, 0x2U); /* 2 bits in 0x12 */
+  TEST_PARAMS3(test_evaluate_operand, "0xc2", &memory, 0x3U); /* 3 bits in 0x34 */
+  TEST_PARAMS3(test_evaluate_operand, "0xc3", &memory, 0x5U); /* 5 bits in 0xAB */
+  TEST_PARAMS3(test_evaluate_operand, "0xc4", &memory, 0x4U); /* 4 bits in 0x56 */
+
+  /* BCD */
+  TEST_PARAMS3(test_evaluate_operand, "b0xh3", &memory, 111U); /* 0xAB not technically valid in BCD */
+
+  ram[3] = 0x56; /* 0xAB not valid in BCD */
+  TEST_PARAMS3(test_evaluate_operand, "b0xh0", &memory, 00U);
+  TEST_PARAMS3(test_evaluate_operand, "b0xh1", &memory, 12U);
+  TEST_PARAMS3(test_evaluate_operand, "b0x 1", &memory, 3412U);
+  TEST_PARAMS3(test_evaluate_operand, "b0xw1", &memory, 563412U);
+  TEST_PARAMS3(test_evaluate_operand, "b0xx1", &memory, 56563412U);
+}
+
+static void test_evaluate_delta_memory_reference() {
+  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  memory_t memory;
+  rc_operand_t op;
+  const char* memaddr;
+  rc_parse_state_t parse;
+  char buffer[256];
+  rc_memref_value_t* memrefs;
+
+  memory.ram = ram;
+  memory.size = sizeof(ram);
+
+  memaddr = "d0xh1";
+  rc_init_parse_state(&parse, buffer, 0, 0);
+  rc_init_parse_state_memrefs(&parse, &memrefs);
+  rc_parse_operand(&op, &memaddr, 1, 0, &parse);
+  rc_destroy_parse_state(&parse);
+
+  ASSERT_UNUM_EQUALS(evaluate_operand(&op, &memory, memrefs), 0x00); /* first call gets uninitialized value */
+  ASSERT_UNUM_EQUALS(evaluate_operand(&op, &memory, memrefs), 0x12); /* second gets current value */
+
+  /* RC_OPERAND_DELTA is always one frame behind */
+  ram[1] = 0x13;
+  ASSERT_UNUM_EQUALS(evaluate_operand(&op, &memory, memrefs), 0x12U);
+
+  ram[1] = 0x14;
+  ASSERT_UNUM_EQUALS(evaluate_operand(&op, &memory, memrefs), 0x13U);
+
+  ram[1] = 0x15;
+  ASSERT_UNUM_EQUALS(evaluate_operand(&op, &memory, memrefs), 0x14U);
+
+  ram[1] = 0x16;
+  ASSERT_UNUM_EQUALS(evaluate_operand(&op, &memory, memrefs), 0x15U);
+
+  ASSERT_UNUM_EQUALS(evaluate_operand(&op, &memory, memrefs), 0x16U);
+  ASSERT_UNUM_EQUALS(evaluate_operand(&op, &memory, memrefs), 0x16U);
+}
+
+void test_evaluate_prior_memory_reference() {
+  unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  memory_t memory;
+  rc_operand_t op;
+  const char* memaddr;
+  rc_parse_state_t parse;
+  char buffer[256];
+  rc_memref_value_t* memrefs;
+
+  memory.ram = ram;
+  memory.size = sizeof(ram);
+
+  memaddr = "p0xh1";
+  rc_init_parse_state(&parse, buffer, 0, 0);
+  rc_init_parse_state_memrefs(&parse, &memrefs);
+  rc_parse_operand(&op, &memaddr, 1, 0, &parse);
+  rc_destroy_parse_state(&parse);
+
+  /* RC_OPERAND_PRIOR only updates when the memory value changes */
+  ASSERT_UNUM_EQUALS(evaluate_operand(&op, &memory, memrefs), 0x00); /* first call gets uninitialized value */
+  ASSERT_UNUM_EQUALS(evaluate_operand(&op, &memory, memrefs), 0x00); /* value only changes when memory changes */
+
+  ram[1] = 0x13;
+  ASSERT_UNUM_EQUALS(evaluate_operand(&op, &memory, memrefs), 0x12U);
+  ASSERT_UNUM_EQUALS(evaluate_operand(&op, &memory, memrefs), 0x12U);
+  ASSERT_UNUM_EQUALS(evaluate_operand(&op, &memory, memrefs), 0x12U);
+  ASSERT_UNUM_EQUALS(evaluate_operand(&op, &memory, memrefs), 0x12U);
+
+  ram[1] = 0x14;
+  ASSERT_UNUM_EQUALS(evaluate_operand(&op, &memory, memrefs), 0x13U);
+
+  ram[1] = 0x15;
+  ASSERT_UNUM_EQUALS(evaluate_operand(&op, &memory, memrefs), 0x14U);
+
+  ram[1] = 0x16;
+  ASSERT_UNUM_EQUALS(evaluate_operand(&op, &memory, memrefs), 0x15U);
+  ASSERT_UNUM_EQUALS(evaluate_operand(&op, &memory, memrefs), 0x15U);
+  ASSERT_UNUM_EQUALS(evaluate_operand(&op, &memory, memrefs), 0x15U);
+}
+
+void test_operand(void) {
+  TEST_SUITE_BEGIN();
+
+  test_parse_memory_references();
+  test_parse_delta_memory_references();
+  test_parse_prior_memory_references();
+  test_parse_bcd_memory_references();
+  test_parse_values();
+
+  test_evaluate_memory_references();
+  TEST(test_evaluate_delta_memory_reference);
+  TEST(test_evaluate_prior_memory_reference);
+
+  TEST_SUITE_END();
+}

--- a/test/test_framework.h
+++ b/test/test_framework.h
@@ -1,0 +1,123 @@
+#ifndef TEST_FRAMEWORK_H
+#define TEST_FRAMEWORK_H
+
+#include <string.h>
+#include <stdio.h>
+#include <time.h>
+
+typedef struct
+{
+  const char* current_suite;
+  const char* current_test;
+  const char* current_test_file;
+  unsigned current_test_line;
+  int fail_count;
+  int run_count;
+  time_t time_start;
+} test_framework_state_t;
+
+extern test_framework_state_t __test_framework_state;
+extern const char* test_framework_basename(const char* path);
+
+#define TEST_FRAMEWORK_DECLARATIONS() \
+  test_framework_state_t __test_framework_state; \
+  \
+  const char* test_framework_basename(const char* path) { \
+    const char* last_slash = path; \
+    while (*path) { \
+      if (*path == '/' || *path == '\\') last_slash = path + 1; \
+      ++path; \
+    } \
+    return last_slash; \
+  }
+
+#define TEST_FRAMEWORK_INIT() \
+  memset(&__test_framework_state, 0, sizeof(__test_framework_state)); \
+  __test_framework_state.time_start = time(0)
+
+#define TEST_FRAMEWORK_SHUTDOWN() \
+  printf("\nDone. %d/%d passed in %u seconds\n", \
+    __test_framework_state.run_count - __test_framework_state.fail_count, __test_framework_state.run_count, \
+    (unsigned)(time(0) - __test_framework_state.time_start))
+
+#define TEST_FRAMEWORK_PASSED() (__test_framework_state.fail_count == 0)
+
+#define TEST_SUITE_BEGIN() \
+  __test_framework_state.current_suite = __func__; \
+  printf("%s ", __test_framework_state.current_suite); \
+  fflush(stdout)
+
+#define TEST_SUITE_END() __test_framework_state.current_suite = 0; \
+  printf("\n"); \
+  fflush(stdout)
+
+#define TEST(func) \
+  __test_framework_state.current_test = #func; \
+  __test_framework_state.current_test_file = __FILE__; \
+  __test_framework_state.current_test_line = __LINE__; \
+  printf("."); \
+  fflush(stdout); \
+  func(); \
+  ++__test_framework_state.run_count
+
+#define TEST_PARAMS2(func, p1, p2) \
+  __test_framework_state.current_test = #func "(" #p1 ", " #p2 ")"; \
+  __test_framework_state.current_test_file = __FILE__; \
+  __test_framework_state.current_test_line = __LINE__; \
+  printf("."); \
+  fflush(stdout); \
+  func(p1, p2); \
+  ++__test_framework_state.run_count
+
+#define TEST_PARAMS3(func, p1, p2, p3) \
+  __test_framework_state.current_test = #func "(" #p1 ", " #p2 ", " #p3 ")"; \
+  __test_framework_state.current_test_file = __FILE__; \
+  __test_framework_state.current_test_line = __LINE__; \
+  printf("."); \
+  fflush(stdout); \
+  func(p1, p2, p3); \
+  ++__test_framework_state.run_count
+
+#define TEST_PARAMS4(func, p1, p2, p3, p4) \
+  __test_framework_state.current_test = #func "(" #p1 ", " #p2 ", " #p3 ", " #p4 ")"; \
+  __test_framework_state.current_test_file = __FILE__; \
+  __test_framework_state.current_test_line = __LINE__; \
+  printf("."); \
+  fflush(stdout); \
+  func(p1, p2, p3, p4); \
+  ++__test_framework_state.run_count
+
+#define ASSERT_FAIL(message, ...) \
+  fprintf(stderr, "\n* %s/%s (%s:%d)\n  ", __test_framework_state.current_suite, __test_framework_state.current_test, \
+          test_framework_basename(__test_framework_state.current_test_file), __test_framework_state.current_test_line); \
+  fprintf(stderr, message "\n", __VA_ARGS__); \
+  fflush(stderr); \
+  ++__test_framework_state.fail_count; \
+  return
+
+#define ASSERT_COMPARE(value, compare, expected, type, format) { \
+  type __v = (type)(value); \
+  type __e = (type)(expected); \
+  if (!(__v compare __e)) { \
+    ASSERT_FAIL("Expected: " #value " " #compare " " #expected " (%s:%d)\n  Found:    " format " " #compare " " format, \
+                test_framework_basename(__FILE__), __LINE__, __v, __e); \
+  }}
+
+#define ASSERT_NUM_EQUALS(value, expected)         ASSERT_COMPARE(value, ==, expected, int, "%d")
+#define ASSERT_NUM_NOT_EQUALS(value, expected)     ASSERT_COMPARE(value, !=, expected, int, "%d")
+#define ASSERT_NUM_GREATER(value, expected)        ASSERT_COMPARE(value, >,  expected, int, "%d")
+#define ASSERT_NUM_GREATER_EQUALS(value, expected) ASSERT_COMPARE(value, >=, expected, int, "%d")
+#define ASSERT_NUM_LESS(value, expected)           ASSERT_COMPARE(value, <,  expected, int, "%d")
+#define ASSERT_NUM_LESS_EQUALS(value, expected)    ASSERT_COMPARE(value, <=, expected, int, "%d")
+
+#define ASSERT_UNUM_EQUALS(value, expected) ASSERT_COMPARE(value, ==, expected, unsigned, "%u")
+#define ASSERT_DBL_EQUALS(value, expected)  ASSERT_COMPARE(value, ==, expected, double, "%g")
+
+#define ASSERT_STR_EQUALS(value, expected) { \
+  const char* __v = (const char*)(value); \
+  const char* __e = (const char*)(expected); \
+  if (strcmp(__v, __e) != 0) { \
+    ASSERT_FAIL( "String mismatch for: " #value " (%s:%d)\n  Expected: %s\n  Found:    %s", test_framework_basename(__FILE__), __LINE__, __e, __v); \
+  }}
+
+#endif /* TEST_FRAMEWORK_H */

--- a/test/test_framework.h
+++ b/test/test_framework.h
@@ -110,8 +110,9 @@ extern const char* test_framework_basename(const char* path);
 #define ASSERT_NUM_LESS(value, expected)           ASSERT_COMPARE(value, <,  expected, int, "%d")
 #define ASSERT_NUM_LESS_EQUALS(value, expected)    ASSERT_COMPARE(value, <=, expected, int, "%d")
 
-#define ASSERT_UNUM_EQUALS(value, expected) ASSERT_COMPARE(value, ==, expected, unsigned, "%u")
-#define ASSERT_DBL_EQUALS(value, expected)  ASSERT_COMPARE(value, ==, expected, double, "%g")
+#define ASSERT_UNUM_EQUALS(value, expected)        ASSERT_COMPARE(value, ==, expected, unsigned, "%u")
+#define ASSERT_DBL_EQUALS(value, expected)         ASSERT_COMPARE(value, ==, expected, double, "%g")
+#define ASSERT_PTR_EQUALS(value, expected)         ASSERT_COMPARE(value, ==, expected, void*, "%p")
 
 #define ASSERT_STR_EQUALS(value, expected) { \
   const char* __v = (const char*)(value); \


### PR DESCRIPTION
Provides a skeletal unit test framework that reports successes as well as failures. 

Here's a successful run:
```
test_memref ....
test_operand .........................................................................................................................................................

Done. 157/157 passed in 0 seconds
```

And an example of an error:
```
* test_operand/test_evaluate_prior_memory_reference (test_operand.c:419)
  Expected: evaluate_operand(&op, &memory, memrefs) == 0x16U (test_operand.c:403)
  Found:    21 == 22
```

Additionally, I've pulled the tests related to memrefs and operands out into separate files. The singular `test.c` was getting to be quite large (almost 200KB), and this is an opportune time to split it up. For now, I've only done `test_memref` and `test_operand` to test functionality associated to `memref.c` and `operand.c`. 

Unless someone objects, I will proceed to extract/convert the remaining tests over the next few weeks as several individual PRs.