### PR TITLE
add RC_CONDITION_TRIGGER

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # v9.0.0
 
 * new size: RC_MEMSIZE_8_BITS_BITCOUNT
+* new flag: RC_CONDITION_OR_NEXT
+* new flag: RC_CONDITION_TRIGGER
+* new operators: RC_OPERATOR_MULT / RC_OPERATOR_DIV
 * is_bcd removed from memref - now part of RC_MEMSIZE
 * add rc_runtime_t and associated functions
 * add rc_hash_ functions

--- a/README.md
+++ b/README.md
@@ -253,7 +253,8 @@ enum {
   RC_CONDITION_ADD_HITS,
   RC_CONDITION_AND_NEXT,
   RC_CONDITION_MEASURED,
-  RC_CONDITION_ADD_ADDRESS
+  RC_CONDITION_ADD_ADDRESS,
+  RC_CONDITION_TRIGGER,
 };
 ```
 
@@ -353,7 +354,8 @@ enum {
   RC_TRIGGER_STATE_ACTIVE,     /* achievement is active and may trigger */
   RC_TRIGGER_STATE_PAUSED,     /* achievement is currently paused and will not trigger */
   RC_TRIGGER_STATE_RESET,      /* achievement hit counts were reset */
-  RC_TRIGGER_STATE_TRIGGERED   /* achievement has triggered */
+  RC_TRIGGER_STATE_TRIGGERED,  /* achievement has triggered */
+  RC_TRIGGER_STATE_PRIMED      /* all non-Trigger conditions are true */
 };
 ```
 
@@ -562,6 +564,8 @@ The `event.type` field will be one of the following:
 * RC_RUNTIME_EVENT_ACHIEVEMENT_TRIGGERED (id=achievement id)
   All conditions for the achievement have been met and the user should be informed.
   NOTE: If `rc_runtime_reset` is called without deactivating the achievement, it may trigger again.
+* RC_RUNTIME_EVENT_ACHIEVEMENT_PRIMED (id=achievement id)
+  All non-trigger conditions for the achievement have been met. This typically indicates the achievement is a challenge achievement and the challenge is active.
 * RC_RUNTIME_EVENT_LBOARD_STARTED (id=leaderboard id, value=leaderboard value)
   The leaderboard's start condition has been met and the user should be informed that a leaderboard attempt has started.
 * RC_RUNTIME_EVENT_LBOARD_CANCELED (id=leaderboard id, value=leaderboard value)

--- a/include/rcheevos.h
+++ b/include/rcheevos.h
@@ -159,7 +159,8 @@ enum {
   RC_CONDITION_AND_NEXT,
   RC_CONDITION_MEASURED,
   RC_CONDITION_ADD_ADDRESS,
-  RC_CONDITION_OR_NEXT
+  RC_CONDITION_OR_NEXT,
+  RC_CONDITION_TRIGGER
 };
 
 /* operators */
@@ -234,7 +235,8 @@ enum {
   RC_TRIGGER_STATE_ACTIVE,     /* achievement is active and may trigger */
   RC_TRIGGER_STATE_PAUSED,     /* achievement is currently paused and will not trigger */
   RC_TRIGGER_STATE_RESET,      /* achievement hit counts were reset */
-  RC_TRIGGER_STATE_TRIGGERED   /* achievement has triggered */
+  RC_TRIGGER_STATE_TRIGGERED,  /* achievement has triggered */
+  RC_TRIGGER_STATE_PRIMED      /* all non-Trigger conditions are true */
 };
 
 typedef struct {
@@ -475,10 +477,11 @@ int rc_runtime_activate_richpresence(rc_runtime_t* runtime, const char* script, 
 const char* rc_runtime_get_richpresence(const rc_runtime_t* runtime);
 
 enum {
-  RC_RUNTIME_EVENT_ACHIEVEMENT_ACTIVATED, /* from WAITING or PAUSED to ACTIVE */
+  RC_RUNTIME_EVENT_ACHIEVEMENT_ACTIVATED, /* from WAITING, PAUSED, or PRIMED to ACTIVE */
   RC_RUNTIME_EVENT_ACHIEVEMENT_PAUSED,
   RC_RUNTIME_EVENT_ACHIEVEMENT_RESET,
   RC_RUNTIME_EVENT_ACHIEVEMENT_TRIGGERED,
+  RC_RUNTIME_EVENT_ACHIEVEMENT_PRIMED,
   RC_RUNTIME_EVENT_LBOARD_STARTED,
   RC_RUNTIME_EVENT_LBOARD_CANCELED,
   RC_RUNTIME_EVENT_LBOARD_UPDATED,

--- a/src/rcheevos/condition.c
+++ b/src/rcheevos/condition.c
@@ -23,6 +23,7 @@ rc_condition_t* rc_parse_condition(const char** memaddr, rc_parse_state_t* parse
       case 'o': case 'O': self->type = RC_CONDITION_OR_NEXT; break;
       case 'm': case 'M': self->type = RC_CONDITION_MEASURED; break;
       case 'i': case 'I': self->type = RC_CONDITION_ADD_ADDRESS; can_modify = 1; break;
+      case 't': case 'T': self->type = RC_CONDITION_TRIGGER; break;
       default: parse->offset = RC_INVALID_CONDITION_TYPE; return 0;
     }
 

--- a/src/rcheevos/internal.h
+++ b/src/rcheevos/internal.h
@@ -61,6 +61,7 @@ typedef struct {
   unsigned measured_value;  /* Measured */
   char was_reset;           /* ResetIf triggered */
   char has_hits;            /* one of more hit counts is non-zero */
+  char primed;              /* true if all non-Trigger conditions are true */
 }
 rc_eval_state_t;
 

--- a/src/rcheevos/runtime.c
+++ b/src/rcheevos/runtime.c
@@ -487,6 +487,14 @@ void rc_runtime_do_frame(rc_runtime_t* self, rc_runtime_event_handler_t event_ha
         }
         break;
         
+      case RC_TRIGGER_STATE_PRIMED:
+        if (trigger_state != RC_TRIGGER_STATE_PRIMED) {
+          runtime_event.type = RC_RUNTIME_EVENT_ACHIEVEMENT_PRIMED;
+          runtime_event.id = self->triggers[i].id;
+          event_handler(&runtime_event);
+        }
+        break;
+
       case RC_TRIGGER_STATE_ACTIVE:
         if (trigger_state != RC_TRIGGER_STATE_ACTIVE) {
           runtime_event.type = RC_RUNTIME_EVENT_ACHIEVEMENT_ACTIVATED;


### PR DESCRIPTION
A condition flagged as a Trigger is expected to be the final condition required for an achievement to unlock. 

When all conditions _except_ the Trigger are true, a `RC_RUNTIME_EVENT_ACHIEVEMENT_PRIMED` event will be raised. This can be used by the UI to display a challenge notification (see https://github.com/RetroAchievements/RAIntegration/issues/52). If a non-Trigger condition becomes false, a `RC_RUNTIME_EVENT_ACHIEVEMENT_ACTIVATED` event will be raised, otherwise when the Trigger becomes true, a `RC_RUNTIME_EVENT_ACHIEVEMENT_TRIGGERED` event will be raised.