### PR TITLE
ignore header (if present) when hashing FDS files

### DIFF
--- a/src/rhash/hash.c
+++ b/src/rhash/hash.c
@@ -385,6 +385,13 @@ static int rc_hash_nes(char hash[33], uint8_t* buffer, size_t buffer_size)
     buffer += 16;
     buffer_size -= 16;
   }
+  else if (buffer[0] == 'F' && buffer[1] == 'D' && buffer[2] == 'S' && buffer[3] == 0x1A)
+  {
+      rc_hash_verbose("Ignoring FDS header");
+
+      buffer += 16;
+      buffer_size -= 16;
+  }
 
   return rc_hash_buffer(hash, buffer, buffer_size);
 }
@@ -814,7 +821,7 @@ static int rc_hash_whole_file(char hash[33], int console_id, const char* path)
   md5_state_t md5;
   uint8_t* buffer;
   size_t size;
-  const int buffer_size = 65536;
+  const size_t buffer_size = 65536;
   void* file_handle;
   int result = 0;
 
@@ -1311,7 +1318,10 @@ int rc_hash_iterate(char hash[33], struct rc_hash_iterator* iterator)
   {
     next_console = iterator->consoles[iterator->index];
     if (next_console == 0)
+    {
+      hash[0] = '\0';
       break;
+    }
 
     ++iterator->index;
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -6,7 +6,7 @@ LUA_SRC=lua/src
 OBJ=$(RC_SRC)/trigger.o $(RC_SRC)/condset.o $(RC_SRC)/condition.o $(RC_SRC)/operand.o \
     $(RC_SRC)/value.o $(RC_SRC)/lboard.o $(RC_SRC)/richpresence.o $(RC_SRC)/runtime.o \
     $(RC_SRC)/alloc.o $(RC_SRC)/memref.o $(RC_SRC)/format.o \
-    $(RC_HASH_SRC)/md5.o \
+    $(RC_HASH_SRC)/md5.o $(RC_HASH_SRC)/hash.o \
     $(RC_URL_SRC)/url.o \
     $(LUA_SRC)/lapi.o $(LUA_SRC)/lcode.o $(LUA_SRC)/lctype.o $(LUA_SRC)/ldebug.o \
     $(LUA_SRC)/ldo.o $(LUA_SRC)/ldump.o $(LUA_SRC)/lfunc.o $(LUA_SRC)/lgc.o $(LUA_SRC)/llex.o \
@@ -24,6 +24,8 @@ OBJ=$(RC_SRC)/trigger.o $(RC_SRC)/condset.o $(RC_SRC)/condition.o $(RC_SRC)/oper
     rcheevos/test_value.o \
     rcheevos/test_format.o \
     rcheevos/test_lboard.o \
+    rhash/data.o \
+    rhash/test_hash.o \
     test.o
 
 all: test

--- a/test/rcheevos-test.vcxproj
+++ b/test/rcheevos-test.vcxproj
@@ -76,6 +76,7 @@
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(ProjectDir)..\include;$(ProjectDir)..\src\rcheevos;$(ProjectDir)lua\src</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -99,6 +100,7 @@
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(ProjectDir)..\include;$(ProjectDir)..\src\rcheevos;$(ProjectDir)lua\src</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
@@ -132,6 +134,7 @@
     <ClCompile Include="..\src\rcheevos\runtime.c" />
     <ClCompile Include="..\src\rcheevos\trigger.c" />
     <ClCompile Include="..\src\rcheevos\value.c" />
+    <ClCompile Include="..\src\rhash\hash.c" />
     <ClCompile Include="..\src\rhash\md5.c" />
     <ClCompile Include="lua\src\lapi.c" />
     <ClCompile Include="lua\src\lauxlib.c" />
@@ -174,12 +177,16 @@
     <ClCompile Include="rcheevos\test_operand.c" />
     <ClCompile Include="rcheevos\test_trigger.c" />
     <ClCompile Include="rcheevos\test_value.c" />
+    <ClCompile Include="rhash\data.c" />
+    <ClCompile Include="rhash\test_hash.c" />
     <ClCompile Include="test.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\include\rcheevos.h" />
+    <ClInclude Include="..\include\rhash.h" />
     <ClInclude Include="..\src\rcheevos\internal.h" />
     <ClInclude Include="rcheevos\mock_memory.h" />
+    <ClInclude Include="rhash\data.h" />
     <ClInclude Include="test_framework.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/test/rcheevos-test.vcxproj.filters
+++ b/test/rcheevos-test.vcxproj.filters
@@ -19,6 +19,9 @@
     <Filter Include="tests\rcheevos">
       <UniqueIdentifier>{f890b4f1-8de5-4730-b612-3a7dbf65ca74}</UniqueIdentifier>
     </Filter>
+    <Filter Include="tests\rhash">
+      <UniqueIdentifier>{21341552-6b14-4f5b-a26c-d9393ffbdbcc}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\src\rcheevos\format.c">
@@ -183,6 +186,15 @@
     <ClCompile Include="rcheevos\test_lboard.c">
       <Filter>tests\rcheevos</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\rhash\hash.c">
+      <Filter>src\rhash</Filter>
+    </ClCompile>
+    <ClCompile Include="rhash\test_hash.c">
+      <Filter>tests\rhash</Filter>
+    </ClCompile>
+    <ClCompile Include="rhash\data.c">
+      <Filter>tests\rhash</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\src\rcheevos\internal.h">
@@ -196,6 +208,12 @@
     </ClInclude>
     <ClInclude Include="test_framework.h">
       <Filter>tests</Filter>
+    </ClInclude>
+    <ClInclude Include="rhash\data.h">
+      <Filter>tests\rhash</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\rhash.h">
+      <Filter>src\rhash</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/test/rhash/data.c
+++ b/test/rhash/data.c
@@ -1,0 +1,134 @@
+#include "data.h"
+
+#include <stdlib.h>
+
+static void fill_image(uint8_t* image, size_t size)
+{
+  int seed = size ^ (size >> 8) ^ ((size - 1) * 25387);
+  int count;
+  uint8_t value;
+
+  while (size > 0)
+  {
+    switch (seed & 0xFF)
+    {
+      case 0:
+        count = (((seed >> 8) & 0x3F) & ~(size & 0x0F));
+        if (count == 0)
+          count = 1;
+        value = 0;
+        break;
+
+      case 1:
+        count = ((seed >> 8) & 0x07) + 1;
+        value = ((seed >> 16) & 0xFF);
+        break;
+
+      case 2:
+        count = ((seed >> 8) & 0x03) + 1;
+        value = ((seed >> 16) & 0xFF) ^ 0xFF;
+        break;
+
+      case 3:
+        count = ((seed >> 8) & 0x03) + 1;
+        value = ((seed >> 16) & 0xFF) ^ 0xA5;
+        break;
+
+      case 4:
+        count = ((seed >> 8) & 0x03) + 1;
+        value = ((seed >> 16) & 0xFF) ^ 0xC3;
+        break;
+
+      case 5:
+        count = ((seed >> 8) & 0x03) + 1;
+        value = ((seed >> 16) & 0xFF) ^ 0x96;
+        break;
+
+      case 6:
+        count = ((seed >> 8) & 0x03) + 1;
+        value = ((seed >> 16) & 0xFF) ^ 0x78;
+        break;
+
+      case 7:
+        count = ((seed >> 8) & 0x03) + 1;
+        value = ((seed >> 16) & 0xFF) ^ 0x78;
+        break;
+
+      default:
+        count = 1;
+        value = (seed >> 8) ^ (seed >> 16);
+        break;
+    }
+
+    do
+    {
+      *image++ = value;
+      --size;
+    } while (size && --count);
+
+    /* state mutation from psuedo-random number generator */
+    seed = (seed * 0x41C64E6D + 12345) & 0x7FFFFFFF;
+  }
+}
+
+uint8_t* generate_nes_file(size_t kb, int with_header, size_t* image_size)
+{
+  uint8_t* image;
+  size_t size_needed = kb * 1024;
+  if (with_header)
+    size_needed += 16;
+
+  image = (uint8_t*)calloc(size_needed, 1);
+  if (image != NULL)
+  {
+    if (with_header)
+    {
+      image[0] = 'N';
+      image[1] = 'E';
+      image[2] = 'S';
+      image[3] = '\x1A';
+      image[4] = (uint8_t)(kb / 16);
+
+      fill_image(image + 16, size_needed - 16);
+    }
+    else
+    {
+      fill_image(image, size_needed);
+    }
+  }
+
+  if (image_size)
+    *image_size = size_needed;
+  return image;
+}
+
+uint8_t* generate_fds_file(size_t sides, int with_header, size_t* image_size)
+{
+  uint8_t* image;
+  size_t size_needed = sides * 65500;
+  if (with_header)
+    size_needed += 16;
+
+  image = (uint8_t*)calloc(size_needed, 1);
+  if (image != NULL)
+  {
+    if (with_header)
+    {
+      image[0] = 'F';
+      image[1] = 'D';
+      image[2] = 'S';
+      image[3] = '\x1A';
+      image[4] = (uint8_t)sides;
+
+      fill_image(image + 16, size_needed - 16);
+    }
+    else
+    {
+      fill_image(image, size_needed);
+    }
+  }
+
+  if (image_size)
+    *image_size = size_needed;
+  return image;
+}

--- a/test/rhash/data.h
+++ b/test/rhash/data.h
@@ -1,0 +1,17 @@
+#ifndef RHASH_TEST_DATA_H
+#define RHASH_TEST_DATA_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+uint8_t* generate_nes_file(size_t kb, int with_header, size_t* image_size);
+uint8_t* generate_fds_file(size_t sides, int with_header, size_t* image_size);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RHASH_TEST_DATA_H */

--- a/test/rhash/test_hash.c
+++ b/test/rhash/test_hash.c
@@ -1,0 +1,242 @@
+#include "rhash.h"
+
+#include "../test_framework.h"
+#include "data.h"
+
+#include <stdlib.h>
+
+
+typedef struct mock_file
+{
+  const char* path;
+  uint8_t* data;
+  size_t size;
+  size_t pos;
+} mock_file;
+
+static mock_file mock_file_instance;
+
+static void* mock_file_open(const char* path)
+{
+  if (strcmp(path, mock_file_instance.path) == 0)
+    return &mock_file_instance;
+
+  return NULL;
+}
+
+static void mock_file_seek(void* file_handle, size_t offset, int origin)
+{
+  mock_file* file = (mock_file*)file_handle;
+  switch (origin)
+  {
+    case SEEK_SET:
+      file->pos = offset;
+      break;
+    case SEEK_CUR:
+      file->pos += offset;
+      break;
+    case SEEK_END:
+      file->pos = file->size - offset;
+      break;
+  }
+}
+
+static size_t mock_file_tell(void* file_handle)
+{
+  mock_file* file = (mock_file*)file_handle;
+  return file->pos;
+}
+
+static size_t mock_file_read(void* file_handle, void* buffer, size_t count)
+{
+  mock_file* file = (mock_file*)file_handle;
+  size_t remaining = file->size - file->pos;
+  if (count > remaining)
+    count = remaining;
+
+  if (count > 0)
+  {
+    memcpy(buffer, &file->data[file->pos], count);
+    file->pos += count;
+  }
+
+  return count;
+}
+
+static void mock_file_close(void* file_handle)
+{
+}
+
+static void init_mock_filereader()
+{
+  struct rc_hash_filereader reader;
+  reader.open = mock_file_open;
+  reader.seek = mock_file_seek;
+  reader.tell = mock_file_tell;
+  reader.read = mock_file_read;
+  reader.close = mock_file_close;
+
+  rc_hash_init_custom_filereader(&reader);
+}
+
+static int hash_mock_file(const char* filename, char hash[33], int console_id, uint8_t* buffer, size_t buffer_size)
+{
+  mock_file_instance.path = filename;
+  mock_file_instance.data = buffer;
+  mock_file_instance.size = buffer_size;
+  mock_file_instance.pos = 0;
+
+  return rc_hash_generate_from_file(hash, console_id, filename);
+}
+
+static void iterate_mock_file(struct rc_hash_iterator *iterator, const char* filename, uint8_t* buffer, size_t buffer_size)
+{
+  mock_file_instance.path = filename;
+  mock_file_instance.data = buffer;
+  mock_file_instance.size = buffer_size;
+  mock_file_instance.pos = 0;
+
+  rc_hash_initialize_iterator(iterator, filename, NULL, 0);
+}
+
+
+/* ========================================================================= */
+
+static void test_hash_nes_32k()
+{
+  size_t image_size;
+  uint8_t* image = generate_nes_file(32, 0, &image_size);
+  char hash[33];
+  int result = rc_hash_generate_from_buffer(hash, RC_CONSOLE_NINTENDO, image, image_size);
+  free(image);
+
+  ASSERT_NUM_EQUALS(result, 1);
+  ASSERT_STR_EQUALS(hash, "6a2305a2b6675a97ff792709be1ca857");
+  ASSERT_NUM_EQUALS(image_size, 32768);
+}
+
+static void test_hash_nes_32k_with_header()
+{
+  size_t image_size;
+  uint8_t* image = generate_nes_file(32, 1, &image_size);
+  char hash[33];
+  int result = rc_hash_generate_from_buffer(hash, RC_CONSOLE_NINTENDO, image, image_size);
+  free(image);
+
+  /* NOTE: expectation is that this hash matches the hash in test_hash_nes_32k */
+  ASSERT_NUM_EQUALS(result, 1);
+  ASSERT_STR_EQUALS(hash, "6a2305a2b6675a97ff792709be1ca857");
+  ASSERT_NUM_EQUALS(image_size, 32768 + 16);
+}
+
+static void test_hash_nes_256k()
+{
+  size_t image_size;
+  uint8_t* image = generate_nes_file(256, 0, &image_size);
+  char hash[33];
+  int result = rc_hash_generate_from_buffer(hash, RC_CONSOLE_NINTENDO, image, image_size);
+  free(image);
+
+  ASSERT_NUM_EQUALS(result, 1);
+  ASSERT_STR_EQUALS(hash, "545d527301b8ae148153988d6c4fcb84");
+  ASSERT_NUM_EQUALS(image_size, 262144);
+}
+
+static void test_hash_fds_two_sides()
+{
+  size_t image_size;
+  uint8_t* image = generate_fds_file(2, 0, &image_size);
+  char hash[33];
+  int result = rc_hash_generate_from_buffer(hash, RC_CONSOLE_NINTENDO, image, image_size);
+  free(image);
+
+  ASSERT_NUM_EQUALS(result, 1);
+  ASSERT_STR_EQUALS(hash, "fd770d4d34c00760fabda6ad294a8f0b");
+  ASSERT_NUM_EQUALS(image_size, 65500 * 2);
+}
+
+static void test_hash_fds_two_sides_with_header()
+{
+  size_t image_size;
+  uint8_t* image = generate_fds_file(2, 1, &image_size);
+  char hash[33];
+  int result = rc_hash_generate_from_buffer(hash, RC_CONSOLE_NINTENDO, image, image_size);
+  free(image);
+
+  /* NOTE: expectation is that this hash matches the hash in test_hash_fds_two_sides */
+  ASSERT_NUM_EQUALS(result, 1);
+  ASSERT_STR_EQUALS(hash, "fd770d4d34c00760fabda6ad294a8f0b");
+  ASSERT_NUM_EQUALS(image_size, 65500 * 2 + 16);
+}
+
+static void test_hash_nes_file_32k()
+{
+  size_t image_size;
+  uint8_t* image = generate_nes_file(32, 0, &image_size);
+  char hash[33];
+  int result = hash_mock_file("test.nes", hash, RC_CONSOLE_NINTENDO, image, image_size);
+  free(image);
+
+  ASSERT_NUM_EQUALS(result, 1);
+  ASSERT_STR_EQUALS(hash, "6a2305a2b6675a97ff792709be1ca857");
+  ASSERT_NUM_EQUALS(image_size, 32768);
+}
+
+static void test_hash_nes_iterator_32k()
+{
+    size_t image_size;
+    uint8_t* image = generate_nes_file(32, 0, &image_size);
+    char hash1[33], hash2[33];
+    int result1, result2;
+    struct rc_hash_iterator iterator;
+    iterate_mock_file(&iterator, "test.nes", image, image_size);
+    result1 = rc_hash_iterate(hash1, &iterator);
+    result2 = rc_hash_iterate(hash2, &iterator);
+    rc_hash_destroy_iterator(&iterator);
+    free(image);
+
+    ASSERT_NUM_EQUALS(result1, 1);
+    ASSERT_STR_EQUALS(hash1, "6a2305a2b6675a97ff792709be1ca857");
+
+    ASSERT_NUM_EQUALS(result2, 0);
+    ASSERT_STR_EQUALS(hash2, "");
+}
+
+static void test_hash_nes_file_iterator_32k()
+{
+  size_t image_size;
+  uint8_t* image = generate_nes_file(32, 0, &image_size);
+  char hash1[33], hash2[33];
+  int result1, result2;
+  struct rc_hash_iterator iterator;
+  rc_hash_initialize_iterator(&iterator, "test.nes", image, image_size);
+  result1 = rc_hash_iterate(hash1, &iterator);
+  result2 = rc_hash_iterate(hash2, &iterator);
+  rc_hash_destroy_iterator(&iterator);
+  free(image);
+
+  ASSERT_NUM_EQUALS(result1, 1);
+  ASSERT_STR_EQUALS(hash1, "6a2305a2b6675a97ff792709be1ca857");
+
+  ASSERT_NUM_EQUALS(result2, 0);
+  ASSERT_STR_EQUALS(hash2, "");
+}
+
+void test_hash(void) {
+  TEST_SUITE_BEGIN();
+
+  init_mock_filereader();
+
+  /* NES */
+  TEST(test_hash_nes_32k);
+  TEST(test_hash_nes_32k_with_header);
+  TEST(test_hash_nes_256k);
+  TEST(test_hash_fds_two_sides);
+  TEST(test_hash_fds_two_sides_with_header);
+
+  TEST(test_hash_nes_file_32k);
+  TEST(test_hash_nes_file_iterator_32k);
+  TEST(test_hash_nes_iterator_32k);
+
+  TEST_SUITE_END();
+}

--- a/test/test.c
+++ b/test/test.c
@@ -1666,6 +1666,8 @@ extern void test_value();
 extern void test_format();
 extern void test_lboard();
 
+extern void test_hash();
+
 TEST_FRAMEWORK_DECLARATIONS()
 
 int main(void) {
@@ -1683,6 +1685,8 @@ int main(void) {
   test_richpresence();
   test_runtime();
   test_lua();
+
+  test_hash();
 
   TEST_FRAMEWORK_SHUTDOWN();
 


### PR DESCRIPTION
for ralibretro and rahasher. ranes already does this.