### PR TITLE
include parent folder in arcade hash for specific folder names

### DIFF
--- a/src/rhash/hash.c
+++ b/src/rhash/hash.c
@@ -505,6 +505,7 @@ static int rc_hash_arcade(char hash[33], const char* path)
             memcmp(folder, "fds", 3) == 0 ||
             memcmp(folder, "sms", 3) == 0 ||
             memcmp(folder, "msx", 3) == 0 ||
+            memcmp(folder, "ngp", 3) == 0 ||
             memcmp(folder, "pce", 3) == 0 ||
             memcmp(folder, "sgx", 3) == 0)
           include_folder = 1;

--- a/test/rhash/test_hash.c
+++ b/test/rhash/test_hash.c
@@ -214,6 +214,15 @@ static void test_hash_m3u(int console_id, const char* filename, size_t size, con
   ASSERT_STR_EQUALS(hash_iterator, expected_md5);
 }
 
+static void test_hash_filename(int console_id, const char* path, const char* expected_md5)
+{
+    char hash_file[33];
+    int result_file = rc_hash_generate_from_file(hash_file, console_id, path);
+
+    ASSERT_NUM_EQUALS(result_file, 1);
+    ASSERT_STR_EQUALS(hash_file, expected_md5);
+}
+
 /* ========================================================================= */
 
 static void test_hash_3do_bin()
@@ -575,6 +584,35 @@ void test_hash(void) {
 
   /* Apple II */
   TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_APPLE_II, "test.dsk", 143360, "88be638f4d78b4072109e55f13e8a0ac");
+
+  /* Arcade */
+  TEST_PARAMS3(test_hash_filename, RC_CONSOLE_ARCADE, "game.zip", "c8d46d341bea4fd5bff866a65ff8aea9");
+  TEST_PARAMS3(test_hash_filename, RC_CONSOLE_ARCADE, "/game.zip", "c8d46d341bea4fd5bff866a65ff8aea9");
+  TEST_PARAMS3(test_hash_filename, RC_CONSOLE_ARCADE, "\\game.zip", "c8d46d341bea4fd5bff866a65ff8aea9");
+  TEST_PARAMS3(test_hash_filename, RC_CONSOLE_ARCADE, "roms\\game.zip", "c8d46d341bea4fd5bff866a65ff8aea9");
+  TEST_PARAMS3(test_hash_filename, RC_CONSOLE_ARCADE, "C:\\roms\\game.zip", "c8d46d341bea4fd5bff866a65ff8aea9");
+  TEST_PARAMS3(test_hash_filename, RC_CONSOLE_ARCADE, "/home/user/roms/game.zip", "c8d46d341bea4fd5bff866a65ff8aea9");
+  TEST_PARAMS3(test_hash_filename, RC_CONSOLE_ARCADE, "/home/user/games/game.zip", "c8d46d341bea4fd5bff866a65ff8aea9");
+  TEST_PARAMS3(test_hash_filename, RC_CONSOLE_ARCADE, "/home/user/roms/game.7z", "c8d46d341bea4fd5bff866a65ff8aea9");
+
+  TEST_PARAMS3(test_hash_filename, RC_CONSOLE_ARCADE, "/home/user/nes_game.zip", "9b7aad36b365712fc93728088de4c209");
+  TEST_PARAMS3(test_hash_filename, RC_CONSOLE_ARCADE, "/home/user/nes/game.zip", "9b7aad36b365712fc93728088de4c209");
+  TEST_PARAMS3(test_hash_filename, RC_CONSOLE_ARCADE, "C:\\roms\\nes\\game.zip", "9b7aad36b365712fc93728088de4c209");
+  TEST_PARAMS3(test_hash_filename, RC_CONSOLE_ARCADE, "nes\\game.zip", "9b7aad36b365712fc93728088de4c209");
+  TEST_PARAMS3(test_hash_filename, RC_CONSOLE_ARCADE, "/home/user/snes/game.zip", "c8d46d341bea4fd5bff866a65ff8aea9");
+  TEST_PARAMS3(test_hash_filename, RC_CONSOLE_ARCADE, "/home/user/nes2/game.zip", "c8d46d341bea4fd5bff866a65ff8aea9");
+
+  TEST_PARAMS3(test_hash_filename, RC_CONSOLE_ARCADE, "/home/user/coleco/game.zip", "c546f63ae7de98add4b9f221a4749260");
+  TEST_PARAMS3(test_hash_filename, RC_CONSOLE_ARCADE, "/home/user/msx/game.zip", "59ab85f6b56324fd81b4e324b804c29f");
+  TEST_PARAMS3(test_hash_filename, RC_CONSOLE_ARCADE, "/home/user/pce/game.zip", "c414a783f3983bbe2e9e01d9d5320c7e");
+  TEST_PARAMS3(test_hash_filename, RC_CONSOLE_ARCADE, "/home/user/sgx/game.zip", "db545ab29694bfda1010317d4bac83b8");
+  TEST_PARAMS3(test_hash_filename, RC_CONSOLE_ARCADE, "/home/user/tg16/game.zip", "8b6c5c2e54915be2cdba63973862e143");
+  TEST_PARAMS3(test_hash_filename, RC_CONSOLE_ARCADE, "/home/user/fds/game.zip", "c0c135a97e8c577cfdf9204823ff211f");
+  TEST_PARAMS3(test_hash_filename, RC_CONSOLE_ARCADE, "/home/user/gamegear/game.zip", "f6f471e952b8103032b723f57bdbe767");
+  TEST_PARAMS3(test_hash_filename, RC_CONSOLE_ARCADE, "/home/user/sms/game.zip", "43f35f575dead94dd2f42f9caf69fe5a");
+  TEST_PARAMS3(test_hash_filename, RC_CONSOLE_ARCADE, "/home/user/megadriv/game.zip", "f99d0aaf12ba3eb6ced9878c76692c63");
+  TEST_PARAMS3(test_hash_filename, RC_CONSOLE_ARCADE, "/home/user/sg1000/game.zip", "e8f6c711c4371f09537b4f2a7a304d6c");
+  TEST_PARAMS3(test_hash_filename, RC_CONSOLE_ARCADE, "/home/user/spectrum/game.zip", "a5f62157b2617bd728c4b1bc885c29e9");
 
   /* Atari 2600 */
   TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_ATARI_2600, "test.bin", 2048, "02c3f2fa186388ba8eede9147fb431c4");

--- a/test/rhash/test_hash.c
+++ b/test/rhash/test_hash.c
@@ -613,6 +613,7 @@ void test_hash(void) {
   TEST_PARAMS3(test_hash_filename, RC_CONSOLE_ARCADE, "/home/user/megadriv/game.zip", "f99d0aaf12ba3eb6ced9878c76692c63");
   TEST_PARAMS3(test_hash_filename, RC_CONSOLE_ARCADE, "/home/user/sg1000/game.zip", "e8f6c711c4371f09537b4f2a7a304d6c");
   TEST_PARAMS3(test_hash_filename, RC_CONSOLE_ARCADE, "/home/user/spectrum/game.zip", "a5f62157b2617bd728c4b1bc885c29e9");
+  TEST_PARAMS3(test_hash_filename, RC_CONSOLE_ARCADE, "/home/user/ngp/game.zip", "d4133b74c4e57274ca514e27a370dcb6");
 
   /* Atari 2600 */
   TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_ATARI_2600, "test.bin", 2048, "02c3f2fa186388ba8eede9147fb431c4");


### PR DESCRIPTION
FBNeo supports several consoles in addition to arcade via subsystems. Because the arcade hash is just the md5 of the filename, this can lead to conflicts between actual arcade roms and console roms. To address this, I've been asked to include the parent folder as part of the hash when the parent folder is one of the [known subsystem keys](https://github.com/libretro/FBNeo/blob/master/src/burner/libretro/README.md#emulating-consoles).

For example, `columns.zip` could be the arcade game or the megadrive game. If present in the `megadriv` folder, the hash would be calculated from `megadriv_columns`, which would differentiate it from `columns`.

Note that FBNeo subsystem games must still be launched via the `Arcade > FBNeo` core in RALibretro. This may be confusing to users, but we don't really expect many to use FBNeo as their primary core for the consoles that FBNeo supports.

While this solution is primarily to avoid loading an arcade set for a non-arcade title, it's entirely possible that the non-arcade hash could be added. It would have to be done manually as the unknown game dialog would only show arcade titles. 