### PR TITLE
also reset measured value when trigger is reset

### DIFF
--- a/src/rcheevos/condset.c
+++ b/src/rcheevos/condset.c
@@ -9,7 +9,7 @@ static void rc_update_condition_pause(rc_condition_t* condition, int* in_pause) 
     case RC_CONDITION_PAUSE_IF:
       *in_pause = condition->pause = 1;
       break;
-    
+
     case RC_CONDITION_ADD_SOURCE:
     case RC_CONDITION_SUB_SOURCE:
     case RC_CONDITION_ADD_HITS:
@@ -18,7 +18,7 @@ static void rc_update_condition_pause(rc_condition_t* condition, int* in_pause) 
     case RC_CONDITION_ADD_ADDRESS:
       condition->pause = *in_pause;
       break;
-    
+
     default:
       *in_pause = condition->pause = 0;
       break;
@@ -132,7 +132,7 @@ static int rc_test_condset_internal(rc_condset_t* self, int processing_pause, rc
         eval_state->add_value += rc_evaluate_condition_value(condition, eval_state);
         eval_state->add_address = 0;
         continue;
-      
+
       case RC_CONDITION_SUB_SOURCE:
         eval_state->add_value -= rc_evaluate_condition_value(condition, eval_state);
         eval_state->add_address = 0;
@@ -245,7 +245,7 @@ static int rc_test_condset_internal(rc_condset_t* self, int processing_pause, rc
         }
 
         continue;
-      
+
       case RC_CONDITION_RESET_IF:
         if (cond_valid) {
           eval_state->was_reset = 1; /* let caller know to reset all hit counts */
@@ -256,6 +256,7 @@ static int rc_test_condset_internal(rc_condset_t* self, int processing_pause, rc
       case RC_CONDITION_MEASURED:
         if (measured_value > eval_state->measured_value) {
           eval_state->measured_value = measured_value;
+          eval_state->measured_from_hits = (condition->required_hits != 0);
         }
         break;
 

--- a/src/rcheevos/internal.h
+++ b/src/rcheevos/internal.h
@@ -58,6 +58,7 @@ typedef struct {
   char was_reset;           /* ResetIf triggered */
   char has_hits;            /* one of more hit counts is non-zero */
   char primed;              /* true if all non-Trigger conditions are true */
+  char measured_from_hits;  /* true if the measured_value came from a condition's hit count */
 }
 rc_eval_state_t;
 

--- a/src/rcheevos/trigger.c
+++ b/src/rcheevos/trigger.c
@@ -33,7 +33,7 @@ void rc_parse_trigger_internal(rc_trigger_t* self, const char** memaddr, rc_pars
 
     next = &(*next)->next;
   }
-  
+
   *next = 0;
   *memaddr = aux;
 
@@ -59,7 +59,7 @@ rc_trigger_t* rc_parse_trigger(void* buffer, const char* memaddr, lua_State* L, 
   rc_trigger_t* self;
   rc_parse_state_t parse;
   rc_init_parse_state(&parse, buffer, L, funcs_ndx);
-  
+
   self = RC_ALLOC(rc_trigger_t, &parse);
   rc_init_parse_state_memrefs(&parse, &self->memrefs);
 
@@ -154,6 +154,10 @@ int rc_evaluate_trigger(rc_trigger_t* self, rc_peek_t peek, void* ud, lua_State*
   if (eval_state.was_reset) {
     /* if any ResetIf condition was true, reset the hit counts */
     rc_reset_trigger_hitcounts(self);
+
+    /* if the measured value came from a hit count, reset it too */
+    if (eval_state.measured_from_hits)
+      self->measured_value = 0;
 
     /* if there were hit counts to clear, return RESET, but don't change the state */
     if (self->has_hits) {

--- a/test/test.c
+++ b/test/test.c
@@ -833,7 +833,6 @@ static void test_richpresence(void) {
     /*------------------------------------------------------------------------
     TestTextAfterDisplay
     ------------------------------------------------------------------------*/
-    unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
     memory_t memory;
     rc_richpresence_t* richpresence;
 
@@ -841,7 +840,6 @@ static void test_richpresence(void) {
     rc_evaluate_richpresence(richpresence, output, sizeof(output), peek, &memory, NULL);
     assert(strcmp(output, "First") == 0);
   }
-
 
   {
     /*------------------------------------------------------------------------


### PR DESCRIPTION
Because resetting hit counts happens after the entire trigger has been processed, the measured value was captured before the hit counts were reset. This caused the measured value to be one frame behind the reset.

This PR adds an additional flag to the `rc_eval_state` that indicates when the measured value comes from a hit count so it can also be reset when the rest of the trigger is reset.