### PR TITLE
store console names and memory map information in rcheevos

### DIFF
--- a/include/rcheevos.h
+++ b/include/rcheevos.h
@@ -469,6 +469,37 @@ typedef void (*rc_runtime_event_handler_t)(const rc_runtime_event_t* runtime_eve
 void rc_runtime_do_frame(rc_runtime_t* runtime, rc_runtime_event_handler_t event_handler, rc_peek_t peek, void* ud, lua_State* L);
 void rc_runtime_reset(rc_runtime_t* runtime);
 
+/*****************************************************************************\
+| Memory mapping                                                              |
+\*****************************************************************************/
+
+enum {
+  RC_MEMORY_TYPE_SYSTEM_RAM,          /* normal system memory */
+  RC_MEMORY_TYPE_SAVE_RAM,            /* memory that persists between sessions */
+  RC_MEMORY_TYPE_VIDEO_RAM,           /* memory reserved for graphical processing */
+  RC_MEMORY_TYPE_READONLY,            /* memory that maps to read only data */
+  RC_MEMORY_TYPE_HARDWARE_CONTROLLER, /* memory for interacting with system components */
+  RC_MEMORY_TYPE_VIRTUAL_RAM,         /* secondary address space that maps to real memory in system RAM */
+  RC_MEMORY_TYPE_UNUSED               /* these addresses don't really exist */
+};
+
+typedef struct rc_memory_region_t {
+  unsigned start_address;             /* first address of block as queried by RetroAchievements */
+  unsigned end_address;               /* last address of block as queried by RetroAchievements */
+  unsigned real_address;              /* real address for first address of block */
+  char type;                          /* RC_MEMORY_TYPE_ for block */
+  const char* description;            /* short description of block */
+}
+rc_memory_region_t;
+
+typedef struct rc_memory_regions_t {
+  const rc_memory_region_t* region;
+  unsigned num_regions;
+}
+rc_memory_regions_t;
+
+const rc_memory_regions_t* rc_console_memory_regions(int console_id);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/rconsoles.h
+++ b/include/rconsoles.h
@@ -32,7 +32,7 @@ enum {
   RC_CONSOLE_WII_U = 20,
   RC_CONSOLE_PLAYSTATION_2 = 21,
   RC_CONSOLE_XBOX = 22,
-  RC_CONSOLE_SKYNET = 23,
+  RC_CONSOLE_EVENTS = 23,
   RC_CONSOLE_POKEMON_MINI = 24,
   RC_CONSOLE_ATARI_2600 = 25,
   RC_CONSOLE_MS_DOS = 26,
@@ -66,6 +66,8 @@ enum {
   RC_CONSOLE_CASSETTEVISION = 54,
   RC_CONSOLE_SUPER_CASSETTEVISION = 55
 };
+
+const char* rc_console_name(int console_id);
 
 #ifdef __cplusplus
 }

--- a/src/rcheevos/consoleinfo.c
+++ b/src/rcheevos/consoleinfo.c
@@ -1,3 +1,4 @@
+#include "rcheevos.h"
 #include "rconsoles.h"
 
 #include <ctype.h>
@@ -173,5 +174,377 @@ const char* rc_console_name(int console_id)
 
     default:
       return "Unknown";
+  }
+}
+
+/* ===== Apple II ===== */
+static const rc_memory_region_t _rc_memory_regions_appleii[] = {
+    { 0x000000U, 0x00FFFFU, 0x000000U, RC_MEMORY_TYPE_SYSTEM_RAM, "Main RAM" },
+    { 0x010000U, 0x01FFFFU, 0x010000U, RC_MEMORY_TYPE_SYSTEM_RAM, "Auxillary RAM" }
+};
+static const rc_memory_regions_t rc_memory_regions_appleii = { _rc_memory_regions_appleii, 2 };
+
+/* ===== Atari 2600 ===== */
+static const rc_memory_region_t _rc_memory_regions_atari2600[] = {
+    { 0x000000U, 0x00007FU, 0x000080U, RC_MEMORY_TYPE_SYSTEM_RAM, "System RAM" }
+};
+static const rc_memory_regions_t rc_memory_regions_atari2600 = { _rc_memory_regions_atari2600, 1 };
+
+/* ===== Atari 7800 ===== */
+/* http://www.atarihq.com/danb/files/78map.txt */
+/* http://pdf.textfiles.com/technical/7800_devkit.pdf */
+static const rc_memory_region_t _rc_memory_regions_atari7800[] = {
+    { 0x000000U, 0x0017FFU, 0x000000U, RC_MEMORY_TYPE_HARDWARE_CONTROLLER, "Hardware Interface" },
+    { 0x001800U, 0x0027FFU, 0x001800U, RC_MEMORY_TYPE_SYSTEM_RAM, "System RAM" },
+    { 0x002800U, 0x002FFFU, 0x002800U, RC_MEMORY_TYPE_VIRTUAL_RAM, "Mirrored RAM" },
+    { 0x003000U, 0x0037FFU, 0x003000U, RC_MEMORY_TYPE_VIRTUAL_RAM, "Mirrored RAM" },
+    { 0x003800U, 0x003FFFU, 0x003800U, RC_MEMORY_TYPE_VIRTUAL_RAM, "Mirrored RAM" },
+    { 0x004000U, 0x007FFFU, 0x004000U, RC_MEMORY_TYPE_SAVE_RAM, "Cartridge RAM" },
+    { 0x008000U, 0x00FFFFU, 0x008000U, RC_MEMORY_TYPE_READONLY, "Cartridge ROM" }
+};
+static const rc_memory_regions_t rc_memory_regions_atari7800 = { _rc_memory_regions_atari7800, 7 };
+
+/* ===== Atari Jaguar ===== */
+/* https://www.mulle-kybernetik.com/jagdox/memorymap.html */
+static const rc_memory_region_t _rc_memory_regions_atari_jaguar[] = {
+    { 0x000000U, 0x1FFFFFU, 0x000000U, RC_MEMORY_TYPE_SYSTEM_RAM, "System RAM" }
+};
+static const rc_memory_regions_t rc_memory_regions_atari_jaguar = { _rc_memory_regions_atari_jaguar, 1 };
+
+/* ===== Atari Lynx ===== */
+/* http://www.retroisle.com/atari/lynx/Technical/Programming/lynxprgdumm.php */
+static const rc_memory_region_t _rc_memory_regions_atari_lynx[] = {
+    { 0x000000U, 0x0000FFU, 0x000000U, RC_MEMORY_TYPE_SYSTEM_RAM, "Zero Page" },
+    { 0x000100U, 0x0001FFU, 0x000100U, RC_MEMORY_TYPE_SYSTEM_RAM, "Stack" },
+    { 0x000200U, 0x00FBFFU, 0x000200U, RC_MEMORY_TYPE_SYSTEM_RAM, "System RAM" },
+    { 0x00FC00U, 0x00FCFFU, 0x00FC00U, RC_MEMORY_TYPE_HARDWARE_CONTROLLER, "SUZY hardware access" },
+    { 0x00FD00U, 0x00FDFFU, 0x00FD00U, RC_MEMORY_TYPE_HARDWARE_CONTROLLER, "MIKEY hardware access" },
+    { 0x00FE00U, 0x00FFF7U, 0x00FE00U, RC_MEMORY_TYPE_HARDWARE_CONTROLLER, "Boot ROM" },
+    { 0x00FFF8U, 0x00FFFFU, 0x00FFF8U, RC_MEMORY_TYPE_HARDWARE_CONTROLLER, "Hardware vectors" }
+};
+static const rc_memory_regions_t rc_memory_regions_atari_lynx = { _rc_memory_regions_atari_lynx, 7 };
+
+/* ===== ColecoVision ===== */
+static const rc_memory_region_t _rc_memory_regions_colecovision[] = {
+    { 0x000000U, 0x0003FFU, 0x006000U, RC_MEMORY_TYPE_SYSTEM_RAM, "System RAM" }
+};
+static const rc_memory_regions_t rc_memory_regions_colecovision = { _rc_memory_regions_colecovision, 1 };
+
+/* ===== GameBoy / GameBoy Color ===== */
+static const rc_memory_region_t _rc_memory_regions_gameboy[] = {
+    { 0x000000U, 0x0000FFU, 0x000000U, RC_MEMORY_TYPE_HARDWARE_CONTROLLER, "Interrupt vector" },
+    { 0x000100U, 0x00014FU, 0x000100U, RC_MEMORY_TYPE_READONLY, "Cartridge header" },
+    { 0x000150U, 0x003FFFU, 0x000150U, RC_MEMORY_TYPE_READONLY, "Cartridge ROM (fixed)" }, /* bank 0 */
+    { 0x004000U, 0x007FFFU, 0x004000U, RC_MEMORY_TYPE_READONLY, "Cartridge ROM (paged)" }, /* bank 1-XX (switchable) */
+    { 0x008000U, 0x0097FFU, 0x008000U, RC_MEMORY_TYPE_VIDEO_RAM, "Tile RAM" },
+    { 0x009800U, 0x009BFFU, 0x009800U, RC_MEMORY_TYPE_VIDEO_RAM, "BG1 map data" },
+    { 0x009C00U, 0x009FFFU, 0x009C00U, RC_MEMORY_TYPE_VIDEO_RAM, "BG2 map data" },
+    { 0x00A000U, 0x00BFFFU, 0x00A000U, RC_MEMORY_TYPE_SAVE_RAM, "Cartridge RAM"},
+    { 0x00C000U, 0x00CFFFU, 0x00C000U, RC_MEMORY_TYPE_SYSTEM_RAM, "System RAM (fixed)" },
+    { 0x00D000U, 0x00DFFFU, 0x00D000U, RC_MEMORY_TYPE_SYSTEM_RAM, "System RAM (bank 1)" },
+    { 0x00E000U, 0x00FDFFU, 0x00E000U, RC_MEMORY_TYPE_VIRTUAL_RAM, "Echo RAM" },
+    { 0x00FE00U, 0x00FE9FU, 0x00FE00U, RC_MEMORY_TYPE_VIDEO_RAM, "Sprite RAM"},
+    { 0x00FEA0U, 0x00FEFFU, 0x00FEA0U, RC_MEMORY_TYPE_READONLY, "Unusable"},
+    { 0x00FF00U, 0x00FF7FU, 0x00FF00U, RC_MEMORY_TYPE_HARDWARE_CONTROLLER, "Hardware I/O"},
+    { 0x00FF80U, 0x00FFFEU, 0x00FF80U, RC_MEMORY_TYPE_SYSTEM_RAM, "Quick RAM"},
+    { 0x00FFFFU, 0x00FFFFU, 0x00FFFFU, RC_MEMORY_TYPE_HARDWARE_CONTROLLER, "Interrupt enable"},
+    { 0x010000U, 0x015FFFU, 0x010000U, RC_MEMORY_TYPE_SYSTEM_RAM, "System RAM (banks 2-7, GBC only)" }
+};
+static const rc_memory_regions_t rc_memory_regions_gameboy = { _rc_memory_regions_gameboy, 16 };
+static const rc_memory_regions_t rc_memory_regions_gameboy_color = { _rc_memory_regions_gameboy, 17 };
+
+/* ===== GameBoy Advance ===== */
+static const rc_memory_region_t _rc_memory_regions_gameboy_advance[] = {
+    { 0x000000U, 0x007FFFU, 0x03000000U, RC_MEMORY_TYPE_SAVE_RAM, "Cartridge RAM" },
+    { 0x008000U, 0x047FFFU, 0x02000000U, RC_MEMORY_TYPE_SYSTEM_RAM, "System RAM" }
+};
+static const rc_memory_regions_t rc_memory_regions_gameboy_advance = { _rc_memory_regions_gameboy_advance, 2 };
+
+/* ===== Game Gear ===== */
+/* http://www.smspower.org/Development/MemoryMap */
+static const rc_memory_region_t _rc_memory_regions_game_gear[] = {
+    { 0x000000U, 0x001FFFU, 0x00C000U, RC_MEMORY_TYPE_SYSTEM_RAM, "System RAM" }
+};
+static const rc_memory_regions_t rc_memory_regions_game_gear = { _rc_memory_regions_game_gear, 1 };
+
+/* ===== Intellivision ===== */
+/* http://wiki.intellivision.us/index.php%3Ftitle%3DMemory_Map */
+static const rc_memory_region_t _rc_memory_regions_intellivision[] = {
+    { 0x000000U, 0x00007FU, 0x000000U, RC_MEMORY_TYPE_VIDEO_RAM, "STIC Registers" },
+    { 0x000080U, 0x0000FFU, 0x000080U, RC_MEMORY_TYPE_UNUSED, "" },
+    { 0x000100U, 0x00035FU, 0x000100U, RC_MEMORY_TYPE_SYSTEM_RAM, "System RAM" },
+    { 0x000360U, 0x0003FFU, 0x000360U, RC_MEMORY_TYPE_UNUSED, "" },
+    { 0x000400U, 0x000FFFU, 0x000400U, RC_MEMORY_TYPE_SYSTEM_RAM, "Cartridge RAM" },
+    { 0x001000U, 0x001FFFU, 0x001000U, RC_MEMORY_TYPE_UNUSED, "" },
+    { 0x002000U, 0x002FFFU, 0x002000U, RC_MEMORY_TYPE_SYSTEM_RAM, "Cartridge RAM" },
+    { 0x003000U, 0x003FFFU, 0x003000U, RC_MEMORY_TYPE_VIDEO_RAM, "Video RAM" },
+    { 0x004000U, 0x00FFFFU, 0x004000U, RC_MEMORY_TYPE_SYSTEM_RAM, "Cartridge RAM" },
+};
+static const rc_memory_regions_t rc_memory_regions_intellivision = { _rc_memory_regions_intellivision, 9 };
+
+/* ===== Master System ===== */
+/* http://www.smspower.org/Development/MemoryMap */
+static const rc_memory_region_t _rc_memory_regions_master_system[] = {
+    { 0x000000U, 0x001FFFU, 0x00C000U, RC_MEMORY_TYPE_SYSTEM_RAM, "System RAM" }
+};
+static const rc_memory_regions_t rc_memory_regions_master_system = { _rc_memory_regions_master_system, 1 };
+
+/* ===== MegaDrive (Genesis) ===== */
+/* http://www.smspower.org/Development/MemoryMap */
+static const rc_memory_region_t _rc_memory_regions_megadrive[] = {
+    { 0x000000U, 0x00FFFFU, 0xFF0000U, RC_MEMORY_TYPE_SYSTEM_RAM, "System RAM" },
+    { 0x010000U, 0x01FFFFU, 0x000000U, RC_MEMORY_TYPE_SAVE_RAM, "Cartridge RAM" }
+};
+static const rc_memory_regions_t rc_memory_regions_megadrive = { _rc_memory_regions_megadrive, 2 };
+
+/* ===== Neo Geo Pocket ===== */
+/* http://neopocott.emuunlim.com/docs/tech-11.txt */
+static const rc_memory_region_t _rc_memory_regions_neo_geo_pocket[] = {
+    /* MednafenNGP exposes 16KB, but the doc suggests there's 24-32KB */
+    { 0x000000U, 0x003FFFU, 0x000000U, RC_MEMORY_TYPE_SYSTEM_RAM, "System RAM" }
+};
+static const rc_memory_regions_t rc_memory_regions_neo_geo_pocket = { _rc_memory_regions_neo_geo_pocket, 1 };
+
+/* ===== Nintendo Entertainment System ===== */
+/* https://wiki.nesdev.com/w/index.php/CPU_memory_map */
+static const rc_memory_region_t _rc_memory_regions_nes[] = {
+    { 0x0000U, 0x07FFU, 0x0000U, RC_MEMORY_TYPE_SYSTEM_RAM, "System RAM" },
+    { 0x0800U, 0x0FFFU, 0x0800U, RC_MEMORY_TYPE_VIRTUAL_RAM, "Mirror RAM" }, /* duplicates memory from $0000-$07FF */
+    { 0x1000U, 0x17FFU, 0x1000U, RC_MEMORY_TYPE_VIRTUAL_RAM, "Mirror RAM" }, /* duplicates memory from $0000-$07FF */
+    { 0x1800U, 0x1FFFU, 0x1800U, RC_MEMORY_TYPE_VIRTUAL_RAM, "Mirror RAM" }, /* duplicates memory from $0000-$07FF */
+    { 0x2000U, 0x2007U, 0x2000U, RC_MEMORY_TYPE_HARDWARE_CONTROLLER, "PPU Register" },
+    { 0x2008U, 0x3FFFU, 0x2008U, RC_MEMORY_TYPE_VIRTUAL_RAM, "Mirrored PPU Register" }, /* repeats every 8 bytes */
+    { 0x4000U, 0x4017U, 0x4000U, RC_MEMORY_TYPE_HARDWARE_CONTROLLER, "APU and I/O register" },
+    { 0x4018U, 0x401FU, 0x4018U, RC_MEMORY_TYPE_HARDWARE_CONTROLLER, "APU and I/O test register" },
+    { 0x4020U, 0x5FFFU, 0x4020U, RC_MEMORY_TYPE_READONLY, "Cartridge data"}, /* varies by mapper */
+    { 0x6000U, 0x7FFFU, 0x6000U, RC_MEMORY_TYPE_SAVE_RAM, "Cartridge RAM"},
+    { 0x8000U, 0xFFFFU, 0x8000U, RC_MEMORY_TYPE_READONLY, "Cartridge ROM"},
+};
+static const rc_memory_regions_t rc_memory_regions_nes = { _rc_memory_regions_nes, 11 };
+
+/* ===== Nintendo 64 ===== */
+/* https://raw.githubusercontent.com/mikeryan/n64dev/master/docs/n64ops/n64ops%23h.txt */
+static const rc_memory_region_t _rc_memory_regions_n64[] = {
+    { 0x000000U, 0x1FFFFFU, 0x00000000U, RC_MEMORY_TYPE_SYSTEM_RAM, "System RAM" }, /* RDRAM 1 */
+    { 0x200000U, 0x3FFFFFU, 0x00020000U, RC_MEMORY_TYPE_SYSTEM_RAM, "System RAM" }, /* RDRAM 2 */
+    { 0x400000U, 0x7FFFFFU, 0x80000000U, RC_MEMORY_TYPE_SYSTEM_RAM, "System RAM" }  /* expansion pak - cannot find any details for real address */
+};
+static const rc_memory_regions_t rc_memory_regions_n64 = { _rc_memory_regions_n64, 3 };
+
+/* ===== Nintendo DS ===== */
+/* https://www.akkit.org/info/gbatek.htm#dsmemorymaps */
+static const rc_memory_region_t _rc_memory_regions_nintendo_ds[] = {
+    { 0x000000U, 0x3FFFFFU, 0x02000000U, RC_MEMORY_TYPE_SYSTEM_RAM, "System RAM" }
+};
+static const rc_memory_regions_t rc_memory_regions_nintendo_ds = { _rc_memory_regions_nintendo_ds, 1 };
+
+/* ===== Oric ===== */
+static const rc_memory_region_t _rc_memory_regions_oric[] = {
+    /* actual size depends on machine type - up to 64KB */
+    { 0x000000U, 0x00FFFFU, 0x000000U, RC_MEMORY_TYPE_SYSTEM_RAM, "System RAM" }
+};
+static const rc_memory_regions_t rc_memory_regions_oric = { _rc_memory_regions_oric, 1 };
+
+/* ===== PC-8800 ===== */
+static const rc_memory_region_t _rc_memory_regions_pc8800[] = {
+    { 0x000000U, 0x00FFFFU, 0x000000U, RC_MEMORY_TYPE_SYSTEM_RAM, "Main RAM" },
+    { 0x010000U, 0x010FFFU, 0x010000U, RC_MEMORY_TYPE_VIDEO_RAM, "Text VRAM" } /* technically VRAM, but often used as system RAM */
+};
+static const rc_memory_regions_t rc_memory_regions_pc8800 = { _rc_memory_regions_pc8800, 2 };
+
+/* ===== PC Engine ===== */
+static const rc_memory_region_t _rc_memory_regions_pcengine[] = {
+    { 0x000000U, 0x001FFFU, 0x1F0000U, RC_MEMORY_TYPE_SYSTEM_RAM, "System RAM" },
+    { 0x002000U, 0x011FFFU, 0x100000U, RC_MEMORY_TYPE_SYSTEM_RAM, "CD RAM" },
+    { 0x012000U, 0x041FFFU, 0x0D0000U, RC_MEMORY_TYPE_SYSTEM_RAM, "Super System Card RAM" },
+    { 0x042000U, 0x0427FFU, 0x1EE000U, RC_MEMORY_TYPE_SAVE_RAM,   "CD Battery-backed RAM" }
+};
+static const rc_memory_regions_t rc_memory_regions_pcengine = { _rc_memory_regions_pcengine, 4 };
+
+/* ===== PlayStation ===== */
+/* http://www.raphnet.net/electronique/psx_adaptor/Playstation.txt */
+static const rc_memory_region_t _rc_memory_regions_playstation[] = {
+    { 0x000000U, 0x00FFFFU, 0x000000U, RC_MEMORY_TYPE_SYSTEM_RAM, "Kernel RAM" },
+    { 0x010000U, 0x1FFFFFU, 0x010000U, RC_MEMORY_TYPE_SYSTEM_RAM, "System RAM" }
+};
+static const rc_memory_regions_t rc_memory_regions_playstation = { _rc_memory_regions_playstation, 2 };
+
+/* ===== Pokemon Mini ===== */
+/* https://www.pokemon-mini.net/documentation/memory-map/ */
+static const rc_memory_region_t _rc_memory_regions_pokemini[] = {
+    { 0x000000U, 0x000FFFU, 0x000000U, RC_MEMORY_TYPE_SYSTEM_RAM, "BIOS RAM" },
+    { 0x001000U, 0x001FFFU, 0x001000U, RC_MEMORY_TYPE_SYSTEM_RAM, "System RAM" }
+};
+static const rc_memory_regions_t rc_memory_regions_pokemini = { _rc_memory_regions_pokemini, 2 };
+
+/* ===== Sega CD ===== */
+static const rc_memory_region_t _rc_memory_regions_segacd[] = {
+    { 0x000000U, 0x00FFFFU, 0x00FF0000U, RC_MEMORY_TYPE_SYSTEM_RAM, "68000 RAM" },
+    { 0x010000U, 0x08FFFFU, 0x80000000U, RC_MEMORY_TYPE_SAVE_RAM, "CD PRG RAM" } /* normally banked into $020000-$03FFFF */
+};
+static const rc_memory_regions_t rc_memory_regions_segacd = { _rc_memory_regions_segacd, 2 };
+
+/* ===== Sega Saturn ===== */
+/* https://segaretro.org/Sega_Saturn_hardware_notes_(2004-04-27) */
+static const rc_memory_region_t _rc_memory_regions_saturn[] = {
+    { 0x000000U, 0x0FFFFFU, 0x00200000U, RC_MEMORY_TYPE_SYSTEM_RAM, "Work RAM Low" },
+    { 0x100000U, 0x1FFFFFU, 0x06000000U, RC_MEMORY_TYPE_SAVE_RAM, "Work RAM High" }
+};
+static const rc_memory_regions_t rc_memory_regions_saturn = { _rc_memory_regions_saturn, 2 };
+
+/* ===== SG-1000 ===== */
+/* http://www.smspower.org/Development/MemoryMap */
+static const rc_memory_region_t _rc_memory_regions_sg1000[] = {
+    { 0x000000U, 0x0003FFU, 0xC000U, RC_MEMORY_TYPE_SYSTEM_RAM, "System RAM" }
+    /* TODO: should cartridge memory be exposed ($0000-$BFFF)? it's usually just ROM data, but may contain on-cartridge RAM
+     * This not is also concerning: http://www.smspower.org/Development/MemoryMap
+     *   Cartridges may disable the system RAM and thus take over the full 64KB address space. */
+};
+static const rc_memory_regions_t rc_memory_regions_sg1000 = { _rc_memory_regions_sg1000, 1 };
+
+/* ===== Super Cassette Vision ===== */
+static const rc_memory_region_t _rc_memory_regions_scv[] = {
+    { 0x000000U, 0x000FFFU, 0x000000U, RC_MEMORY_TYPE_READONLY, "System ROM" },
+    { 0x001000U, 0x001FFFU, 0x001000U, RC_MEMORY_TYPE_UNUSED, "" },
+    { 0x002000U, 0x003FFFU, 0x002000U, RC_MEMORY_TYPE_VIDEO_RAM, "Video RAM" },
+    { 0x004000U, 0x007FFFU, 0x004000U, RC_MEMORY_TYPE_UNUSED, "" },
+    { 0x008000U, 0x00DFFFU, 0x008000U, RC_MEMORY_TYPE_READONLY, "Cartridge ROM" },
+    { 0x00E000U, 0x00FF7FU, 0x00E000U, RC_MEMORY_TYPE_SAVE_RAM, "Cartridge RAM" },
+    { 0x00FF80U, 0x00FFFFU, 0x00FF80U, RC_MEMORY_TYPE_SYSTEM_RAM, "System RAM" }
+};
+static const rc_memory_regions_t rc_memory_regions_scv = { _rc_memory_regions_scv, 7 };
+
+/* ===== Super Nintendo ===== */
+/* https://segaretro.org/Sega_Saturn_hardware_notes_(2004-04-27) */
+static const rc_memory_region_t _rc_memory_regions_snes[] = {
+    { 0x000000U, 0x01FFFFU, 0x7E0000U, RC_MEMORY_TYPE_SYSTEM_RAM, "System RAM" },
+    { 0x020000U, 0x03FFFFU, 0xFE0000U, RC_MEMORY_TYPE_SAVE_RAM, "Cartridge RAM" }
+};
+static const rc_memory_regions_t rc_memory_regions_snes = { _rc_memory_regions_snes, 2 };
+
+/* ===== WonderSwan ===== */
+/* http://daifukkat.su/docs/wsman/#ovr_memmap */
+static const rc_memory_region_t _rc_memory_regions_wonderswan[] = {
+    /* RAM ends at 0x3FFF for WonderSwan, WonderSwan color uses all 64KB */
+    { 0x000000U, 0x00FFFFU, 0x000000U, RC_MEMORY_TYPE_SYSTEM_RAM, "System RAM" }
+};
+static const rc_memory_regions_t rc_memory_regions_wonderswan = { _rc_memory_regions_wonderswan, 1 };
+
+/* ===== Vectrex ===== */
+/* https://roadsidethoughts.com/vectrex/vectrex-memory-map.htm */
+static const rc_memory_region_t _rc_memory_regions_vectrex[] = {
+    { 0x000000U, 0x0003FFU, 0x00C800U, RC_MEMORY_TYPE_SYSTEM_RAM, "System RAM" }
+};
+static const rc_memory_regions_t rc_memory_regions_vectrex = { _rc_memory_regions_vectrex, 1 };
+
+/* ===== Virtual Boy ===== */
+static const rc_memory_region_t _rc_memory_regions_virtualboy[] = {
+    { 0x000000U, 0x00FFFFU, 0x05000000U, RC_MEMORY_TYPE_SYSTEM_RAM, "System RAM" },
+    { 0x010000U, 0x01FFFFU, 0x06000000U, RC_MEMORY_TYPE_SAVE_RAM, "Cartridge RAM" }
+};
+static const rc_memory_regions_t rc_memory_regions_virtualboy = { _rc_memory_regions_virtualboy, 2 };
+
+/* ===== default ===== */
+static const rc_memory_regions_t rc_memory_regions_none = { 0, 0 };
+
+const rc_memory_regions_t* rc_console_memory_regions(int console_id)
+{
+  switch (console_id)
+  {
+    case RC_CONSOLE_APPLE_II:
+      return &rc_memory_regions_appleii;
+
+    case RC_CONSOLE_ATARI_2600:
+      return &rc_memory_regions_atari2600;
+
+    case RC_CONSOLE_ATARI_7800:
+      return &rc_memory_regions_atari7800;
+
+    case RC_CONSOLE_ATARI_JAGUAR:
+      return &rc_memory_regions_atari_jaguar;
+
+    case RC_CONSOLE_ATARI_LYNX:
+      return &rc_memory_regions_atari_lynx;
+
+    case RC_CONSOLE_COLECOVISION:
+      return &rc_memory_regions_colecovision;
+
+    case RC_CONSOLE_GAMEBOY:
+      return &rc_memory_regions_gameboy;
+
+    case RC_CONSOLE_GAMEBOY_COLOR:
+      return &rc_memory_regions_gameboy_color;
+
+    case RC_CONSOLE_GAMEBOY_ADVANCE:
+      return &rc_memory_regions_gameboy_advance;
+
+    case RC_CONSOLE_GAME_GEAR:
+      return &rc_memory_regions_game_gear;
+
+    case RC_CONSOLE_INTELLIVISION:
+      return &rc_memory_regions_intellivision;
+
+    case RC_CONSOLE_MASTER_SYSTEM:
+      return &rc_memory_regions_master_system;
+
+    case RC_CONSOLE_MEGA_DRIVE:
+    case RC_CONSOLE_SEGA_32X:
+      /* NOTE: 32x adds an extra 512KB of memory (256KB RAM + 256KB VRAM) to the 
+       *       Genesis, but we currently don't support it. */
+      return &rc_memory_regions_megadrive;
+
+    case RC_CONSOLE_NEOGEO_POCKET:
+      return &rc_memory_regions_neo_geo_pocket;
+
+    case RC_CONSOLE_NINTENDO:
+      return &rc_memory_regions_nes;
+
+    case RC_CONSOLE_NINTENDO_64:
+      return &rc_memory_regions_n64;
+
+    case RC_CONSOLE_NINTENDO_DS:
+      return &rc_memory_regions_nintendo_ds;
+
+    case RC_CONSOLE_ORIC:
+      return &rc_memory_regions_oric;
+
+    case RC_CONSOLE_PC8800:
+      return &rc_memory_regions_pc8800;
+
+    case RC_CONSOLE_PC_ENGINE:
+      return &rc_memory_regions_pcengine;
+
+    case RC_CONSOLE_PLAYSTATION:
+      return &rc_memory_regions_playstation;
+
+    case RC_CONSOLE_POKEMON_MINI:
+      return &rc_memory_regions_pokemini;
+
+    case RC_CONSOLE_SATURN:
+      return &rc_memory_regions_saturn;
+
+    case RC_CONSOLE_SEGA_CD:
+      return &rc_memory_regions_segacd;
+
+    case RC_CONSOLE_SG1000:
+      return &rc_memory_regions_sg1000;
+
+    case RC_CONSOLE_SUPER_CASSETTEVISION:
+      return &rc_memory_regions_scv;
+
+    case RC_CONSOLE_SUPER_NINTENDO:
+      return &rc_memory_regions_snes;
+
+    case RC_CONSOLE_WONDERSWAN:
+      return &rc_memory_regions_wonderswan;
+
+    case RC_CONSOLE_VECTREX:
+      return &rc_memory_regions_vectrex;
+
+    case RC_CONSOLE_VIRTUAL_BOY:
+      return &rc_memory_regions_virtualboy;
+
+    default:
+      return &rc_memory_regions_none;
   }
 }

--- a/src/rcheevos/consoleinfo.c
+++ b/src/rcheevos/consoleinfo.c
@@ -242,12 +242,17 @@ static const rc_memory_region_t _rc_memory_regions_gameboy[] = {
     { 0x00A000U, 0x00BFFFU, 0x00A000U, RC_MEMORY_TYPE_SAVE_RAM, "Cartridge RAM"},
     { 0x00C000U, 0x00CFFFU, 0x00C000U, RC_MEMORY_TYPE_SYSTEM_RAM, "System RAM (fixed)" },
     { 0x00D000U, 0x00DFFFU, 0x00D000U, RC_MEMORY_TYPE_SYSTEM_RAM, "System RAM (bank 1)" },
-    { 0x00E000U, 0x00FDFFU, 0x00E000U, RC_MEMORY_TYPE_VIRTUAL_RAM, "Echo RAM" },
+    { 0x00E000U, 0x00FDFFU, 0x00C000U, RC_MEMORY_TYPE_VIRTUAL_RAM, "Echo RAM" },
     { 0x00FE00U, 0x00FE9FU, 0x00FE00U, RC_MEMORY_TYPE_VIDEO_RAM, "Sprite RAM"},
     { 0x00FEA0U, 0x00FEFFU, 0x00FEA0U, RC_MEMORY_TYPE_READONLY, "Unusable"},
     { 0x00FF00U, 0x00FF7FU, 0x00FF00U, RC_MEMORY_TYPE_HARDWARE_CONTROLLER, "Hardware I/O"},
     { 0x00FF80U, 0x00FFFEU, 0x00FF80U, RC_MEMORY_TYPE_SYSTEM_RAM, "Quick RAM"},
     { 0x00FFFFU, 0x00FFFFU, 0x00FFFFU, RC_MEMORY_TYPE_HARDWARE_CONTROLLER, "Interrupt enable"},
+
+    /* GameBoy Color provides six extra banks of memory that can be paged out through the $DXXX 
+     * memory space, but the timing of that does not correspond with blanks, which is when achievements 
+     * are processed. As such, it is desirable to always have access to these extra banks. We do this
+     * by expecting the extra banks to be addressable at addresses not supported by the native system. */
     { 0x010000U, 0x015FFFU, 0x010000U, RC_MEMORY_TYPE_SYSTEM_RAM, "System RAM (banks 2-7, GBC only)" }
 };
 static const rc_memory_regions_t rc_memory_regions_gameboy = { _rc_memory_regions_gameboy, 16 };
@@ -309,9 +314,9 @@ static const rc_memory_regions_t rc_memory_regions_neo_geo_pocket = { _rc_memory
 /* https://wiki.nesdev.com/w/index.php/CPU_memory_map */
 static const rc_memory_region_t _rc_memory_regions_nes[] = {
     { 0x0000U, 0x07FFU, 0x0000U, RC_MEMORY_TYPE_SYSTEM_RAM, "System RAM" },
-    { 0x0800U, 0x0FFFU, 0x0800U, RC_MEMORY_TYPE_VIRTUAL_RAM, "Mirror RAM" }, /* duplicates memory from $0000-$07FF */
-    { 0x1000U, 0x17FFU, 0x1000U, RC_MEMORY_TYPE_VIRTUAL_RAM, "Mirror RAM" }, /* duplicates memory from $0000-$07FF */
-    { 0x1800U, 0x1FFFU, 0x1800U, RC_MEMORY_TYPE_VIRTUAL_RAM, "Mirror RAM" }, /* duplicates memory from $0000-$07FF */
+    { 0x0800U, 0x0FFFU, 0x0000U, RC_MEMORY_TYPE_VIRTUAL_RAM, "Mirror RAM" }, /* duplicates memory from $0000-$07FF */
+    { 0x1000U, 0x17FFU, 0x0000U, RC_MEMORY_TYPE_VIRTUAL_RAM, "Mirror RAM" }, /* duplicates memory from $0000-$07FF */
+    { 0x1800U, 0x1FFFU, 0x0000U, RC_MEMORY_TYPE_VIRTUAL_RAM, "Mirror RAM" }, /* duplicates memory from $0000-$07FF */
     { 0x2000U, 0x2007U, 0x2000U, RC_MEMORY_TYPE_HARDWARE_CONTROLLER, "PPU Register" },
     { 0x2008U, 0x3FFFU, 0x2008U, RC_MEMORY_TYPE_VIRTUAL_RAM, "Mirrored PPU Register" }, /* repeats every 8 bytes */
     { 0x4000U, 0x4017U, 0x4000U, RC_MEMORY_TYPE_HARDWARE_CONTROLLER, "APU and I/O register" },

--- a/src/rcheevos/consoleinfo.c
+++ b/src/rcheevos/consoleinfo.c
@@ -1,0 +1,177 @@
+#include "rconsoles.h"
+
+#include <ctype.h>
+
+const char* rc_console_name(int console_id)
+{
+  switch (console_id)
+  {
+    case RC_CONSOLE_3DO:
+      return "3DO";
+
+    case RC_CONSOLE_AMIGA:
+      return "Amiga";
+
+    case RC_CONSOLE_AMIGA_ST:
+      return "Amiga ST";
+
+    case RC_CONSOLE_AMSTRAD_PC:
+      return "Amstrad CPC";
+
+    case RC_CONSOLE_APPLE_II:
+      return "Apple II";
+
+    case RC_CONSOLE_ARCADE:
+      return "Arcade";
+
+    case RC_CONSOLE_ATARI_2600:
+      return "Atari 2600";
+
+    case RC_CONSOLE_ATARI_5200:
+      return "Atari 5200";
+
+    case RC_CONSOLE_ATARI_7800:
+      return "Atari 7800";
+
+    case RC_CONSOLE_ATARI_JAGUAR:
+      return "Atari Jaguar";
+
+    case RC_CONSOLE_ATARI_LYNX:
+      return "Atari Lynx";
+
+    case RC_CONSOLE_CASSETTEVISION:
+      return "CassetteVision";
+
+    case RC_CONSOLE_CDI:
+      return "CD-I";
+
+    case RC_CONSOLE_COLECOVISION:
+      return "ColecoVision";
+
+    case RC_CONSOLE_COMMODORE_64:
+      return "Commodore 64";
+
+    case RC_CONSOLE_DREAMCAST:
+      return "Dreamcast";
+
+    case RC_CONSOLE_EVENTS:
+      return "Events";
+
+    case RC_CONSOLE_GAMEBOY:
+      return "GameBoy";
+
+    case RC_CONSOLE_GAMEBOY_ADVANCE:
+      return "GameBoy Advance";
+
+    case RC_CONSOLE_GAMEBOY_COLOR:
+      return "GameBoy Color";
+
+    case RC_CONSOLE_GAMECUBE:
+      return "GameCube";
+
+    case RC_CONSOLE_GAME_GEAR:
+      return "Game Gear";
+
+    case RC_CONSOLE_INTELLIVISION:
+      return "Intellivision";
+
+    case RC_CONSOLE_MASTER_SYSTEM:
+      return "Master System";
+
+    case RC_CONSOLE_MEGA_DRIVE:
+      return "Sega Genesis";
+
+    case RC_CONSOLE_MS_DOS:
+      return "MS-DOS";
+
+    case RC_CONSOLE_MSX:
+      return "MSX";
+
+    case RC_CONSOLE_NINTENDO:
+      return "Nintendo Entertainment System";
+
+    case RC_CONSOLE_NINTENDO_64:
+      return "Nintendo 64";
+
+    case RC_CONSOLE_NINTENDO_DS:
+      return "Nintendo DS";
+
+    case RC_CONSOLE_NEOGEO_POCKET:
+      return "Neo Geo Pocket";
+
+    case RC_CONSOLE_ORIC:
+      return "Oric";
+
+    case RC_CONSOLE_PC8800:
+      return "PC-8000/8800";
+
+    case RC_CONSOLE_PC9800:
+      return "PC-9800";
+
+    case RC_CONSOLE_PCFX:
+      return "PCFX";
+
+    case RC_CONSOLE_PC_ENGINE:
+      return "PCEngine";
+
+    case RC_CONSOLE_PLAYSTATION:
+      return "PlayStation";
+
+    case RC_CONSOLE_PLAYSTATION_2:
+      return "PlayStation 2";
+
+    case RC_CONSOLE_PSP:
+      return "PlayStation Portable";
+
+    case RC_CONSOLE_POKEMON_MINI:
+      return "Pokemon Mini";
+
+    case RC_CONSOLE_SEGA_32X:
+      return "Sega 32X";
+
+    case RC_CONSOLE_SEGA_CD:
+      return "Sega CD";
+
+    case RC_CONSOLE_SATURN:
+      return "Sega Saturn";
+
+    case RC_CONSOLE_SG1000:
+      return "SG-1000";
+
+    case RC_CONSOLE_SUPER_NINTENDO:
+      return "Super Nintendo Entertainment System";
+
+    case RC_CONSOLE_SUPER_CASSETTEVISION:
+      return "Super CassetteVision";
+
+    case RC_CONSOLE_WONDERSWAN:
+      return "WonderSwan";
+
+    case RC_CONSOLE_VECTREX:
+      return "Vectrex";
+
+    case RC_CONSOLE_VIC20:
+      return "VIC-20";
+
+    case RC_CONSOLE_VIRTUAL_BOY:
+      return "Virtual Boy";
+
+    case RC_CONSOLE_WII:
+      return "Wii";
+
+    case RC_CONSOLE_WII_U:
+      return "Wii-U";
+
+    case RC_CONSOLE_X68K:
+      return "X68K";
+
+    case RC_CONSOLE_XBOX:
+      return "XBOX";
+
+    case RC_CONSOLE_ZX81:
+      return "ZX-81";
+
+    default:
+      return "Unknown";
+  }
+}

--- a/test/Makefile
+++ b/test/Makefile
@@ -5,7 +5,7 @@ LUA_SRC=lua/src
 
 OBJ=$(RC_SRC)/trigger.o $(RC_SRC)/condset.o $(RC_SRC)/condition.o $(RC_SRC)/operand.o \
     $(RC_SRC)/value.o $(RC_SRC)/lboard.o $(RC_SRC)/richpresence.o $(RC_SRC)/runtime.o \
-    $(RC_SRC)/alloc.o $(RC_SRC)/memref.o $(RC_SRC)/format.o $(RC_SRC)/compat.o \
+    $(RC_SRC)/alloc.o $(RC_SRC)/memref.o $(RC_SRC)/format.o $(RC_SRC)/compat.o $(RC_SRC)/consoleinfo.o \
     $(RC_HASH_SRC)/md5.o $(RC_HASH_SRC)/hash.o \
     $(RC_URL_SRC)/url.o \
     rcheevos/test_memref.o \
@@ -18,6 +18,7 @@ OBJ=$(RC_SRC)/trigger.o $(RC_SRC)/condset.o $(RC_SRC)/condition.o $(RC_SRC)/oper
     rcheevos/test_lboard.o \
     rcheevos/test_richpresence.o \
     rcheevos/test_runtime.o \
+    rcheevos/test_consoleinfo.o \
     rhash/data.o \
     rhash/test_hash.o \
     test.o

--- a/test/rcheevos-test.vcxproj
+++ b/test/rcheevos-test.vcxproj
@@ -127,6 +127,7 @@
     <ClCompile Include="..\src\rcheevos\compat.c" />
     <ClCompile Include="..\src\rcheevos\condition.c" />
     <ClCompile Include="..\src\rcheevos\condset.c" />
+    <ClCompile Include="..\src\rcheevos\consoleinfo.c" />
     <ClCompile Include="..\src\rcheevos\format.c" />
     <ClCompile Include="..\src\rcheevos\lboard.c" />
     <ClCompile Include="..\src\rcheevos\memref.c" />
@@ -172,6 +173,7 @@
     <ClCompile Include="lua\src\lzio.c" />
     <ClCompile Include="rcheevos\test_condition.c" />
     <ClCompile Include="rcheevos\test_condset.c" />
+    <ClCompile Include="rcheevos\test_consoleinfo.c" />
     <ClCompile Include="rcheevos\test_format.c" />
     <ClCompile Include="rcheevos\test_lboard.c" />
     <ClCompile Include="rcheevos\test_memref.c" />
@@ -186,6 +188,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\include\rcheevos.h" />
+    <ClInclude Include="..\include\rconsoles.h" />
     <ClInclude Include="..\include\rhash.h" />
     <ClInclude Include="..\src\rcheevos\compat.h" />
     <ClInclude Include="..\src\rcheevos\internal.h" />

--- a/test/rcheevos-test.vcxproj.filters
+++ b/test/rcheevos-test.vcxproj.filters
@@ -204,6 +204,12 @@
     <ClCompile Include="rcheevos\test_runtime.c">
       <Filter>tests\rcheevos</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\rcheevos\consoleinfo.c">
+      <Filter>src\rcheevos</Filter>
+    </ClCompile>
+    <ClCompile Include="rcheevos\test_consoleinfo.c">
+      <Filter>tests\rcheevos</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\src\rcheevos\internal.h">
@@ -225,6 +231,9 @@
       <Filter>src\rhash</Filter>
     </ClInclude>
     <ClInclude Include="..\src\rcheevos\compat.h">
+      <Filter>src\rcheevos</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\rconsoles.h">
       <Filter>src\rcheevos</Filter>
     </ClInclude>
   </ItemGroup>

--- a/test/rcheevos/test_consoleinfo.c
+++ b/test/rcheevos/test_consoleinfo.c
@@ -1,10 +1,38 @@
 #include "rconsoles.h"
+#include "rcheevos.h"
 
 #include "../test_framework.h"
 
 static void test_name(int console_id, const char* expected_name)
 {
   ASSERT_STR_EQUALS(rc_console_name(console_id), expected_name);
+}
+
+static void test_memory(int console_id, unsigned expected_total_memory)
+{
+  const rc_memory_regions_t* regions = rc_console_memory_regions(console_id);
+  unsigned total_memory = 0;
+  unsigned max_address = 0;
+  unsigned i;
+  ASSERT_PTR_NOT_NULL(regions);
+
+  if (expected_total_memory == 0)
+  {
+    ASSERT_NUM_EQUALS(regions->num_regions, 0);
+    return;
+  }
+
+  ASSERT_NUM_GREATER(regions->num_regions, 0);
+  for (i = 0; i < regions->num_regions; ++i) {
+    total_memory += (regions->region[i].end_address - regions->region[i].start_address + 1);
+    if (regions->region[i].end_address > max_address)
+      max_address = regions->region[i].end_address;
+
+    ASSERT_PTR_NOT_NULL(regions->region[i].description);
+  }
+
+  ASSERT_NUM_EQUALS(total_memory, expected_total_memory);
+  ASSERT_NUM_EQUALS(max_address, expected_total_memory - 1);
 }
 
 void test_consoleinfo(void) {
@@ -68,6 +96,40 @@ void test_consoleinfo(void) {
   TEST_PARAMS2(test_name, 54, "CassetteVision");
   TEST_PARAMS2(test_name, 55, "Super CassetteVision");
   TEST_PARAMS2(test_name, 56, "Unknown");
+
+  /* memory maps */
+  TEST_PARAMS2(test_memory, RC_CONSOLE_APPLE_II, 0x020000);
+  TEST_PARAMS2(test_memory, RC_CONSOLE_ARCADE, 0x000000);
+  TEST_PARAMS2(test_memory, RC_CONSOLE_ATARI_2600, 0x000080);
+  TEST_PARAMS2(test_memory, RC_CONSOLE_ATARI_7800, 0x010000);
+  TEST_PARAMS2(test_memory, RC_CONSOLE_ATARI_JAGUAR, 0x200000);
+  TEST_PARAMS2(test_memory, RC_CONSOLE_ATARI_LYNX, 0x010000);
+  TEST_PARAMS2(test_memory, RC_CONSOLE_COLECOVISION, 0x000400);
+  TEST_PARAMS2(test_memory, RC_CONSOLE_GAMEBOY, 0x010000);
+  TEST_PARAMS2(test_memory, RC_CONSOLE_GAMEBOY_COLOR, 0x016000);
+  TEST_PARAMS2(test_memory, RC_CONSOLE_GAMEBOY_ADVANCE, 0x048000);
+  TEST_PARAMS2(test_memory, RC_CONSOLE_GAME_GEAR, 0x002000);
+  TEST_PARAMS2(test_memory, RC_CONSOLE_INTELLIVISION, 0x010000);
+  TEST_PARAMS2(test_memory, RC_CONSOLE_MASTER_SYSTEM, 0x002000);
+  TEST_PARAMS2(test_memory, RC_CONSOLE_MEGA_DRIVE, 0x020000);
+  TEST_PARAMS2(test_memory, RC_CONSOLE_NEOGEO_POCKET, 0x004000);
+  TEST_PARAMS2(test_memory, RC_CONSOLE_NINTENDO, 0x010000);
+  TEST_PARAMS2(test_memory, RC_CONSOLE_NINTENDO_64, 0x800000);
+  TEST_PARAMS2(test_memory, RC_CONSOLE_NINTENDO_DS, 0x400000);
+  TEST_PARAMS2(test_memory, RC_CONSOLE_ORIC, 0x010000);
+  TEST_PARAMS2(test_memory, RC_CONSOLE_PC8800, 0x011000);
+  TEST_PARAMS2(test_memory, RC_CONSOLE_PC_ENGINE, 0x42800);
+  TEST_PARAMS2(test_memory, RC_CONSOLE_PLAYSTATION, 0x200000);
+  TEST_PARAMS2(test_memory, RC_CONSOLE_POKEMON_MINI, 0x002000);
+  TEST_PARAMS2(test_memory, RC_CONSOLE_SATURN, 0x200000);
+  TEST_PARAMS2(test_memory, RC_CONSOLE_SEGA_32X, 0x020000);
+  TEST_PARAMS2(test_memory, RC_CONSOLE_SEGA_CD, 0x090000);
+  TEST_PARAMS2(test_memory, RC_CONSOLE_SG1000, 0x000400);
+  TEST_PARAMS2(test_memory, RC_CONSOLE_SUPER_CASSETTEVISION, 0x010000);
+  TEST_PARAMS2(test_memory, RC_CONSOLE_SUPER_NINTENDO, 0x040000);
+  TEST_PARAMS2(test_memory, RC_CONSOLE_WONDERSWAN, 0x010000);
+  TEST_PARAMS2(test_memory, RC_CONSOLE_VECTREX, 0x000400);
+  TEST_PARAMS2(test_memory, RC_CONSOLE_VIRTUAL_BOY, 0x020000);
 
   TEST_SUITE_END();
 }

--- a/test/rcheevos/test_consoleinfo.c
+++ b/test/rcheevos/test_consoleinfo.c
@@ -1,0 +1,73 @@
+#include "rconsoles.h"
+
+#include "../test_framework.h"
+
+static void test_name(int console_id, const char* expected_name)
+{
+  ASSERT_STR_EQUALS(rc_console_name(console_id), expected_name);
+}
+
+void test_consoleinfo(void) {
+  TEST_SUITE_BEGIN();
+
+  /* use raw numbers instead of constants to ensure constants don't change */
+  TEST_PARAMS2(test_name,  0, "Unknown");
+  TEST_PARAMS2(test_name,  1, "Sega Genesis");
+  TEST_PARAMS2(test_name,  2, "Nintendo 64");
+  TEST_PARAMS2(test_name,  3, "Super Nintendo Entertainment System");
+  TEST_PARAMS2(test_name,  4, "GameBoy");
+  TEST_PARAMS2(test_name,  5, "GameBoy Advance");
+  TEST_PARAMS2(test_name,  6, "GameBoy Color");
+  TEST_PARAMS2(test_name,  7, "Nintendo Entertainment System");
+  TEST_PARAMS2(test_name,  8, "PCEngine");
+  TEST_PARAMS2(test_name,  9, "Sega CD");
+  TEST_PARAMS2(test_name, 10, "Sega 32X");
+  TEST_PARAMS2(test_name, 11, "Master System");
+  TEST_PARAMS2(test_name, 12, "PlayStation");
+  TEST_PARAMS2(test_name, 13, "Atari Lynx");
+  TEST_PARAMS2(test_name, 14, "Neo Geo Pocket");
+  TEST_PARAMS2(test_name, 15, "Game Gear");
+  TEST_PARAMS2(test_name, 16, "GameCube");
+  TEST_PARAMS2(test_name, 17, "Atari Jaguar");
+  TEST_PARAMS2(test_name, 18, "Nintendo DS");
+  TEST_PARAMS2(test_name, 19, "Wii");
+  TEST_PARAMS2(test_name, 20, "Wii-U");
+  TEST_PARAMS2(test_name, 21, "PlayStation 2");
+  TEST_PARAMS2(test_name, 22, "XBOX");
+  TEST_PARAMS2(test_name, 23, "Events");
+  TEST_PARAMS2(test_name, 24, "Pokemon Mini");
+  TEST_PARAMS2(test_name, 25, "Atari 2600");
+  TEST_PARAMS2(test_name, 26, "MS-DOS");
+  TEST_PARAMS2(test_name, 27, "Arcade");
+  TEST_PARAMS2(test_name, 28, "Virtual Boy");
+  TEST_PARAMS2(test_name, 29, "MSX");
+  TEST_PARAMS2(test_name, 30, "Commodore 64");
+  TEST_PARAMS2(test_name, 31, "ZX-81");
+  TEST_PARAMS2(test_name, 32, "Oric");
+  TEST_PARAMS2(test_name, 33, "SG-1000");
+  TEST_PARAMS2(test_name, 34, "VIC-20");
+  TEST_PARAMS2(test_name, 35, "Amiga");
+  TEST_PARAMS2(test_name, 36, "Amiga ST");
+  TEST_PARAMS2(test_name, 37, "Amstrad CPC");
+  TEST_PARAMS2(test_name, 38, "Apple II");
+  TEST_PARAMS2(test_name, 39, "Sega Saturn");
+  TEST_PARAMS2(test_name, 40, "Dreamcast");
+  TEST_PARAMS2(test_name, 41, "PlayStation Portable");
+  TEST_PARAMS2(test_name, 42, "CD-I");
+  TEST_PARAMS2(test_name, 43, "3DO");
+  TEST_PARAMS2(test_name, 44, "ColecoVision");
+  TEST_PARAMS2(test_name, 45, "Intellivision");
+  TEST_PARAMS2(test_name, 46, "Vectrex");
+  TEST_PARAMS2(test_name, 47, "PC-8000/8800");
+  TEST_PARAMS2(test_name, 48, "PC-9800");
+  TEST_PARAMS2(test_name, 49, "PCFX");
+  TEST_PARAMS2(test_name, 50, "Atari 5200");
+  TEST_PARAMS2(test_name, 51, "Atari 7800");
+  TEST_PARAMS2(test_name, 52, "X68K");
+  TEST_PARAMS2(test_name, 53, "WonderSwan");
+  TEST_PARAMS2(test_name, 54, "CassetteVision");
+  TEST_PARAMS2(test_name, 55, "Super CassetteVision");
+  TEST_PARAMS2(test_name, 56, "Unknown");
+
+  TEST_SUITE_END();
+}

--- a/test/test.c
+++ b/test/test.c
@@ -55,6 +55,8 @@ extern void test_lboard();
 extern void test_richpresence();
 extern void test_runtime();
 
+extern void test_consoleinfo();
+
 extern void test_hash();
 
 TEST_FRAMEWORK_DECLARATIONS()
@@ -72,6 +74,7 @@ int main(void) {
   test_lboard();
   test_richpresence();
   test_runtime();
+  test_consoleinfo();
 
   test_lua();
 

--- a/test/test_framework.h
+++ b/test/test_framework.h
@@ -141,5 +141,11 @@ extern const char* test_framework_basename(const char* path);
     ASSERT_FAIL( "String mismatch for: " #value " (%s:%d)\n  Expected: %s\n  Found:    %s", test_framework_basename(__FILE__), __LINE__, __e, __v); \
   }}
 
+#define ASSERT_STR_NOT_EQUALS(value, expected) { \
+  const char* __v = (const char*)(value); \
+  const char* __e = (const char*)(expected); \
+  if (strcmp(__v, __e) == 0) { \
+    ASSERT_FAIL( "String match for: " #value " (%s:%d)\n  Found, but not expected: %s", test_framework_basename(__FILE__), __LINE__, __v); \
+  }}
 
 #endif /* TEST_FRAMEWORK_H */


### PR DESCRIPTION
Allows for deduplication of similar code in RAIntegration, RALibRetro, and RetroArch.