### PR TITLE
rich presence unknown macro fix

### DIFF
--- a/test/test.c
+++ b/test/test.c
@@ -4793,6 +4793,14 @@ static void test_richpresence(void) {
 
   {
     /*------------------------------------------------------------------------
+    TestEmpty
+    ------------------------------------------------------------------------*/
+    int result = rc_richpresence_size("");
+    assert(result == RC_MISSING_DISPLAY_STRING);
+  }
+
+  {
+    /*------------------------------------------------------------------------
     TestValueMacro
     ------------------------------------------------------------------------*/
     unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
@@ -4937,6 +4945,23 @@ static void test_richpresence(void) {
     assert(strcmp(output, "[Unknown macro]Points(0x 0001) Points") == 0);
     assert(result == 37);
   }
+
+  {
+    /*------------------------------------------------------------------------
+    TestUndefinedMacroAtEndOfLine
+    ------------------------------------------------------------------------*/
+    unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+    memory_t memory;
+    rc_richpresence_t* richpresence;
+    int result;
+
+    memory.ram = ram;
+    memory.size = sizeof(ram);
+
+    richpresence = parse_richpresence("Display:\n@Points(0x 0001)", buffer);
+    result = rc_evaluate_richpresence(richpresence, output, sizeof(output), peek, &memory, NULL);
+    assert(strcmp(output, "[Unknown macro]Points(0x 0001)") == 0);
+    assert(result == 30);  }
 
   {
     /*------------------------------------------------------------------------


### PR DESCRIPTION
Fixes an overflow that occurs when an unknown macro is encountered while parsing a rich presence script. The sizing code is unable to detect the unknown macro, so it generates the size as if everything is fine. When the actual parser hits the unknown macro, it injects a "[Unknown macro]" string to help report and debug the problem. If injecting this takes more space then the evaluation of the macro when it is correct, then the completely parsed script may exceed the size of the buffer allocated by the sizing code.

When an unknown macro was encountered, the current `rc_richpresence_display_part_t` was changed to display the static string "[Unknown macro]" and a second `rc_richpresence_display_part_t` was created to display the name of the unknown macro. The solution is to merge the two into a single `rc_richpresence_display_part_t`. Instead of having two `RC_FORMAT_STRING`s, a new type `RC_FORMAT_UNKNOWN_MACRO` was added. This element references the name of the unknown macro, and the "[Unknown macro]" text is no longer stored directly in the compiled rich presence.

As a result, we avoid the overhead of a second `rc_richpresence_display_part_t` and a copy of the "[Unknown macro]" string (roughly 44 bytes). As long as the string representation of the macro lookup is smaller than the calculated size to compile it (~60 characters for a single memory lookup), this should prevent the buffer overflow.

A better solution would be to actually validate the macro when calculating the size so the size is more accurately calculated.