### PR TITLE
add ASSERT_HELPER macro

### DIFF
--- a/test/rcheevos/test_condition.c
+++ b/test/rcheevos/test_condition.c
@@ -3,7 +3,7 @@
 #include "../test_framework.h"
 #include "mock_memory.h"
 
-static void assert_operand(rc_operand_t* self, char expected_type, char expected_size, unsigned expected_address) {
+static void _assert_operand(rc_operand_t* self, char expected_type, char expected_size, unsigned expected_address) {
   ASSERT_NUM_EQUALS(self->type, expected_type);
 
   switch (expected_type) {
@@ -19,8 +19,9 @@ static void assert_operand(rc_operand_t* self, char expected_type, char expected
       break;
   }
 }
+#define assert_operand(operand, expected_type, expected_size, expected_address) ASSERT_HELPER(_assert_operand(operand, expected_type, expected_size, expected_address), "assert_operand")
 
-static void assert_parse_condition(
+static void _assert_parse_condition(
     const char* memaddr, char expected_type,
     char expected_left_type, char expected_left_size, unsigned expected_left_value,
     char expected_operator,
@@ -43,6 +44,10 @@ static void assert_parse_condition(
     assert_operand(&self->operand2, expected_right_type, expected_right_size, expected_right_value);
     ASSERT_NUM_EQUALS(self->required_hits, expected_required_hits);
 }
+#define assert_parse_condition(memaddr, expected_type, expected_left_type, expected_left_size, expected_left_value, \
+                               expected_operator, expected_right_type, expected_right_size, expected_right_value, expected_required_hits) \
+    ASSERT_HELPER(_assert_parse_condition(memaddr, expected_type, expected_left_type, expected_left_size, expected_left_value, \
+                                          expected_operator, expected_right_type, expected_right_size, expected_right_value, expected_required_hits), "assert_parse_condition")
 
 static void test_parse_condition(const char* memaddr, int expected_type, int expected_left_type,
     int expected_operator, int expected_required_hits) {

--- a/test/rcheevos/test_condset.c
+++ b/test/rcheevos/test_condset.c
@@ -3,7 +3,7 @@
 #include "../test_framework.h"
 #include "mock_memory.h"
 
-static void assert_parse_condset(rc_condset_t** condset, rc_memref_value_t** memrefs, void* buffer, const char* memaddr)
+static void _assert_parse_condset(rc_condset_t** condset, rc_memref_value_t** memrefs, void* buffer, const char* memaddr)
 {
   rc_parse_state_t parse;
   int size;
@@ -18,8 +18,9 @@ static void assert_parse_condset(rc_condset_t** condset, rc_memref_value_t** mem
   ASSERT_NUM_GREATER(size, 0);
   ASSERT_PTR_NOT_NULL(*condset);
 }
+#define assert_parse_condset(condset, memrefs_out, buffer, memaddr) ASSERT_HELPER(_assert_parse_condset(condset, memrefs_out, buffer, memaddr), "assert_parse_condset")
 
-static void assert_evaluate_condset(rc_condset_t* condset, rc_memref_value_t* memrefs, memory_t* memory, int expected_result) {
+static void _assert_evaluate_condset(rc_condset_t* condset, rc_memref_value_t* memrefs, memory_t* memory, int expected_result) {
   int result;
   rc_eval_state_t eval_state;
 
@@ -37,6 +38,7 @@ static void assert_evaluate_condset(rc_condset_t* condset, rc_memref_value_t* me
 
   ASSERT_NUM_EQUALS(result, expected_result);
 }
+#define assert_evaluate_condset(condset, memrefs, memory, expected_result) ASSERT_HELPER(_assert_evaluate_condset(condset, memrefs, memory, expected_result), "assert_evaluate_condset")
 
 static rc_condition_t* condset_get_cond(rc_condset_t* condset, int cond_index) {
   rc_condition_t* cond = condset->conditions;
@@ -51,12 +53,14 @@ static rc_condition_t* condset_get_cond(rc_condset_t* condset, int cond_index) {
   return cond;
 }
 
-static void assert_hit_count(rc_condset_t* condset, int cond_index, unsigned expected_hit_count) {
+static void _assert_hit_count(rc_condset_t* condset, int cond_index, unsigned expected_hit_count) {
   rc_condition_t* cond = condset_get_cond(condset, cond_index);
   ASSERT_PTR_NOT_NULL(cond);
 
   ASSERT_NUM_EQUALS(cond->current_hits, expected_hit_count);
 }
+#define assert_hit_count(condset, cond_index, expected_hit_count) ASSERT_HELPER(_assert_hit_count(condset, cond_index, expected_hit_count), "assert_hit_count")
+
 
 static void test_hitcount_increment_when_true() {
   unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};

--- a/test/rcheevos/test_lboard.c
+++ b/test/rcheevos/test_lboard.c
@@ -3,7 +3,7 @@
 #include "../test_framework.h"
 #include "mock_memory.h"
 
-static void assert_parse_lboard(rc_lboard_t** lboard, void* buffer, const char* memaddr)
+static void _assert_parse_lboard(rc_lboard_t** lboard, void* buffer, const char* memaddr)
 {
   int size;
   unsigned* overflow;
@@ -21,6 +21,7 @@ static void assert_parse_lboard(rc_lboard_t** lboard, void* buffer, const char* 
     ASSERT_FAIL("write past end of buffer");
   }
 }
+#define assert_parse_lboard(lboard, buffer, memaddr) ASSERT_HELPER(_assert_parse_lboard(lboard, buffer, memaddr), "assert_parse_lboard")
 
 static int evaluate_lboard(rc_lboard_t* lboard, memory_t* memory, int* value) {
   return rc_evaluate_lboard(lboard, value, peek, memory, NULL);

--- a/test/rcheevos/test_operand.c
+++ b/test/rcheevos/test_operand.c
@@ -3,7 +3,7 @@
 #include "../test_framework.h"
 #include "mock_memory.h"
 
-static void parse_operand(rc_operand_t* self, const char** memaddr) {
+static void _assert_parse_operand(rc_operand_t* self, const char** memaddr) {
   rc_parse_state_t parse;
   char buffer[256];
   rc_memref_value_t* memrefs;
@@ -17,8 +17,9 @@ static void parse_operand(rc_operand_t* self, const char** memaddr) {
   ASSERT_NUM_GREATER_EQUALS(ret, 0);
   ASSERT_NUM_EQUALS(**memaddr, 0);
 }
+#define assert_parse_operand(operand, memaddr_out) ASSERT_HELPER(_assert_parse_operand(operand, memaddr_out), "assert_parse_operand")
 
-static void assert_operand(rc_operand_t* self, char expected_type, char expected_size, unsigned expected_address) {
+static void _assert_operand(rc_operand_t* self, char expected_type, char expected_size, unsigned expected_address) {
   ASSERT_NUM_EQUALS(expected_type, self->type);
   switch (expected_type) {
     case RC_OPERAND_ADDRESS:
@@ -33,16 +34,17 @@ static void assert_operand(rc_operand_t* self, char expected_type, char expected
       break;
   }
 }
+#define assert_operand(operand, expected_type, expected_size, expected_address) ASSERT_HELPER(_assert_operand(operand, expected_type, expected_size, expected_address), "assert_operand")
 
 static void test_parse_operand(const char* memaddr, char expected_type, char expected_size, unsigned expected_value) {
   rc_operand_t self;
-  parse_operand(&self, &memaddr);
+  assert_parse_operand(&self, &memaddr);
   assert_operand(&self, expected_type, expected_size, expected_value);
 }
 
 static void test_parse_operand_fp(const char* memaddr, char expected_type, double expected_value) {
   rc_operand_t self;
-  parse_operand(&self, &memaddr);
+  assert_parse_operand(&self, &memaddr);
 
   ASSERT_NUM_EQUALS(expected_type, self.type);
   switch (expected_type) {

--- a/test/rcheevos/test_richpresence.c
+++ b/test/rcheevos/test_richpresence.c
@@ -3,7 +3,7 @@
 #include "../test_framework.h"
 #include "mock_memory.h"
 
-static void assert_parse_richpresence(rc_richpresence_t** richpresence, void* buffer, const char* script) {
+static void _assert_parse_richpresence(rc_richpresence_t** richpresence, void* buffer, const char* script) {
   int size;
   unsigned* overflow;
 
@@ -20,8 +20,9 @@ static void assert_parse_richpresence(rc_richpresence_t** richpresence, void* bu
     ASSERT_FAIL("write past end of buffer");
   }
 }
+#define assert_parse_richpresence(richpresence_out, buffer, script) ASSERT_HELPER(_assert_parse_richpresence(richpresence_out, buffer, script), "assert_parse_richpresence")
 
-static void assert_richpresence_output(rc_richpresence_t* richpresence, memory_t* memory, const char* expected_display_string) {
+static void _assert_richpresence_output(rc_richpresence_t* richpresence, memory_t* memory, const char* expected_display_string) {
   char output[256];
   int result;
 
@@ -29,6 +30,7 @@ static void assert_richpresence_output(rc_richpresence_t* richpresence, memory_t
   ASSERT_STR_EQUALS(output, expected_display_string);
   ASSERT_NUM_EQUALS(result, strlen(expected_display_string));
 }
+#define assert_richpresence_output(richpresence, memory, expected_display_string) ASSERT_HELPER(_assert_richpresence_output(richpresence, memory, expected_display_string), "assert_richpresence_output")
 
 static void test_empty_script() {
   int result = rc_richpresence_size("");

--- a/test/rcheevos/test_runtime.c
+++ b/test/rcheevos/test_runtime.c
@@ -12,7 +12,7 @@ static void event_handler(const rc_runtime_event_t* e)
   memcpy(&events[event_count++], e, sizeof(rc_runtime_event_t));
 }
 
-static void assert_event(char type, int id, int value)
+static void _assert_event(char type, int id, int value)
 {
   int i;
 
@@ -23,24 +23,28 @@ static void assert_event(char type, int id, int value)
 
   ASSERT_FAIL("expected event not found");
 }
+#define assert_event(type, id, value) ASSERT_HELPER(_assert_event(type, id, value), "assert_event")
 
-static void assert_activate_achievement(rc_runtime_t* runtime, unsigned int id, const char* memaddr)
+static void _assert_activate_achievement(rc_runtime_t* runtime, unsigned int id, const char* memaddr)
 {
   int result = rc_runtime_activate_achievement(runtime, id, memaddr, NULL, 0);
   ASSERT_NUM_EQUALS(result, RC_OK);
 }
+#define assert_activate_achievement(runtime, id, memaddr) ASSERT_HELPER(_assert_activate_achievement(runtime, id, memaddr), "assert_activate_achievement")
 
-static void assert_activate_lboard(rc_runtime_t* runtime, unsigned int id, const char* memaddr)
+static void _assert_activate_lboard(rc_runtime_t* runtime, unsigned int id, const char* memaddr)
 {
   int result = rc_runtime_activate_lboard(runtime, id, memaddr, NULL, 0);
   ASSERT_NUM_EQUALS(result, RC_OK);
 }
+#define assert_activate_lboard(runtime, id, memaddr) ASSERT_HELPER(_assert_activate_lboard(runtime, id, memaddr), "assert_activate_lboard")
 
-static void assert_activate_richpresence(rc_runtime_t* runtime, const char* script)
+static void _assert_activate_richpresence(rc_runtime_t* runtime, const char* script)
 {
   int result = rc_runtime_activate_richpresence(runtime, script, NULL, 0);
   ASSERT_NUM_EQUALS(result, RC_OK);
 }
+#define assert_activate_richpresence(runtime, script) ASSERT_HELPER(_assert_activate_richpresence(runtime, script), "assert_activate_richpresence")
 
 static void assert_do_frame(rc_runtime_t* runtime, memory_t* memory)
 {

--- a/test/rcheevos/test_runtime_progress.c
+++ b/test/rcheevos/test_runtime_progress.c
@@ -4,11 +4,12 @@
 #include "../rhash/md5.h"
 #include "mock_memory.h"
 
-static void assert_activate_achievement(rc_runtime_t* runtime, unsigned int id, const char* memaddr)
+static void _assert_activate_achievement(rc_runtime_t* runtime, unsigned int id, const char* memaddr)
 {
   int result = rc_runtime_activate_achievement(runtime, id, memaddr, NULL, 0);
   ASSERT_NUM_EQUALS(result, RC_OK);
 }
+#define assert_activate_achievement(runtime, id, memaddr) ASSERT_HELPER(_assert_activate_achievement(runtime, id, memaddr), "assert_activate_achievement")
 
 static void event_handler(const rc_runtime_event_t* e)
 {
@@ -19,7 +20,7 @@ static void assert_do_frame(rc_runtime_t* runtime, memory_t* memory)
   rc_runtime_do_frame(runtime, event_handler, peek, memory, NULL);
 }
 
-static void assert_serialize(rc_runtime_t* runtime, unsigned char* buffer, unsigned buffer_size)
+static void _assert_serialize(rc_runtime_t* runtime, unsigned char* buffer, unsigned buffer_size)
 {
   int result;
   unsigned* overflow;
@@ -37,14 +38,16 @@ static void assert_serialize(rc_runtime_t* runtime, unsigned char* buffer, unsig
     ASSERT_FAIL("write past end of buffer");
   }
 }
+#define assert_serialize(runtime, buffer, buffer_size) ASSERT_HELPER(_assert_serialize(runtime, buffer, buffer_size), "assert_serialize")
 
-static void assert_deserialize(rc_runtime_t* runtime, unsigned char* buffer)
+static void _assert_deserialize(rc_runtime_t* runtime, unsigned char* buffer)
 {
   int result = rc_runtime_deserialize_progress(runtime, buffer, NULL);
   ASSERT_NUM_EQUALS(result, RC_OK);
 }
+#define assert_deserialize(runtime, buffer) ASSERT_HELPER(_assert_deserialize(runtime, buffer), "assert_deserialize")
 
-static void assert_sized_memref(rc_runtime_t* runtime, unsigned address, char size, unsigned value, unsigned prev, unsigned prior)
+static void _assert_sized_memref(rc_runtime_t* runtime, unsigned address, char size, unsigned value, unsigned prev, unsigned prior)
 {
   rc_memref_value_t* memref = runtime->memrefs;
   while (memref)
@@ -62,11 +65,8 @@ static void assert_sized_memref(rc_runtime_t* runtime, unsigned address, char si
 
   ASSERT_FAIL("could not find memref for address %u", address);
 }
-
-static void assert_memref(rc_runtime_t* runtime, unsigned address, unsigned value, unsigned prev, unsigned prior)
-{
-  assert_sized_memref(runtime, address, RC_MEMSIZE_8_BITS, value, prev, prior);
-}
+#define assert_sized_memref(runtime, address, size, value, prev, prior) ASSERT_HELPER(_assert_sized_memref(runtime, address, size, value, prev, prior), "assert_sized_memref")
+#define assert_memref(runtime, address, value, prev, prior) ASSERT_HELPER(_assert_sized_memref(runtime, address, RC_MEMSIZE_8_BITS, value, prev, prior), "assert_memref")
 
 static rc_trigger_t* find_trigger(rc_runtime_t* runtime, unsigned ach_id)
 {
@@ -97,7 +97,7 @@ static rc_condset_t* find_condset(rc_runtime_t* runtime, unsigned ach_id, unsign
   return condset;
 }
 
-static void assert_hitcount(rc_runtime_t* runtime, unsigned ach_id, unsigned group_idx, unsigned cond_idx, unsigned expected_hits)
+static void _assert_hitcount(rc_runtime_t* runtime, unsigned ach_id, unsigned group_idx, unsigned cond_idx, unsigned expected_hits)
 {
   rc_condition_t* cond;
 
@@ -113,14 +113,16 @@ static void assert_hitcount(rc_runtime_t* runtime, unsigned ach_id, unsigned gro
 
   ASSERT_NUM_EQUALS(cond->current_hits, expected_hits);
 }
+#define assert_hitcount(runtime, ach_id, group_idx, cond_idx, expected_hits) ASSERT_HELPER(_assert_hitcount(runtime, ach_id, group_idx, cond_idx, expected_hits), "assert_hitcount")
 
-static void assert_achievement_state(rc_runtime_t* runtime, unsigned ach_id, int state)
+static void _assert_achievement_state(rc_runtime_t* runtime, unsigned ach_id, int state)
 {
   rc_trigger_t* trigger = find_trigger(runtime, ach_id);
   ASSERT_PTR_NOT_NULL(trigger);
 
   ASSERT_NUM_EQUALS(trigger->state, state);
 }
+#define assert_achievement_state(runtime, ach_id, state) ASSERT_HELPER(_assert_achievement_state(runtime, ach_id, state), "assert_achievement_state")
 
 static void update_md5(unsigned char* buffer)
 {

--- a/test/rcheevos/test_trigger.c
+++ b/test/rcheevos/test_trigger.c
@@ -3,7 +3,7 @@
 #include "../test_framework.h"
 #include "mock_memory.h"
 
-static void assert_parse_trigger(rc_trigger_t** trigger, void* buffer, const char* memaddr)
+static void _assert_parse_trigger(rc_trigger_t** trigger, void* buffer, const char* memaddr)
 {
   int size;
   unsigned* overflow;
@@ -21,11 +21,13 @@ static void assert_parse_trigger(rc_trigger_t** trigger, void* buffer, const cha
     ASSERT_FAIL("write past end of buffer");
   }
 }
+#define assert_parse_trigger(trigger, buffer, memaddr) ASSERT_HELPER(_assert_parse_trigger(trigger, buffer, memaddr), "assert_parse_trigger")
 
-static void assert_evaluate_trigger(rc_trigger_t* trigger, memory_t* memory, int expected_result) {
+static void _assert_evaluate_trigger(rc_trigger_t* trigger, memory_t* memory, int expected_result) {
   int result = rc_test_trigger(trigger, peek, memory, NULL);
   ASSERT_NUM_EQUALS(result, expected_result);
 }
+#define assert_evaluate_trigger(trigger, memory, expected_result) ASSERT_HELPER(_assert_evaluate_trigger(trigger, memory, expected_result), "assert_evaluate_trigger")
 
 static rc_condition_t* trigger_get_cond(rc_trigger_t* trigger, int group_index, int cond_index) {
   rc_condset_t* condset = trigger->requirement;
@@ -56,12 +58,13 @@ static rc_condition_t* trigger_get_cond(rc_trigger_t* trigger, int group_index, 
   return cond;
 }
 
-static void assert_hit_count(rc_trigger_t* trigger, int group_index, int cond_index, unsigned expected_hit_count) {
+static void _assert_hit_count(rc_trigger_t* trigger, int group_index, int cond_index, unsigned expected_hit_count) {
   rc_condition_t* cond = trigger_get_cond(trigger, group_index, cond_index);
   ASSERT_PTR_NOT_NULL(cond);
 
   ASSERT_NUM_EQUALS(cond->current_hits, expected_hit_count);
 }
+#define assert_hit_count(trigger, group_index, cond_index, expected_hit_count) ASSERT_HELPER(_assert_hit_count(trigger, group_index, cond_index, expected_hit_count), "assert_hit_count")
 
 static int evaluate_trigger(rc_trigger_t* self, memory_t* memory) {
   return rc_evaluate_trigger(self, peek, memory, NULL);


### PR DESCRIPTION
Allows aliasing helper functions so they get included in the error stack:
```
* test_trigger/test_bit_lookups_share_memref (test_trigger.c:1521)
  Expected: size > 0 (test_trigger.c:12)
  Found:    -1 > 0
```
becomes
```
* test_trigger/test_bit_lookups_share_memref (test_trigger.c:1521)
  via assert_parse_trigger (test_trigger.c:1431)
  Expected: size > 0 (test_trigger.c:12)
  Found:    -1 > 0
```
Which lets the user know that the failure on line 12 was caused due to calling a function from line 1431. This is particularly helpful when the function containing line 12 is called multiple times from within a test.

This change also allows failures to bubble up more cleanly. When an assert fails, it bails from the current function. With these changes, it will also bail from the calling function, and so on up the chain as long as each function in the chain is calling through an `ASSERT_HELPER`.

In order to properly capture line numbers, the functionality has to be hidden behind a `#define`, causing an extra `#define` to be declared for each helper function that does validation. The convention used is that the actual helper function be declared with a preceding underscore, and the `#define` have the same name without the underscore.