### PR TITLE
add validator project

### DIFF
--- a/test/rcheevos-test.sln
+++ b/test/rcheevos-test.sln
@@ -10,6 +10,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\.editorconfig = ..\.editorconfig
 	EndProjectSection
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "validator", "..\validator\validator.vcxproj", "{16FABFA7-A2EC-4CD0-9E04-50315A2BB613}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -26,6 +28,14 @@ Global
 		{74FBBFC4-5AC5-4A86-B292-B2F535E9912C}.Release|x64.Build.0 = Release|x64
 		{74FBBFC4-5AC5-4A86-B292-B2F535E9912C}.Release|x86.ActiveCfg = Release|Win32
 		{74FBBFC4-5AC5-4A86-B292-B2F535E9912C}.Release|x86.Build.0 = Release|Win32
+		{16FABFA7-A2EC-4CD0-9E04-50315A2BB613}.Debug|x64.ActiveCfg = Debug|x64
+		{16FABFA7-A2EC-4CD0-9E04-50315A2BB613}.Debug|x64.Build.0 = Debug|x64
+		{16FABFA7-A2EC-4CD0-9E04-50315A2BB613}.Debug|x86.ActiveCfg = Debug|Win32
+		{16FABFA7-A2EC-4CD0-9E04-50315A2BB613}.Debug|x86.Build.0 = Debug|Win32
+		{16FABFA7-A2EC-4CD0-9E04-50315A2BB613}.Release|x64.ActiveCfg = Release|x64
+		{16FABFA7-A2EC-4CD0-9E04-50315A2BB613}.Release|x64.Build.0 = Release|x64
+		{16FABFA7-A2EC-4CD0-9E04-50315A2BB613}.Release|x86.ActiveCfg = Release|Win32
+		{16FABFA7-A2EC-4CD0-9E04-50315A2BB613}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/validator/Makefile
+++ b/validator/Makefile
@@ -1,0 +1,29 @@
+RC_SRC=../src/rcheevos
+RC_HASH_SRC=../src/rhash
+LUA_SRC=../test/lua/src
+
+OBJ=$(RC_SRC)/trigger.o $(RC_SRC)/condset.o $(RC_SRC)/condition.o $(RC_SRC)/operand.o \
+    $(RC_SRC)/term.o $(RC_SRC)/expression.o $(RC_SRC)/value.o $(RC_SRC)/lboard.o \
+    $(RC_SRC)/alloc.o $(RC_SRC)/memref.o $(RC_SRC)/format.o $(RC_SRC)/richpresence.o \
+    $(RC_SRC)/runtime.o \
+    $(RC_HASH_SRC)/md5.o \
+    $(LUA_SRC)/lapi.o $(LUA_SRC)/lcode.o $(LUA_SRC)/lctype.o $(LUA_SRC)/ldebug.o \
+    $(LUA_SRC)/ldo.o $(LUA_SRC)/ldump.o $(LUA_SRC)/lfunc.o $(LUA_SRC)/lgc.o $(LUA_SRC)/llex.o \
+    $(LUA_SRC)/lmem.o $(LUA_SRC)/lobject.o $(LUA_SRC)/lopcodes.o $(LUA_SRC)/lparser.o \
+    $(LUA_SRC)/lstate.o $(LUA_SRC)/lstring.o $(LUA_SRC)/ltable.o $(LUA_SRC)/ltm.o \
+    $(LUA_SRC)/lundump.o $(LUA_SRC)/lvm.o $(LUA_SRC)/lzio.o $(LUA_SRC)/lauxlib.o \
+    $(LUA_SRC)/lbaselib.o $(LUA_SRC)/lbitlib.o $(LUA_SRC)/lcorolib.o $(LUA_SRC)/ldblib.o \
+    $(LUA_SRC)/liolib.o $(LUA_SRC)/lmathlib.o $(LUA_SRC)/loslib.o $(LUA_SRC)/lstrlib.o \
+    $(LUA_SRC)/ltablib.o $(LUA_SRC)/lutf8lib.o $(LUA_SRC)/loadlib.o $(LUA_SRC)/linit.o \
+    validator.o
+
+all: validator
+
+%.o: %.c
+	gcc -Wall -O0 -g -std=c89 -ansi -Wno-long-long -DLUA_32BITS -I../include -I$(RC_SRC) -I$(LUA_SRC) -c $< -o $@
+
+validator: $(OBJ)
+	gcc -o $@ $+ -lm
+
+clean:
+	rm -f test $(OBJ)

--- a/validator/validator.c
+++ b/validator/validator.c
@@ -1,0 +1,369 @@
+#include "internal.h"
+#include "rurl.h"
+
+#include <stdio.h>
+#include <stddef.h>
+#include <malloc.h>
+#include <string.h> /* memset */
+
+#ifdef _CRT_SECURE_NO_WARNINGS /* windows build*/
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#else
+#include <dirent.h>
+#endif
+
+/* usage exmaple:
+ *
+ * ./validator.exe d "E:\RetroAchievements\dump" | sort > results.txt
+ * grep -v ": OK" results.txt  | grep -v "File: " | grep .
+ */
+
+static void validate_trigger(const char* trigger) {
+  char* buffer;
+  rc_trigger_t* compiled;
+
+  int ret = rc_trigger_size(trigger);
+  if (ret < 0) {
+    printf("%s", rc_error_str(ret));
+    return;
+  }
+
+  buffer = (char*)malloc(ret + 4);
+  memset(buffer + ret, 0xCD, 4);
+  compiled = rc_parse_trigger(buffer, trigger, NULL, 0);
+  if (compiled == NULL) {
+    printf("parse failed");
+    free(buffer);
+    return;
+  }
+
+  if (*(unsigned*)&buffer[ret] != 0xCDCDCDCD) {
+    printf("write past end of buffer");
+    free(buffer);
+    return;
+  }
+
+  printf("OK");
+  free(buffer);
+}
+
+static void validate_leaderboard(const char* leaderboard)
+{
+  char* buffer;
+  rc_lboard_t* compiled;
+
+  int ret = rc_lboard_size(leaderboard);
+  if (ret < 0) {
+    printf("%s", rc_error_str(ret));
+    return;
+  }
+
+  buffer = (char*)malloc(ret + 4);
+  memset(buffer + ret, 0xCD, 4);
+  compiled = rc_parse_lboard(buffer, leaderboard, NULL, 0);
+  if (compiled == NULL) {
+    printf("parse failed");
+    free(buffer);
+    return;
+  }
+
+  if (*(unsigned*)&buffer[ret] != 0xCDCDCDCD) {
+    printf("write past end of buffer");
+    free(buffer);
+    return;
+  }
+
+  printf("OK");
+  free(buffer);
+}
+
+static void validate_richpresence(const char* script)
+{
+  char* buffer;
+  rc_richpresence_t* compiled;
+
+  int ret = rc_richpresence_size(script);
+  if (ret < 0) {
+    printf("%s", rc_error_str(ret));
+    return;
+  }
+
+  buffer = (char*)malloc(ret + 4);
+  memset(buffer + ret, 0xCD, 4);
+  compiled = rc_parse_richpresence(buffer, script, NULL, 0);
+  if (compiled == NULL) {
+    printf("parse failed");
+    free(buffer);
+    return;
+  }
+
+  if (*(unsigned*)&buffer[ret] != 0xCDCDCDCD) {
+    printf("write past end of buffer");
+    free(buffer);
+    return;
+  }
+
+  printf("OK");
+  free(buffer);
+}
+
+static void validate_richpresence_file(const char* richpresence_file)
+{
+  char* file_contents;
+  size_t file_size;
+  FILE* file;
+
+  file = fopen(richpresence_file, "rb");
+  if (!file) {
+    printf("could not open file");
+    return;
+  }
+
+  fseek(file, 0, SEEK_END);
+  file_size = ftell(file);
+  fseek(file, 0, SEEK_SET);
+
+  file_contents = (char*)malloc(file_size + 1);
+  fread(file_contents, 1, file_size, file);
+  file_contents[file_size] = '\0';
+  fclose(file);
+
+  validate_richpresence(file_contents);
+
+  free(file_contents);
+}
+
+static char* get_json_value(char* start, const char* id, char** next)
+{
+  char* ptr = start;
+  char* value;
+  size_t id_len = strlen(id);
+
+  while (*ptr) {
+    if (*ptr == '"' && ptr[id_len + 1] == '"' && memcmp(ptr + 1, id, id_len) == 0) {
+      ptr += id_len + 3; /* skip over id and colon */
+      if (*ptr == '"') {
+        char* copy = ++ptr;
+        value = copy;
+        while (*ptr && *ptr != '"') {
+          if (*ptr != '\\') {
+            *copy++ = *ptr++;
+          } else {
+            ++ptr;
+            switch (*ptr) {
+              case 'r': *copy++ = '\r'; break;
+              case 'n': *copy++ = '\n'; break;
+              case 't': *copy++ = '\t'; break;
+              default: *copy++ = *ptr; break;
+            }
+            ++ptr;
+          }
+        }
+        if (*ptr)
+          *ptr++ = '\0';
+        *copy = '\0';
+      } else if (*ptr == '[') {
+        if (next) 
+          *next = ptr;
+        return ptr;
+      } else {
+        value = ptr;
+        while (*ptr && *ptr != ',' && *ptr != '}')
+          ++ptr;
+        if (*ptr)
+          *ptr++ = '\0';
+      }
+
+      if (next)
+        *next = ptr;
+
+      return value;
+    }
+    
+    ++ptr;
+  }
+
+  return NULL;
+}
+
+static void validate_patchdata_file(const char* patchdata_file) {
+  char* file_contents;
+  size_t file_size;
+  FILE* file;
+  char* ptr, *value, *lboard_start, *ach_start, *game_id;
+
+  file = fopen(patchdata_file, "rb");
+  if (!file) {
+    printf("could not open file");
+    return;
+  }
+
+  fseek(file, 0, SEEK_END);
+  file_size = ftell(file);
+  fseek(file, 0, SEEK_SET);
+
+  file_contents = (char*)malloc(file_size + 1);
+  fread(file_contents, 1, file_size, file);
+  file_contents[file_size] = '\0';
+  fclose(file);
+
+  /* this makes assumptions about the layout of the JSON */
+  game_id = get_json_value(file_contents, "ID", &ptr);
+  if (game_id == NULL) {
+    printf("not a patchdata file");
+    return;
+  }
+
+  value = get_json_value(ptr, "Title", &ptr);
+  printf("%s\n", value);
+
+  value = get_json_value(ptr, "RichPresencePatch", &ptr);
+  if (value && *value && strcmp(value, "null") != 0) {
+    printf(" rich presence %s: ", game_id);
+    validate_richpresence(value);
+    printf("\n");
+  }
+
+  lboard_start = get_json_value(ptr, "Leaderboards", NULL);
+  if (lboard_start)
+    lboard_start[-1] = '\0';
+
+  ach_start = get_json_value(ptr, "Achievements", NULL);
+  if (ach_start) {
+    do {
+      value = get_json_value(ptr, "ID", &ptr);
+      if (!value)
+        break;
+
+      printf(" achievement %s: ", value);
+      value = get_json_value(ptr, "MemAddr", &ptr);
+      validate_trigger(value);
+      printf("\n");
+    } while (1);
+  }
+
+  if (lboard_start) {
+    ptr = lboard_start;
+    do {
+      value = get_json_value(ptr, "ID", &ptr);
+      if (!value)
+        break;
+
+      printf(" leaderboard %s: ", value);
+      value = get_json_value(ptr, "Mem", &ptr);
+      validate_leaderboard(value);
+      printf("\n");
+    } while (1);
+  }
+
+  free(file_contents);
+}
+
+#ifdef _CRT_SECURE_NO_WARNINGS
+static void validate_pathdata_directory(const char* patchdata_directory) {
+  WIN32_FIND_DATA fdFile;
+  HANDLE hFind = NULL;
+
+  char filename[MAX_PATH];
+  sprintf(filename, "%s\\*.json", patchdata_directory);
+
+  if ((hFind = FindFirstFile(filename, &fdFile)) == INVALID_HANDLE_VALUE) {
+    printf("failed to open directory");
+    return;
+  }
+
+  do
+  {
+    sprintf(filename, "%s\\%s", patchdata_directory, fdFile.cFileName);
+
+    if (!(fdFile.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)) {
+      printf("File: %s: ", fdFile.cFileName);
+      validate_patchdata_file(filename);
+      printf("\n");
+    }
+  } while(FindNextFile(hFind, &fdFile));
+
+  FindClose(hFind);
+}
+#else
+static void validate_pathdata_directory(const char* patchdata_directory) {
+  struct dirent* entry;
+  char* filename;
+  size_t filename_len;
+  char path[2048];
+
+  DIR* dir = opendir(patchdata_directory);
+  if (!dir) {
+    printf("failed to open directory");
+    return;
+  }
+
+  while ((entry = readdir(dir)) != NULL) {
+    filename = entry->d_name;
+    filename_len = strlen(filename);
+    if (filename_len > 5 && stricmp(&filename[filename_len - 5], ".json") == 0) {
+      sprintf(path, "%s/%s", patchdata_directory, filename);
+      printf("File: %s: ", filename);
+      validate_patchdata_file(path);
+      printf("\n");
+    }
+  }
+
+  closedir(dir);
+}
+#endif
+
+static int usage() {
+  printf("validator [type] [data]\n"
+         "\n"
+         "where [type] is one of the following:\n"
+         "  a   achievement, [data] = trigger definition\n"
+         "  l   leaderboard, [data] = leaderboard definition\n"
+         "  r   rich presence, [data] = path to rich presence script\n"
+         "  f   patchdata file, [data] = path to patchdata json file\n"
+         "  d   patchdata directory, [data] = path to directory containing one or more patchdata json files\n"
+  );
+
+  return 0;
+}
+
+int main(int argc, char* argv[]) {
+  
+  if (argc < 3)
+    return usage();
+
+  switch (argv[1][0])
+  {
+    case 'a':
+      printf("Achievement: ");
+      validate_trigger(argv[2]);
+      break;
+
+    case 'l':
+      printf("Leaderboard: ");
+      validate_leaderboard(argv[2]);
+      break;
+
+    case 'r':
+      printf("Rich Presence: ");
+      validate_richpresence_file(argv[2]);
+      break;
+
+    case 'f':
+      printf("File: %s: ", argv[2]);
+      validate_patchdata_file(argv[2]);
+      break;
+
+    case 'd':
+      printf("Directory: %s: ", argv[2]);
+      validate_pathdata_directory(argv[2]);
+      break;
+
+    default:
+      return usage();
+  }
+
+  printf("\n");
+  return 0;
+}

--- a/validator/validator.vcxproj
+++ b/validator/validator.vcxproj
@@ -1,0 +1,185 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>15.0</VCProjectVersion>
+    <ProjectGuid>{16FABFA7-A2EC-4CD0-9E04-50315A2BB613}</ProjectGuid>
+    <RootNamespace>rcheevostest</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\include;$(ProjectDir)..\src\rcheevos;$(ProjectDir)..\test\lua\src</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\include;$(ProjectDir)..\src\rcheevos;$(ProjectDir)..\test\lua\src</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\include;$(ProjectDir)..\src\rcheevos;$(ProjectDir)..\test\lua\src</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\include;$(ProjectDir)..\src\rcheevos;$(ProjectDir)..\test\lua\src</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\src\rcheevos\alloc.c" />
+    <ClCompile Include="..\src\rcheevos\condition.c" />
+    <ClCompile Include="..\src\rcheevos\condset.c" />
+    <ClCompile Include="..\src\rcheevos\expression.c" />
+    <ClCompile Include="..\src\rcheevos\format.c" />
+    <ClCompile Include="..\src\rcheevos\lboard.c" />
+    <ClCompile Include="..\src\rcheevos\memref.c" />
+    <ClCompile Include="..\src\rcheevos\operand.c" />
+    <ClCompile Include="..\src\rcheevos\richpresence.c" />
+    <ClCompile Include="..\src\rcheevos\runtime.c" />
+    <ClCompile Include="..\src\rcheevos\term.c" />
+    <ClCompile Include="..\src\rcheevos\trigger.c" />
+    <ClCompile Include="..\src\rcheevos\value.c" />
+    <ClCompile Include="..\src\rhash\md5.c" />
+    <ClCompile Include="..\test\lua\src\lapi.c" />
+    <ClCompile Include="..\test\lua\src\lauxlib.c" />
+    <ClCompile Include="..\test\lua\src\lbaselib.c" />
+    <ClCompile Include="..\test\lua\src\lbitlib.c" />
+    <ClCompile Include="..\test\lua\src\lcode.c" />
+    <ClCompile Include="..\test\lua\src\lcorolib.c" />
+    <ClCompile Include="..\test\lua\src\lctype.c" />
+    <ClCompile Include="..\test\lua\src\ldblib.c" />
+    <ClCompile Include="..\test\lua\src\ldebug.c" />
+    <ClCompile Include="..\test\lua\src\ldo.c" />
+    <ClCompile Include="..\test\lua\src\ldump.c" />
+    <ClCompile Include="..\test\lua\src\lfunc.c" />
+    <ClCompile Include="..\test\lua\src\lgc.c" />
+    <ClCompile Include="..\test\lua\src\linit.c" />
+    <ClCompile Include="..\test\lua\src\liolib.c" />
+    <ClCompile Include="..\test\lua\src\llex.c" />
+    <ClCompile Include="..\test\lua\src\lmathlib.c" />
+    <ClCompile Include="..\test\lua\src\lmem.c" />
+    <ClCompile Include="..\test\lua\src\loadlib.c" />
+    <ClCompile Include="..\test\lua\src\lobject.c" />
+    <ClCompile Include="..\test\lua\src\lopcodes.c" />
+    <ClCompile Include="..\test\lua\src\loslib.c" />
+    <ClCompile Include="..\test\lua\src\lparser.c" />
+    <ClCompile Include="..\test\lua\src\lstate.c" />
+    <ClCompile Include="..\test\lua\src\lstring.c" />
+    <ClCompile Include="..\test\lua\src\lstrlib.c" />
+    <ClCompile Include="..\test\lua\src\ltable.c" />
+    <ClCompile Include="..\test\lua\src\ltablib.c" />
+    <ClCompile Include="..\test\lua\src\ltm.c" />
+    <ClCompile Include="..\test\lua\src\lundump.c" />
+    <ClCompile Include="..\test\lua\src\lutf8lib.c" />
+    <ClCompile Include="..\test\lua\src\lvm.c" />
+    <ClCompile Include="..\test\lua\src\lzio.c" />
+    <ClCompile Include="validator.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\include\rcheevos.h" />
+    <ClInclude Include="..\src\rcheevos\internal.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/validator/validator.vcxproj.filters
+++ b/validator/validator.vcxproj.filters
@@ -1,0 +1,169 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="src">
+      <UniqueIdentifier>{125bb837-6e5b-4a66-a607-e2250b31f108}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="src\lua">
+      <UniqueIdentifier>{36DC4CE2-0F57-46DE-A037-25E4272A7747}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="src\rcheevos">
+      <UniqueIdentifier>{DD82F9EB-1066-40C6-9568-D5C7EEB2A49B}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="src\rhash">
+      <UniqueIdentifier>{efdc689a-471b-432e-8ecb-dde3a3202949}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\src\rcheevos\format.c">
+      <Filter>src\rcheevos</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\rcheevos\lboard.c">
+      <Filter>src\rcheevos</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\rcheevos\operand.c">
+      <Filter>src\rcheevos</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\rcheevos\term.c">
+      <Filter>src\rcheevos</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\rcheevos\trigger.c">
+      <Filter>src\rcheevos</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\rcheevos\value.c">
+      <Filter>src\rcheevos</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\rcheevos\alloc.c">
+      <Filter>src\rcheevos</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\rcheevos\condition.c">
+      <Filter>src\rcheevos</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\rcheevos\condset.c">
+      <Filter>src\rcheevos</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\rcheevos\expression.c">
+      <Filter>src\rcheevos</Filter>
+    </ClCompile>
+    <ClCompile Include="..\test\lua\src\lapi.c">
+      <Filter>src\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\test\lua\src\lauxlib.c">
+      <Filter>src\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\test\lua\src\lbaselib.c">
+      <Filter>src\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\test\lua\src\lbitlib.c">
+      <Filter>src\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\test\lua\src\lcode.c">
+      <Filter>src\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\test\lua\src\lcorolib.c">
+      <Filter>src\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\test\lua\src\lctype.c">
+      <Filter>src\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\test\lua\src\ldblib.c">
+      <Filter>src\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\test\lua\src\ldebug.c">
+      <Filter>src\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\test\lua\src\ldo.c">
+      <Filter>src\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\test\lua\src\ldump.c">
+      <Filter>src\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\test\lua\src\lfunc.c">
+      <Filter>src\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\test\lua\src\lgc.c">
+      <Filter>src\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\test\lua\src\linit.c">
+      <Filter>src\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\test\lua\src\liolib.c">
+      <Filter>src\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\test\lua\src\llex.c">
+      <Filter>src\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\test\lua\src\lmathlib.c">
+      <Filter>src\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\test\lua\src\lmem.c">
+      <Filter>src\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\test\lua\src\loadlib.c">
+      <Filter>src\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\test\lua\src\lobject.c">
+      <Filter>src\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\test\lua\src\lopcodes.c">
+      <Filter>src\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\test\lua\src\loslib.c">
+      <Filter>src\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\test\lua\src\lparser.c">
+      <Filter>src\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\test\lua\src\lstate.c">
+      <Filter>src\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\test\lua\src\lstring.c">
+      <Filter>src\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\test\lua\src\lstrlib.c">
+      <Filter>src\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\test\lua\src\ltable.c">
+      <Filter>src\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\test\lua\src\ltablib.c">
+      <Filter>src\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\test\lua\src\ltm.c">
+      <Filter>src\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\test\lua\src\lundump.c">
+      <Filter>src\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\test\lua\src\lutf8lib.c">
+      <Filter>src\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\test\lua\src\lvm.c">
+      <Filter>src\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\test\lua\src\lzio.c">
+      <Filter>src\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\rcheevos\richpresence.c">
+      <Filter>src\rcheevos</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\rcheevos\memref.c">
+      <Filter>src\rcheevos</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\rcheevos\runtime.c">
+      <Filter>src\rcheevos</Filter>
+    </ClCompile>
+    <ClCompile Include="validator.c" />
+    <ClCompile Include="..\src\rhash\md5.c">
+      <Filter>src\rhash</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\src\rcheevos\internal.h">
+      <Filter>src\rcheevos</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\rcheevos.h">
+      <Filter>src\rcheevos</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Provides a way to quickly validate the syntax of all achievements/leaderboards and rich presence for a game given its patchdata json (obtainable from the RACache directory).
```
> validator f E:\RetroAchievements\RALibRetro\RACache\Data\11900.json
 rich presence 11900: Invalid constant operand
```
Can also be used to look at individual achievement or leaderboard definitions
```
> validator a 0xgood=1
Achievement: Invalid memory operand
```
Could be expanded in the future to look for logical errors, like comparing an 8-bit lookup to a 16-bit value.