### PR TITLE
change open_track_handler to open largest data track when passed track 0

### DIFF
--- a/include/rhash.h
+++ b/include/rhash.h
@@ -92,7 +92,7 @@ extern "C" {
 
   /* ===================================================== */
 
-  /* opens a track from the specified file. track 0 indicates the first data track should be opened.
+  /* opens a track from the specified file. track 0 indicates the largest data track should be opened.
    * returns a handle to be passed to the other functions, or NULL if the track could not be opened.
    */
   typedef void* (*rc_hash_cdreader_open_track_handler)(const char* path, uint32_t track);

--- a/test/Makefile
+++ b/test/Makefile
@@ -67,6 +67,8 @@ OBJ=$(RC_SRC)/alloc.o \
     rcheevos/test_value.o \
     rurl/test_url.o \
     rhash/data.o \
+    rhash/mock_filereader.o \
+    rhash/test_cdreader.o \
     rhash/test_hash.o \
     test.o
 

--- a/test/rcheevos-test.vcxproj
+++ b/test/rcheevos-test.vcxproj
@@ -188,6 +188,8 @@
     <ClCompile Include="rcheevos\test_trigger.c" />
     <ClCompile Include="rcheevos\test_value.c" />
     <ClCompile Include="rhash\data.c" />
+    <ClCompile Include="rhash\mock_filereader.c" />
+    <ClCompile Include="rhash\test_cdreader.c" />
     <ClCompile Include="rhash\test_hash.c" />
     <ClCompile Include="rurl\test_url.c" />
     <ClCompile Include="test.c" />
@@ -201,6 +203,7 @@
     <ClInclude Include="..\src\rhash\md5.h" />
     <ClInclude Include="rcheevos\mock_memory.h" />
     <ClInclude Include="rhash\data.h" />
+    <ClInclude Include="rhash\mock_filereader.h" />
     <ClInclude Include="test_framework.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/test/rcheevos-test.vcxproj.filters
+++ b/test/rcheevos-test.vcxproj.filters
@@ -231,6 +231,12 @@
     <ClCompile Include="..\src\rhash\cdreader.c">
       <Filter>src\rhash</Filter>
     </ClCompile>
+    <ClCompile Include="rhash\test_cdreader.c">
+      <Filter>tests\rhash</Filter>
+    </ClCompile>
+    <ClCompile Include="rhash\mock_filereader.c">
+      <Filter>tests\rhash</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\src\rcheevos\internal.h">
@@ -259,6 +265,9 @@
     </ClInclude>
     <ClInclude Include="..\src\rhash\md5.h">
       <Filter>src\rhash</Filter>
+    </ClInclude>
+    <ClInclude Include="rhash\mock_filereader.h">
+      <Filter>tests\rhash</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/test/rhash/mock_filereader.c
+++ b/test/rhash/mock_filereader.c
@@ -1,0 +1,178 @@
+#include "rhash.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct mock_file_data
+{
+  const char* path;
+  const uint8_t* data;
+  size_t size;
+  size_t pos;
+} mock_file_data;
+
+static mock_file_data mock_file_instance[16];
+
+static void* _mock_file_open(const char* path)
+{
+  int i;
+  for (i = 0; i < sizeof(mock_file_instance) / sizeof(mock_file_instance[0]); ++i)
+  {
+    if (strcmp(path, mock_file_instance[i].path) == 0)
+    {
+      mock_file_instance[i].pos = 0;
+      return &mock_file_instance[i];
+    }
+  }
+
+  return NULL;
+}
+
+static void _mock_file_seek(void* file_handle, size_t offset, int origin)
+{
+  mock_file_data* file = (mock_file_data*)file_handle;
+  switch (origin)
+  {
+  case SEEK_SET:
+    file->pos = offset;
+    break;
+  case SEEK_CUR:
+    file->pos += offset;
+    break;
+  case SEEK_END:
+    file->pos = file->size - offset;
+    break;
+  }
+
+  if (file->pos > file->size)
+    file->pos = file->size;
+}
+
+static size_t _mock_file_tell(void* file_handle)
+{
+  mock_file_data* file = (mock_file_data*)file_handle;
+  return file->pos;
+}
+
+static size_t _mock_file_read(void* file_handle, void* buffer, size_t count)
+{
+  mock_file_data* file = (mock_file_data*)file_handle;
+  size_t remaining = file->size - file->pos;
+  if (count > remaining)
+    count = remaining;
+
+  if (count > 0)
+  {
+    if (file->data)
+      memcpy(buffer, &file->data[file->pos], count);
+    else
+      memset(buffer, 0, count);
+
+    file->pos += count;
+  }
+
+  return count;
+}
+
+static void _mock_file_close(void* file_handle)
+{
+}
+
+static void reset_mock_files()
+{
+  int i;
+
+  memset(&mock_file_instance, 0, sizeof(mock_file_instance));
+  for (i = 0; i < sizeof(mock_file_instance) / sizeof(mock_file_instance[0]); ++i)
+    mock_file_instance[i].path = "";
+}
+
+void init_mock_filereader()
+{
+  struct rc_hash_filereader reader;
+  reader.open = _mock_file_open;
+  reader.seek = _mock_file_seek;
+  reader.tell = _mock_file_tell;
+  reader.read = _mock_file_read;
+  reader.close = _mock_file_close;
+
+  rc_hash_init_custom_filereader(&reader);
+
+  reset_mock_files();
+}
+
+void mock_file(int index, const char* filename, const uint8_t* buffer, size_t buffer_size)
+{
+  if (index == 0)
+    reset_mock_files();
+
+  mock_file_instance[index].path = filename;
+  mock_file_instance[index].data = buffer;
+  mock_file_instance[index].size = buffer_size;
+  mock_file_instance[index].pos = 0;
+}
+
+void mock_file_size(int index, size_t mock_size)
+{
+  mock_file_instance[index].size = mock_size;
+}
+
+void mock_empty_file(int index, const char* filename, size_t mock_size)
+{
+  mock_file(index, filename, NULL, mock_size);
+}
+
+static void* _mock_cd_open_track(const char* path, uint32_t track)
+{
+  if (track < 2) /* 0 = first data track, 1 = primary track */
+  {
+    if (strstr(path, ".cue")) 
+    {
+      mock_file_data* file = (mock_file_data*)_mock_file_open(path);
+      if (!file)
+        return file;
+
+      return _mock_file_open((const char*)file->data);
+    }
+
+    return _mock_file_open(path);
+  }
+  else if (strstr(path, ".cue"))
+  {
+    mock_file_data* file = (mock_file_data*)_mock_file_open(path);
+    if (file)
+    {
+      char buffer[256];
+
+      const size_t file_len = strlen(file->data);
+      memcpy(buffer, file->data, file_len - 4);
+      sprintf(&buffer[file_len - 4], "%d%s", track, &file->data[file_len - 4]);
+
+      return _mock_file_open(buffer);
+    }
+  }
+
+  return NULL;
+}
+
+static size_t _mock_cd_read_sector(void* track_handle, uint32_t sector, void* buffer, size_t requested_bytes)
+{
+  _mock_file_seek(track_handle, sector * 2048, SEEK_SET);
+  return _mock_file_read(track_handle, buffer, requested_bytes);
+}
+
+void init_mock_cdreader()
+{
+  struct rc_hash_cdreader cdreader;
+  cdreader.open_track = _mock_cd_open_track;
+  cdreader.close_track = _mock_file_close;
+  cdreader.read_sector = _mock_cd_read_sector;
+
+  rc_hash_init_custom_cdreader(&cdreader);
+}
+
+const char* get_mock_filename(void* file_handle)
+{
+  mock_file_data* file = (mock_file_data*)file_handle;
+  return file->path;
+}

--- a/test/rhash/mock_filereader.c
+++ b/test/rhash/mock_filereader.c
@@ -144,7 +144,7 @@ static void* _mock_cd_open_track(const char* path, uint32_t track)
     {
       char buffer[256];
 
-      const size_t file_len = strlen(file->data);
+      const size_t file_len = strlen((const char*)file->data);
       memcpy(buffer, file->data, file_len - 4);
       sprintf(&buffer[file_len - 4], "%d%s", track, &file->data[file_len - 4]);
 

--- a/test/rhash/mock_filereader.h
+++ b/test/rhash/mock_filereader.h
@@ -1,0 +1,24 @@
+#ifndef RHASH_MOCK_FILEREADER_H
+#define RHASH_MOCK_FILEREADER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+#include <stddef.h>
+
+void init_mock_filereader();
+void init_mock_cdreader();
+
+void mock_file(int index, const char* filename, const uint8_t* buffer, size_t buffer_size);
+void mock_empty_file(int index, const char* filename, size_t mock_size);
+void mock_file_size(int index, size_t mock_size);
+
+const char* get_mock_filename(void* file_handle);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RHASH_MOCK_FILEREADER_H */

--- a/test/rhash/test_cdreader.c
+++ b/test/rhash/test_cdreader.c
@@ -291,7 +291,7 @@ static void test_open_cue_track_largest_data_only_audio()
   ASSERT_PTR_NULL(track_handle);
 }
 
-static void test_determine_sector_size_sync(sector_size)
+static void test_determine_sector_size_sync(int sector_size)
 {
   cdrom_t* track_handle;
   const size_t image_size = sector_size * 32;
@@ -315,7 +315,7 @@ static void test_determine_sector_size_sync(sector_size)
   free(image);
 }
 
-static void test_determine_sector_size_sync_primary_volume_descriptor(sector_size)
+static void test_determine_sector_size_sync_primary_volume_descriptor(int sector_size)
 {
   cdrom_t* track_handle;
   const size_t image_size = sector_size * 32;
@@ -340,7 +340,7 @@ static void test_determine_sector_size_sync_primary_volume_descriptor(sector_siz
   free(image);
 }
 
-static void test_determine_sector_size_sync_primary_volume_descriptor_index0(sector_size)
+static void test_determine_sector_size_sync_primary_volume_descriptor_index0(int sector_size)
 {
   unsigned char cue[] =
     "FILE \"game.bin\" BINARY\n"

--- a/test/rhash/test_cdreader.c
+++ b/test/rhash/test_cdreader.c
@@ -1,0 +1,551 @@
+#include "rhash.h"
+
+#include "../test_framework.h"
+#include "data.h"
+#include "mock_filereader.h"
+
+#include <stdlib.h>
+
+extern struct rc_hash_cdreader* cdreader;
+
+/* as defined in cdreader.c */
+typedef struct cdrom_t
+{
+  void* file_handle;
+  int sector_size;
+  int sector_header_size;
+  int first_sector_offset;
+} cdrom_t;
+
+static const unsigned char sync_pattern[] = {
+  0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x00
+};
+
+static unsigned char cue_single_track[] =
+  "FILE \"game.bin\" BINARY\n"
+  "  TRACK 01 MODE2/2352\n"
+  "    INDEX 01 00:00:00\n";
+
+static unsigned char cue_single_bin_multiple_data[] =
+  "FILE \"game.bin\" BINARY\n"
+  "  TRACK 01 AUDIO\n"
+  "    INDEX 01 00:00:00\n"
+  "  TRACK 02 MODE1/2352\n"
+  "    PREGAP 00:03:00\n"
+  "    INDEX 01 00:55:45\n"
+  "  TRACK 03 MODE1/2352\n"
+  "    INDEX 01 11:30:74\n"
+  "  TRACK 04 MODE1/2352\n"
+  "    INDEX 01 13:31:51\n"
+  "  TRACK 05 MODE1/2352\n"
+  "    INDEX 01 13:48:56\n"
+  "  TRACK 06 MODE1/2352\n"
+  "    INDEX 01 34:48:19\n"
+  "  TRACK 07 MODE1/2352\n"
+  "    INDEX 01 50:42:74\n"
+  "  TRACK 08 MODE1/2352\n"
+  "    INDEX 01 55:20:74\n"
+  "  TRACK 09 MODE1/2352\n"
+  "    INDEX 01 56:25:67\n"
+  "  TRACK 10 MODE1/2352\n"
+  "    INDEX 01 59:04:08\n"
+  "  TRACK 11 MODE1/2352\n"
+  "    INDEX 01 61:17:18\n"
+  "  TRACK 12 MODE1/2352\n"
+  "    INDEX 01 62:44:33\n"
+  "  TRACK 13 AUDIO\n"
+  "    PREGAP 00:02:00\n"
+  "    INDEX 01 66:24:37\n";
+
+static unsigned char cue_multiple_bin_multiple_data[] =
+  "FILE \"track1.bin\" BINARY\n"
+  "  TRACK 01 AUDIO\n"
+  "    INDEX 01 00:00:00\n"
+  "FILE \"track2.bin\" BINARY\n"
+  "  TRACK 02 MODE1/2352\n"
+  "    INDEX 00 00:00:00\n"
+  "    INDEX 01 00:03:00\n"
+  "FILE \"track3.bin\" BINARY\n"
+  "  TRACK 03 MODE1/2352\n"
+  "    INDEX 00 00:00:00\n"
+  "    INDEX 01 00:02:00\n"
+  "FILE \"track4.bin\" BINARY\n"
+  "  TRACK 04 AUDIO\n"
+  "    INDEX 00 00:00:00\n";
+
+static void test_open_cue_track_2()
+{
+  cdrom_t* track_handle;
+
+  mock_file(0, "game.cue", cue_single_bin_multiple_data, sizeof(cue_single_bin_multiple_data));
+  mock_empty_file(1, "game.bin", 718310208);
+
+  track_handle = (cdrom_t*)cdreader->open_track("game.cue", 2);
+  ASSERT_PTR_NOT_NULL(track_handle);
+
+  ASSERT_PTR_NOT_NULL(track_handle->file_handle);
+  ASSERT_STR_EQUALS(get_mock_filename(track_handle->file_handle), "game.bin");
+  ASSERT_NUM_EQUALS(track_handle->first_sector_offset, 9807840); /* track 2: 0x95A7E0 */
+  ASSERT_NUM_EQUALS(track_handle->sector_size, 2352);
+  ASSERT_NUM_EQUALS(track_handle->sector_header_size, 16);
+
+  cdreader->close_track(track_handle);
+}
+
+static void test_open_cue_track_12()
+{
+  cdrom_t* track_handle;
+
+  mock_file(0, "game.cue", cue_single_bin_multiple_data, sizeof(cue_single_bin_multiple_data));
+  mock_empty_file(1, "game.bin", 718310208);
+
+  track_handle = (cdrom_t*)cdreader->open_track("game.cue", 12);
+  ASSERT_PTR_NOT_NULL(track_handle);
+
+  ASSERT_PTR_NOT_NULL(track_handle->file_handle);
+  ASSERT_STR_EQUALS(get_mock_filename(track_handle->file_handle), "game.bin");
+  ASSERT_NUM_EQUALS(track_handle->first_sector_offset, 664047216); /* track 12: 0x27948E70 */
+  ASSERT_NUM_EQUALS(track_handle->sector_size, 2352);
+  ASSERT_NUM_EQUALS(track_handle->sector_header_size, 16);
+
+  cdreader->close_track(track_handle);
+}
+
+static void test_open_cue_track_14()
+{
+  cdrom_t* track_handle;
+
+  mock_file(0, "game.cue", cue_single_bin_multiple_data, sizeof(cue_single_bin_multiple_data));
+  mock_empty_file(1, "game.bin", 718310208);
+
+  /* only 13 tracks */
+  track_handle = (cdrom_t*)cdreader->open_track("game.cue", 14);
+  ASSERT_PTR_NULL(track_handle);
+}
+
+static void test_open_cue_track_missing_bin()
+{
+  cdrom_t* track_handle;
+
+  mock_file(0, "game.cue", cue_single_bin_multiple_data, sizeof(cue_single_bin_multiple_data));
+
+  track_handle = (cdrom_t*)cdreader->open_track("game.cue", 2);
+  ASSERT_PTR_NULL(track_handle);
+}
+
+static void test_open_cue_track_largest_data()
+{
+  cdrom_t* track_handle;
+	
+  mock_file(0, "game.cue", cue_single_bin_multiple_data, sizeof(cue_single_bin_multiple_data));
+  mock_empty_file(1, "game.bin", 718310208);
+
+  track_handle = (cdrom_t*)cdreader->open_track("game.cue", 0);
+  ASSERT_PTR_NOT_NULL(track_handle);
+
+  ASSERT_PTR_NOT_NULL(track_handle->file_handle);
+  ASSERT_STR_EQUALS(get_mock_filename(track_handle->file_handle), "game.bin");
+  ASSERT_NUM_EQUALS(track_handle->first_sector_offset, 146190912); /* track 5: 0x8B6B240 */
+  ASSERT_NUM_EQUALS(track_handle->sector_size, 2352);
+  ASSERT_NUM_EQUALS(track_handle->sector_header_size, 16);
+
+  cdreader->close_track(track_handle);
+}
+
+static void test_open_cue_track_largest_data_last_track()
+{
+  cdrom_t* track_handle;
+  const unsigned char cue[] =
+	  "FILE \"game.bin\" BINARY\n"
+	  "  TRACK 01 AUDIO\n"
+	  "    INDEX 01 00:00:00\n"
+	  "  TRACK 02 MODE1/2352\n"
+	  "    PREGAP 00:03:00\n"
+	  "    INDEX 01 00:55:45\n"
+	  "  TRACK 03 MODE1/2352\n"
+	  "    INDEX 01 11:30:74\n"
+	  "  TRACK 04 MODE1/2352\n"
+	  "    INDEX 01 13:31:51\n"
+	  "  TRACK 05 MODE1/2352\n"
+	  "    INDEX 01 13:48:56\n";
+
+  mock_file(0, "game.cue", cue, sizeof(cue));
+  mock_empty_file(1, "game.bin", 718310208);
+
+  track_handle = (cdrom_t*)cdreader->open_track("game.cue", 0);
+  ASSERT_PTR_NOT_NULL(track_handle);
+
+  ASSERT_PTR_NOT_NULL(track_handle->file_handle);
+  ASSERT_STR_EQUALS(get_mock_filename(track_handle->file_handle), "game.bin");
+  ASSERT_NUM_EQUALS(track_handle->first_sector_offset, 146190912); /* track 5: 0x8B6B240 */
+  ASSERT_NUM_EQUALS(track_handle->sector_size, 2352);
+  ASSERT_NUM_EQUALS(track_handle->sector_header_size, 16);
+
+  cdreader->close_track(track_handle);
+}
+
+static void test_open_cue_track_largest_data_index0s()
+{
+  cdrom_t* track_handle;
+  const unsigned char cue[] =
+	  "FILE \"game.bin\" BINARY\n"
+	  "  TRACK 01 AUDIO\n"
+	  "    INDEX 01 00:00:00\n"
+	  "  TRACK 02 MODE1/2352\n"
+	  "    INDEX 00 00:44:65\n"
+	  "    INDEX 01 00:47:65\n"
+	  "  TRACK 03 AUDIO\n"
+	  "    INDEX 00 01:19:52\n"
+	  "    INDEX 01 01:21:52\n";
+
+  mock_file(0, "game.cue", cue, sizeof(cue));
+  mock_empty_file(1, "game.bin", 718310208);
+
+  track_handle = (cdrom_t*)cdreader->open_track("game.cue", 0);
+  ASSERT_PTR_NOT_NULL(track_handle);
+
+  ASSERT_PTR_NOT_NULL(track_handle->file_handle);
+  ASSERT_STR_EQUALS(get_mock_filename(track_handle->file_handle), "game.bin");
+  ASSERT_NUM_EQUALS(track_handle->first_sector_offset, 8443680); /* track 2: 0x80D720 (00:47:65) */
+  ASSERT_NUM_EQUALS(track_handle->sector_size, 2352);
+  ASSERT_NUM_EQUALS(track_handle->sector_header_size, 16);
+
+  cdreader->close_track(track_handle);
+}
+
+static void test_open_cue_track_largest_data_index2()
+{
+  cdrom_t* track_handle;
+  const unsigned char cue[] =
+	  "FILE \"game.bin\" BINARY\n"
+	  "  TRACK 01 AUDIO\n"
+	  "    INDEX 01 00:00:00\n"
+	  "  TRACK 02 MODE1/2352\n"
+	  "    INDEX 00 00:00:00\n"
+	  "    INDEX 01 00:02:00\n"
+	  "    INDEX 02 00:08:64\n";
+
+  mock_file(0, "game.cue", cue, sizeof(cue));
+  mock_empty_file(1, "game.bin", 718310208);
+
+  track_handle = (cdrom_t*)cdreader->open_track("game.cue", 0);
+  ASSERT_PTR_NOT_NULL(track_handle);
+
+  ASSERT_PTR_NOT_NULL(track_handle->file_handle);
+  ASSERT_STR_EQUALS(get_mock_filename(track_handle->file_handle), "game.bin");
+  ASSERT_NUM_EQUALS(track_handle->first_sector_offset, 352800); /* 00:02:00 = 150 frames in */
+  ASSERT_NUM_EQUALS(track_handle->sector_size, 2352);
+  ASSERT_NUM_EQUALS(track_handle->sector_header_size, 16);
+
+  cdreader->close_track(track_handle);
+}
+
+static void test_open_cue_track_largest_data_multiple_bins()
+{
+  cdrom_t* track_handle;
+	
+  mock_file(0, "game.cue", cue_multiple_bin_multiple_data, sizeof(cue_multiple_bin_multiple_data));
+  mock_empty_file(1, "track1.bin", 4132464);
+  mock_empty_file(2, "track2.bin", 30080102);
+  mock_empty_file(3, "track3.bin", 40343152);
+  mock_empty_file(4, "track4.bin", 47277552);
+
+  track_handle = (cdrom_t*)cdreader->open_track("game.cue", 0);
+  ASSERT_PTR_NOT_NULL(track_handle);
+
+  ASSERT_PTR_NOT_NULL(track_handle->file_handle);
+  ASSERT_STR_EQUALS(get_mock_filename(track_handle->file_handle), "track3.bin");
+  ASSERT_NUM_EQUALS(track_handle->first_sector_offset, 352800); /* 00:02:00 = 150 frames in */
+  ASSERT_NUM_EQUALS(track_handle->sector_size, 2352);
+  ASSERT_NUM_EQUALS(track_handle->sector_header_size, 16);
+
+  cdreader->close_track(track_handle);
+}
+
+static void test_open_cue_track_largest_data_only_audio()
+{
+  unsigned char cue[] =
+    "FILE \"track1.bin\" BINARY\n"
+    "  TRACK 01 AUDIO\n"
+    "    INDEX 01 00:00:00\n"
+    "FILE \"track2.bin\" BINARY\n"
+    "  TRACK 02 AUDIO\n"
+    "    INDEX 00 00:00:00\n"
+    "    INDEX 01 00:03:00\n"
+    "FILE \"track3.bin\" BINARY\n"
+    "  TRACK 03 AUDIO\n"
+    "    INDEX 00 00:00:00\n"
+    "    INDEX 01 00:02:00\n"
+    "FILE \"track4.bin\" BINARY\n"
+    "  TRACK 04 AUDIO\n"
+    "    INDEX 00 00:00:00\n";
+  cdrom_t* track_handle;
+
+  mock_file(0, "game.cue", cue, sizeof(cue));
+  mock_empty_file(1, "track1.bin", 4132464);
+  mock_empty_file(2, "track2.bin", 30080102);
+  mock_empty_file(3, "track3.bin", 40343152);
+  mock_empty_file(4, "track4.bin", 47277552);
+
+  track_handle = (cdrom_t*)cdreader->open_track("game.cue", 0);
+  ASSERT_PTR_NULL(track_handle);
+}
+
+static void test_determine_sector_size_sync(sector_size)
+{
+  cdrom_t* track_handle;
+  const size_t image_size = sector_size * 32;
+  unsigned char* image = (unsigned char*)malloc(image_size);
+  mock_file(0, "game.cue", cue_single_track, sizeof(cue_single_track));
+  mock_file(1, "game.bin", image, image_size);
+
+  memset(image, 0, image_size);
+  memcpy(&image[sector_size * 16], sync_pattern, sizeof(sync_pattern));
+
+  track_handle = (cdrom_t*)cdreader->open_track("game.cue", 1);
+  ASSERT_PTR_NOT_NULL(track_handle);
+
+  ASSERT_PTR_NOT_NULL(track_handle->file_handle);
+  ASSERT_STR_EQUALS(get_mock_filename(track_handle->file_handle), "game.bin");
+  ASSERT_NUM_EQUALS(track_handle->first_sector_offset, 0);
+  ASSERT_NUM_EQUALS(track_handle->sector_size, sector_size);
+  ASSERT_NUM_EQUALS(track_handle->sector_header_size, 16);
+
+  cdreader->close_track(track_handle);
+  free(image);
+}
+
+static void test_determine_sector_size_sync_primary_volume_descriptor(sector_size)
+{
+  cdrom_t* track_handle;
+  const size_t image_size = sector_size * 32;
+  unsigned char* image = (unsigned char*)malloc(image_size);
+  mock_file(0, "game.cue", cue_single_track, sizeof(cue_single_track));
+  mock_file(1, "game.bin", image, image_size);
+
+  memset(image, 0, image_size);
+  memcpy(&image[sector_size * 16], sync_pattern, sizeof(sync_pattern));
+  memcpy(&image[sector_size * 16 + 25], "CD001", 5);
+
+  track_handle = (cdrom_t*)cdreader->open_track("game.cue", 1);
+  ASSERT_PTR_NOT_NULL(track_handle);
+
+  ASSERT_PTR_NOT_NULL(track_handle->file_handle);
+  ASSERT_STR_EQUALS(get_mock_filename(track_handle->file_handle), "game.bin");
+  ASSERT_NUM_EQUALS(track_handle->first_sector_offset, 0);
+  ASSERT_NUM_EQUALS(track_handle->sector_size, sector_size);
+  ASSERT_NUM_EQUALS(track_handle->sector_header_size, 24);
+
+  cdreader->close_track(track_handle);
+  free(image);
+}
+
+static void test_determine_sector_size_sync_primary_volume_descriptor_index0(sector_size)
+{
+  unsigned char cue[] =
+    "FILE \"game.bin\" BINARY\n"
+    "  TRACK 01 MODE2/2352\n"
+    "    INDEX 00 00:00:00\n"
+    "    INDEX 01 00:02:00\n";
+
+  cdrom_t* track_handle;
+  const size_t image_size = sector_size * 200;
+  unsigned char* image = (unsigned char*)malloc(image_size);
+  mock_file(0, "game.cue", cue, sizeof(cue));
+  mock_file(1, "game.bin", image, image_size);
+
+  char sector_size_str[16];
+  sprintf(sector_size_str, "%d", sector_size);
+  memcpy(&cue[40], sector_size_str, 4);
+
+  memset(image, 0, image_size);
+  memcpy(&image[sector_size * (150 + 16)], sync_pattern, sizeof(sync_pattern));
+  memcpy(&image[sector_size * (150 + 16) + 25], "CD001", 5);
+
+  track_handle = (cdrom_t*)cdreader->open_track("game.cue", 1);
+  ASSERT_PTR_NOT_NULL(track_handle);
+
+  ASSERT_PTR_NOT_NULL(track_handle->file_handle);
+  ASSERT_STR_EQUALS(get_mock_filename(track_handle->file_handle), "game.bin");
+  ASSERT_NUM_EQUALS(track_handle->first_sector_offset, sector_size * 150);
+  ASSERT_NUM_EQUALS(track_handle->sector_size, sector_size);
+  ASSERT_NUM_EQUALS(track_handle->sector_header_size, 24);
+
+  cdreader->close_track(track_handle);
+  free(image);
+}
+
+static void test_determine_sector_size_sync_2048()
+{
+  cdrom_t* track_handle;
+  const int sector_size = 2048;
+  const size_t image_size = sector_size * 32;
+  unsigned char* image = (unsigned char*)malloc(image_size);
+  mock_file(0, "game.cue", cue_single_track, sizeof(cue_single_track));
+  mock_file(1, "game.bin", image, image_size);
+
+  memset(image, 0, image_size);
+
+  /* 2048 byte sectors don't have a sync pattern - will use mode specified in header */
+  track_handle = (cdrom_t*)cdreader->open_track("game.cue", 1);
+  ASSERT_PTR_NOT_NULL(track_handle);
+
+  ASSERT_PTR_NOT_NULL(track_handle->file_handle);
+  ASSERT_STR_EQUALS(get_mock_filename(track_handle->file_handle), "game.bin");
+  ASSERT_NUM_EQUALS(track_handle->first_sector_offset, 0);
+  ASSERT_NUM_EQUALS(track_handle->sector_size, 2352);
+  ASSERT_NUM_EQUALS(track_handle->sector_header_size, 24);
+
+  cdreader->close_track(track_handle);
+  free(image);
+}
+
+static void test_determine_sector_size_sync_primary_volume_descriptor_2048()
+{
+  cdrom_t* track_handle;
+  const int sector_size = 2048;
+  const size_t image_size = sector_size * 32;
+  unsigned char* image = (unsigned char*)malloc(image_size);
+  mock_file(0, "game.cue", cue_single_track, sizeof(cue_single_track));
+  mock_file(1, "game.bin", image, image_size);
+
+  memset(image, 0, image_size);
+  memcpy(&image[sector_size * 16 + 1], "CD001", 5);
+
+  track_handle = (cdrom_t*)cdreader->open_track("game.cue", 1);
+  ASSERT_PTR_NOT_NULL(track_handle);
+
+  ASSERT_PTR_NOT_NULL(track_handle->file_handle);
+  ASSERT_STR_EQUALS(get_mock_filename(track_handle->file_handle), "game.bin");
+  ASSERT_NUM_EQUALS(track_handle->first_sector_offset, 0);
+  ASSERT_NUM_EQUALS(track_handle->sector_size, sector_size);
+  ASSERT_NUM_EQUALS(track_handle->sector_header_size, 0);
+
+  cdreader->close_track(track_handle);
+  free(image);
+}
+
+static void test_determine_sector_size_sync_primary_volume_descriptor_index0_2048()
+{
+  unsigned char cue[] =
+    "FILE \"game.bin\" BINARY\n"
+    "  TRACK 01 MODE1/2048\n"
+    "    INDEX 00 00:00:00\n"
+    "    INDEX 01 00:02:00\n";
+
+  cdrom_t* track_handle;
+  const int sector_size = 2048;
+  const size_t image_size = sector_size * 200;
+  unsigned char* image = (unsigned char*)malloc(image_size);
+  mock_file(0, "game.cue", cue, sizeof(cue));
+  mock_file(1, "game.bin", image, image_size);
+
+  char sector_size_str[16];
+  sprintf(sector_size_str, "%d", sector_size);
+  memcpy(&cue[40], sector_size_str, 4);
+
+  memset(image, 0, image_size);
+  memcpy(&image[sector_size * (150 + 16) + 1], "CD001", 5);
+
+  track_handle = (cdrom_t*)cdreader->open_track("game.cue", 1);
+  ASSERT_PTR_NOT_NULL(track_handle);
+
+  ASSERT_PTR_NOT_NULL(track_handle->file_handle);
+  ASSERT_STR_EQUALS(get_mock_filename(track_handle->file_handle), "game.bin");
+  ASSERT_NUM_EQUALS(track_handle->first_sector_offset, sector_size * 150);
+  ASSERT_NUM_EQUALS(track_handle->sector_size, sector_size);
+  ASSERT_NUM_EQUALS(track_handle->sector_header_size, 0);
+
+  cdreader->close_track(track_handle);
+  free(image);
+}
+
+static void test_read_sector()
+{
+  char buffer[4096];
+  cdrom_t* track_handle;
+  const size_t image_size = 2352 * 32;
+  unsigned char* image = (unsigned char*)malloc(image_size);
+  int offset, i;
+
+  mock_file(0, "game.cue", cue_single_track, sizeof(cue_single_track));
+  mock_file(1, "game.bin", image, image_size);
+
+  memset(image, 0, image_size);
+  memcpy(&image[2352 * 16], sync_pattern, sizeof(sync_pattern));
+
+  offset = 2352 * 1 + 16;
+  for (i = 0; i < 26; i++)
+  {
+	memset(&image[offset], i + 'A', 256);
+	offset += 256;
+
+	if ((i % 8) == 7)
+      offset += (2352 - 2048);
+  }
+
+  track_handle = (cdrom_t*)cdreader->open_track("game.cue", 1);
+  ASSERT_PTR_NOT_NULL(track_handle);
+
+  ASSERT_PTR_NOT_NULL(track_handle->file_handle);
+  ASSERT_STR_EQUALS(get_mock_filename(track_handle->file_handle), "game.bin");
+  ASSERT_NUM_EQUALS(track_handle->first_sector_offset, 0);
+  ASSERT_NUM_EQUALS(track_handle->sector_size, 2352);
+  ASSERT_NUM_EQUALS(track_handle->sector_header_size, 16);
+
+  /* read across multiple sectors */
+  ASSERT_NUM_EQUALS(cdreader->read_sector(track_handle, 1, buffer, sizeof(buffer)), 4096);
+
+  ASSERT_NUM_EQUALS(buffer[0], 'A');
+  ASSERT_NUM_EQUALS(buffer[255], 'A');
+  ASSERT_NUM_EQUALS(buffer[256], 'B');
+  ASSERT_NUM_EQUALS(buffer[2047], 'H');
+  ASSERT_NUM_EQUALS(buffer[2048], 'I');
+  ASSERT_NUM_EQUALS(buffer[4095], 'P');
+
+  /* read of partial sector */
+  ASSERT_NUM_EQUALS(cdreader->read_sector(track_handle, 2, buffer, 10), 10);
+  ASSERT_NUM_EQUALS(buffer[0], 'I');
+  ASSERT_NUM_EQUALS(buffer[9], 'I');
+  ASSERT_NUM_EQUALS(buffer[10], 'A');
+
+  cdreader->close_track(track_handle);
+  free(image);
+}
+
+/* ========================================================================= */
+
+void test_cdreader(void) {
+  TEST_SUITE_BEGIN();
+
+  init_mock_filereader();
+  rc_hash_init_default_cdreader();
+  
+  TEST(test_open_cue_track_2);
+  TEST(test_open_cue_track_12);
+  TEST(test_open_cue_track_14);
+  TEST(test_open_cue_track_missing_bin);
+
+  TEST(test_open_cue_track_largest_data);
+  TEST(test_open_cue_track_largest_data_last_track);
+  TEST(test_open_cue_track_largest_data_index0s);
+  TEST(test_open_cue_track_largest_data_index2);
+  TEST(test_open_cue_track_largest_data_multiple_bins);
+  TEST(test_open_cue_track_largest_data_only_audio);
+
+  TEST_PARAMS1(test_determine_sector_size_sync, 2352);
+  TEST_PARAMS1(test_determine_sector_size_sync_primary_volume_descriptor, 2352);
+  TEST_PARAMS1(test_determine_sector_size_sync_primary_volume_descriptor_index0, 2352);
+
+  TEST_PARAMS1(test_determine_sector_size_sync, 2336);
+  TEST_PARAMS1(test_determine_sector_size_sync_primary_volume_descriptor, 2336);
+  TEST_PARAMS1(test_determine_sector_size_sync_primary_volume_descriptor_index0, 2336);
+
+  TEST(test_determine_sector_size_sync_2048);
+  TEST(test_determine_sector_size_sync_primary_volume_descriptor_2048);
+  TEST(test_determine_sector_size_sync_primary_volume_descriptor_index0_2048);
+
+  TEST(test_read_sector);
+
+  TEST_SUITE_END();
+}

--- a/test/rhash/test_hash.c
+++ b/test/rhash/test_hash.c
@@ -2,137 +2,9 @@
 
 #include "../test_framework.h"
 #include "data.h"
+#include "mock_filereader.h"
 
 #include <stdlib.h>
-
-
-typedef struct mock_file_data
-{
-  const char* path;
-  const uint8_t* data;
-  size_t size;
-  size_t pos;
-} mock_file_data;
-
-static mock_file_data mock_file_instance[4];
-
-static void* _mock_file_open(const char* path)
-{
-  int i;
-  for (i = 0; i < sizeof(mock_file_instance)/sizeof(mock_file_instance[0]); ++i)
-  {
-    if (strcmp(path, mock_file_instance[i].path) == 0)
-    {
-      mock_file_instance[i].pos = 0;
-      return &mock_file_instance[i];
-    }
-  }
-
-  return NULL;
-}
-
-static void _mock_file_seek(void* file_handle, size_t offset, int origin)
-{
-  mock_file_data* file = (mock_file_data*)file_handle;
-  switch (origin)
-  {
-    case SEEK_SET:
-      file->pos = offset;
-      break;
-    case SEEK_CUR:
-      file->pos += offset;
-      break;
-    case SEEK_END:
-      file->pos = file->size - offset;
-      break;
-  }
-
-  if (file->pos > file->size)
-    file->pos = file->size;
-}
-
-static size_t _mock_file_tell(void* file_handle)
-{
-  mock_file_data* file = (mock_file_data*)file_handle;
-  return file->pos;
-}
-
-static size_t _mock_file_read(void* file_handle, void* buffer, size_t count)
-{
-  mock_file_data* file = (mock_file_data*)file_handle;
-  size_t remaining = file->size - file->pos;
-  if (count > remaining)
-    count = remaining;
-
-  if (count > 0)
-  {
-    memcpy(buffer, &file->data[file->pos], count);
-    file->pos += count;
-  }
-
-  return count;
-}
-
-static void _mock_file_close(void* file_handle)
-{
-}
-
-static void* _mock_cd_open_track(const char* path, uint32_t track)
-{
-  if (track < 2) /* 0 = first data track, 1 = primary track */
-  {
-    if (strstr(path, ".cue")) 
-    {
-      mock_file_data* file = (mock_file_data*)_mock_file_open(path);
-      if (!file)
-        return file;
-
-      return _mock_file_open((const char*)file->data);
-    }
-
-    return _mock_file_open(path);
-  }
-
-  return NULL;
-}
-
-static size_t _mock_cd_read_sector(void* track_handle, uint32_t sector, void* buffer, size_t requested_bytes)
-{
-  _mock_file_seek(track_handle, sector * 2048, SEEK_SET);
-  return _mock_file_read(track_handle, buffer, requested_bytes);
-}
-
-static void init_mock_filereader()
-{
-  int i;
-
-  struct rc_hash_filereader reader;
-  reader.open = _mock_file_open;
-  reader.seek = _mock_file_seek;
-  reader.tell = _mock_file_tell;
-  reader.read = _mock_file_read;
-  reader.close = _mock_file_close;
-
-  struct rc_hash_cdreader cdreader;
-  cdreader.open_track = _mock_cd_open_track;
-  cdreader.close_track = _mock_file_close;
-  cdreader.read_sector = _mock_cd_read_sector;
-
-  rc_hash_init_custom_filereader(&reader);
-  rc_hash_init_custom_cdreader(&cdreader);
-
-  memset(&mock_file_instance, 0, sizeof(mock_file_instance));
-  for (i = 0; i < sizeof(mock_file_instance) / sizeof(mock_file_instance[0]); ++i)
-    mock_file_instance[i].path = "";
-}
-
-static void mock_file(int index, const char* filename, const uint8_t* buffer, size_t buffer_size)
-{
-  mock_file_instance[index].path = filename;
-  mock_file_instance[index].data = buffer;
-  mock_file_instance[index].size = buffer_size;
-  mock_file_instance[index].pos = 0;
-}
 
 static int hash_mock_file(const char* filename, char hash[33], int console_id, const uint8_t* buffer, size_t buffer_size)
 {
@@ -255,9 +127,9 @@ static void test_hash_3do_bin()
   int result_iterator;
   struct rc_hash_iterator iterator;
 
-  mock_file_instance[0].size = 45678901; /* must be > 32MB for iterator to consider CD formats for bin */
+  mock_file_size(0, 45678901); /* must be > 32MB for iterator to consider CD formats for bin */
   rc_hash_initialize_iterator(&iterator, "game.bin", NULL, 0);
-  mock_file_instance[0].size = image_size; /* change it back before doing the hashing */
+  mock_file_size(0, image_size); /* change it back before doing the hashing */
 
   result_iterator = rc_hash_iterate(hash_iterator, &iterator);
   rc_hash_destroy_iterator(&iterator);
@@ -692,6 +564,7 @@ static void test_hash_pcfx_pce_cd()
 
   mock_file(0, "game.bin", image, image_size);
   mock_file(1, "game.cue", (uint8_t*)"game.bin", 8);
+  mock_file(2, "game2.bin", image, image_size); /* PC-Engine CD check only applies to track 2 */
 
   /* test file hash */
   int result_file = rc_hash_generate_from_file(hash_file, RC_CONSOLE_PCFX, "game.cue");
@@ -850,6 +723,7 @@ void test_hash(void) {
   TEST_SUITE_BEGIN();
 
   init_mock_filereader();
+  init_mock_cdreader();
 
   /* 3DO */
   TEST(test_hash_3do_bin);

--- a/test/test.c
+++ b/test/test.c
@@ -60,6 +60,7 @@ extern void test_consoleinfo();
 
 extern void test_url();
 
+extern void test_cdreader();
 extern void test_hash();
 
 TEST_FRAMEWORK_DECLARATIONS()
@@ -85,6 +86,7 @@ int main(void) {
 
   test_url();
 
+  test_cdreader();
   test_hash();
 
   TEST_FRAMEWORK_SHUTDOWN();


### PR DESCRIPTION
fixes issue identifying some PC-FX titles where the boot code is not in the first data track

added unit tests for cdreader code