### PR TITLE
Add hash validation for Dreamcast GDI files

### DIFF
--- a/include/rhash.h
+++ b/include/rhash.h
@@ -105,9 +105,8 @@ extern "C" {
   /* closes the track handle */
   typedef void (*rc_hash_cdreader_close_track_handler)(void* track_handle);
 
+  /* get number of tracks */
   typedef int (*rc_hash_cdreader_num_tracks_handler)(const char* path);
-
-  typedef uint32_t(*rc_hash_cdreader_get_lba_handler)(void* track_handle);
 
   struct rc_hash_cdreader
   {
@@ -115,7 +114,6 @@ extern "C" {
     rc_hash_cdreader_read_sector_handler          read_sector;
     rc_hash_cdreader_close_track_handler          close_track;
     rc_hash_cdreader_num_tracks_handler           num_tracks;
-    rc_hash_cdreader_get_lba_handler              get_lba;
   };
 
   void rc_hash_init_default_cdreader();

--- a/include/rhash.h
+++ b/include/rhash.h
@@ -105,14 +105,17 @@ extern "C" {
   /* closes the track handle */
   typedef void (*rc_hash_cdreader_close_track_handler)(void* track_handle);
 
+  typedef int (*rc_hash_cdreader_num_tracks_track_handler)(const char* path);
+
   typedef uint32_t(*rc_hash_cdreader_get_lba_handler)(void* track_handle);
 
   struct rc_hash_cdreader
   {
-    rc_hash_cdreader_open_track_handler      open_track;
-    rc_hash_cdreader_read_sector_handler     read_sector;
-    rc_hash_cdreader_close_track_handler     close_track;
-    rc_hash_cdreader_get_lba_handler         get_lba;
+    rc_hash_cdreader_open_track_handler           open_track;
+    rc_hash_cdreader_read_sector_handler          read_sector;
+    rc_hash_cdreader_close_track_handler          close_track;
+    rc_hash_cdreader_num_tracks_track_handler     num_tracks;
+    rc_hash_cdreader_get_lba_handler              get_lba;
   };
 
   void rc_hash_init_default_cdreader();

--- a/include/rhash.h
+++ b/include/rhash.h
@@ -105,7 +105,7 @@ extern "C" {
   /* closes the track handle */
   typedef void (*rc_hash_cdreader_close_track_handler)(void* track_handle);
 
-  typedef int (*rc_hash_cdreader_get_lba_handler)(void* track_handle);
+  typedef uint32_t(*rc_hash_cdreader_get_lba_handler)(void* track_handle);
 
   struct rc_hash_cdreader
   {

--- a/include/rhash.h
+++ b/include/rhash.h
@@ -105,11 +105,14 @@ extern "C" {
   /* closes the track handle */
   typedef void (*rc_hash_cdreader_close_track_handler)(void* track_handle);
 
+  typedef int (*rc_hash_cdreader_get_lba_handler)(void* track_handle);
+
   struct rc_hash_cdreader
   {
     rc_hash_cdreader_open_track_handler      open_track;
     rc_hash_cdreader_read_sector_handler     read_sector;
     rc_hash_cdreader_close_track_handler     close_track;
+    rc_hash_cdreader_get_lba_handler         get_lba;
   };
 
   void rc_hash_init_default_cdreader();

--- a/include/rhash.h
+++ b/include/rhash.h
@@ -105,7 +105,7 @@ extern "C" {
   /* closes the track handle */
   typedef void (*rc_hash_cdreader_close_track_handler)(void* track_handle);
 
-  typedef int (*rc_hash_cdreader_num_tracks_track_handler)(const char* path);
+  typedef int (*rc_hash_cdreader_num_tracks_handler)(const char* path);
 
   typedef uint32_t(*rc_hash_cdreader_get_lba_handler)(void* track_handle);
 
@@ -114,7 +114,7 @@ extern "C" {
     rc_hash_cdreader_open_track_handler           open_track;
     rc_hash_cdreader_read_sector_handler          read_sector;
     rc_hash_cdreader_close_track_handler          close_track;
-    rc_hash_cdreader_num_tracks_track_handler     num_tracks;
+    rc_hash_cdreader_num_tracks_handler           num_tracks;
     rc_hash_cdreader_get_lba_handler              get_lba;
   };
 

--- a/src/rhash/cdreader.c
+++ b/src/rhash/cdreader.c
@@ -546,13 +546,16 @@ static void* cdreader_open_gdi_track(const char* path, uint32_t track)
     while (*ptr != '\n' && ptr < end)
     {
       ++ptr;
+      if (*ptr == '\n')
+      {
+        ++ptr;
+        break;
+      }
     }
 
     /* begins looping inside content*/
     while (ptr < end)
     {
-      ++ptr;
-
       ptr2 = ptr;
 
       while ((*ptr2 >= 97 && *ptr2 <= 122) || (*ptr2 >= 65 && *ptr2 <= 90) ||
@@ -576,8 +579,10 @@ static void* cdreader_open_gdi_track(const char* path, uint32_t track)
       }
 
       /* skip newlines */
-      while (*ptr == '\r')
-        ++ptr;
+      while ((*ptr == '\n' && ptr < end) || (*ptr == '\r' && ptr < end))
+      {
+          ++ptr;
+      }
     }
     if (done)
       break;

--- a/src/rhash/cdreader.c
+++ b/src/rhash/cdreader.c
@@ -249,7 +249,6 @@ static int cdreader_cue_num_tracks(const char* path)
 
   size_t num_read = 0;
   size_t file_offset = 0;
-  int done = 0;
 
   file_handle = rc_file_open(path);
   if (!file_handle)

--- a/src/rhash/cdreader.c
+++ b/src/rhash/cdreader.c
@@ -583,10 +583,7 @@ static void* cdreader_open_gdi_track(const char* path, uint32_t track)
           ++ptr;
       }
     }
-    if (done)
-      break;
-
-  } while (1);
+  } while (!done);
 
   uint8_t file_len = strlen(file);
 

--- a/src/rhash/cdreader.c
+++ b/src/rhash/cdreader.c
@@ -525,7 +525,6 @@ static void* cdreader_open_gdi_track(const char* path, uint32_t track)
   char sector_size[16];
   char file[256];
   char* bin_path = "";
-  char track_data[256];
   int current_track = 0;
   char* ptr, * ptr2, * end;
 

--- a/src/rhash/cdreader.c
+++ b/src/rhash/cdreader.c
@@ -576,11 +576,12 @@ static void* cdreader_open_gdi_track(const char* path, uint32_t track)
 
         if (current_track == (int)track)
         {
+          size_t i;
+
           if (strlen(file) == 0)
             /*2nd attempt to get file if it has failed before, now without double quotes*/
             sscanf(track_data, "%*d %*s %*s %*s %s %*s", file);
 
-          size_t i;
           for (i = 0; i < strlen(sector_size); i++)
             if (sector_size[i] != '\"')
               strncat(mode, &sector_size[i], 1);

--- a/src/rhash/cdreader.c
+++ b/src/rhash/cdreader.c
@@ -711,12 +711,14 @@ static void cdreader_close_track(void* track_handle)
   }
 }
 
-static uint32_t cdreader_get_lba(struct cdrom_t* track_handle)
+static uint32_t cdreader_get_lba(void* track_handle)
 {
+  uint32_t lba;
   struct cdrom_t* cdrom = (struct cdrom_t*)track_handle;
   if (!cdrom)
     return 0;
-  return cdrom->lba;
+  lba = (uint32_t)cdrom->lba;
+  return lba;
 }
 
 void rc_hash_init_default_cdreader()
@@ -726,7 +728,7 @@ void rc_hash_init_default_cdreader()
   cdreader.open_track = cdreader_open_track;
   cdreader.read_sector = cdreader_read_sector;
   cdreader.close_track = cdreader_close_track;
-  cdreader.get_lba =     cdreader_get_lba;
+  cdreader.get_lba = cdreader_get_lba;
 
   rc_hash_init_custom_cdreader(&cdreader);
 }

--- a/src/rhash/cdreader.c
+++ b/src/rhash/cdreader.c
@@ -27,10 +27,6 @@ struct cdrom_t
 };
 
 
-static uint32_t cdreader_get_lba(struct cdrom_t* cdrom)
-{
-  return (uint32_t)cdrom->lba;
-}
 
 static void cdreader_determine_sector_size(struct cdrom_t* cdrom)
 {
@@ -713,6 +709,14 @@ static void cdreader_close_track(void* track_handle)
 
     free(track_handle);
   }
+}
+
+static uint32_t cdreader_get_lba(struct cdrom_t* track_handle)
+{
+  struct cdrom_t* cdrom = (struct cdrom_t*)track_handle;
+  if (!cdrom)
+    return 0;
+  return cdrom->lba;
 }
 
 void rc_hash_init_default_cdreader()

--- a/src/rhash/cdreader.c
+++ b/src/rhash/cdreader.c
@@ -558,8 +558,7 @@ static void* cdreader_open_gdi_track(const char* path, uint32_t track)
     {
       ptr2 = ptr;
 
-      while ((*ptr2 >= 97 && *ptr2 <= 122) || (*ptr2 >= 65 && *ptr2 <= 90) ||
-        (*ptr2 >= 48 && *ptr2 <= 57) || (*ptr2 == 32) || (*ptr2 == '.' || (*ptr2 == ' ')))
+      while ((*ptr2 != '\n') && (*ptr2 != '\r'))
       {
         ++ptr2;
       }

--- a/src/rhash/cdreader.c
+++ b/src/rhash/cdreader.c
@@ -580,7 +580,8 @@ static void* cdreader_open_gdi_track(const char* path, uint32_t track)
             /*2nd attempt to get file if it has failed before, now without double quotes*/
             sscanf(track_data, "%*d %*s %*s %*s %s %*s", file);
 
-          for (int i = 0; i < strlen(sector_size); i++)
+          size_t i;
+          for (i = 0; i < strlen(sector_size); i++)
             if (sector_size[i] != '\"')
               strncat(mode, &sector_size[i], 1);
 
@@ -612,7 +613,7 @@ static void* cdreader_open_gdi_track(const char* path, uint32_t track)
 
   bin_path = cdreader_get_bin_path(path, file);
 
-  if (cdreader_open_bin(cdrom, bin_path, mode)) // gives your cd rom
+  if (cdreader_open_bin(cdrom, bin_path, mode)) /*gives your cd rom*/
   {
     if (verbose_message_callback)
     {

--- a/src/rhash/cdreader.c
+++ b/src/rhash/cdreader.c
@@ -23,13 +23,13 @@ struct cdrom_t
   int sector_size;
   int sector_header_size;
   int first_sector_offset;
-  int lba;
+  uint32_t lba;
 };
 
 
-static int cdreader_get_lba(struct cdrom_t* cdrom)
+static uint32_t cdreader_get_lba(struct cdrom_t* cdrom)
 {
-  return cdrom->lba;
+  return (uint32_t)cdrom->lba;
 }
 
 static void cdreader_determine_sector_size(struct cdrom_t* cdrom)

--- a/src/rhash/cdreader.c
+++ b/src/rhash/cdreader.c
@@ -518,7 +518,6 @@ static void* cdreader_open_gdi_track(const char* path, uint32_t track)
   int current_track = 0;
   char* ptr, * ptr2, * end;
 
-  int ignored_track_count = 0;
   int offset = 0;
   int done = 0;
   size_t num_read = 0;
@@ -541,21 +540,21 @@ static void* cdreader_open_gdi_track(const char* path, uint32_t track)
     else
       end = buffer + num_read;
 
-    for (ptr = buffer; ptr < end; ++ptr)
+    ptr = buffer;
+
+    /* removes first line, as it always have a track counter */
+    while (*ptr != '\n' && ptr < end)
     {
-      if (ignored_track_count == 0)
-      {
-        // remove track counter until reach a newline
-        while (*ptr != '\r')
-        {
-          ++ptr;
-        }
-        ignored_track_count = 1;
-      }
+      ++ptr;
+    }
+
+    /* begins looping inside content*/
+    while (ptr < end)
+    {
+      ++ptr;
 
       ptr2 = ptr;
 
-      // if it finds content
       while ((*ptr2 >= 97 && *ptr2 <= 122) || (*ptr2 >= 65 && *ptr2 <= 90) ||
         (*ptr2 >= 48 && *ptr2 <= 57) || (*ptr2 == 32) || (*ptr2 == '.' || (*ptr2 == ' ')))
       {
@@ -564,7 +563,7 @@ static void* cdreader_open_gdi_track(const char* path, uint32_t track)
 
       if (ptr2 - ptr != 0)
       {
-        memcpy(track_data, ptr, ptr2 - ptr);  // operation to get track data
+        memcpy(track_data, ptr, ptr2 - ptr);  /* operation to get track data */
         track_data[ptr2 - ptr] = '\0';
         sscanf(track_data, "%d %*d %*d %s %s %*d", &current_track, &mode, &file);
         ptr = ptr2;
@@ -576,7 +575,7 @@ static void* cdreader_open_gdi_track(const char* path, uint32_t track)
         }
       }
 
-      // skip newlines
+      /* skip newlines */
       while (*ptr == '\r')
         ++ptr;
     }

--- a/src/rhash/hash.c
+++ b/src/rhash/hash.c
@@ -961,6 +961,13 @@ static int rc_hash_dreamcast(char hash[33], const char* path)
   if (size > MAX_BUFFER_SIZE)
     size = MAX_BUFFER_SIZE;
 
+  if (verbose_message_callback)
+  {
+    char message[128];
+    snprintf(message, sizeof(message), "Hashing %s title (%u bytes) and contents (%u bytes) ", exe_file, (unsigned)strlen(exe_file), size);
+    verbose_message_callback(message);
+  }
+
   do
   {
     md5_append(&md5, buffer, (int)num_read);

--- a/src/rhash/hash.c
+++ b/src/rhash/hash.c
@@ -171,13 +171,13 @@ static void rc_cd_close_track(void* track_handle)
 
 static int rc_cd_get_lba(void* track_handle)
 {
-    if (cdreader && cdreader->get_lba)
-    {
-        cdreader->get_lba(track_handle);
-        return;
-    }
+  if (cdreader && cdreader->get_lba)
+  {
+    return cdreader->get_lba(track_handle);
+  }
 
-    rc_hash_error("no hook registered for cdreader_close_track");
+  rc_hash_error("no hook registered for cdreader_get_lba");
+  return 0;
 }
 
 static uint32_t rc_cd_find_file_sector(void* track_handle, const char* path, unsigned* size, unsigned sector_offset)

--- a/src/rhash/hash.c
+++ b/src/rhash/hash.c
@@ -169,7 +169,7 @@ static void rc_cd_close_track(void* track_handle)
   rc_hash_error("no hook registered for cdreader_close_track");
 }
 
-static int rc_cd_get_lba(void* track_handle)
+static uint32_t rc_cd_get_lba(void* track_handle)
 {
   if (cdreader && cdreader->get_lba)
   {

--- a/src/rhash/hash.c
+++ b/src/rhash/hash.c
@@ -877,9 +877,9 @@ static int rc_hash_dreamcast(char hash[33], const char* path)
   if (!track_handle)
     return rc_hash_error("Could not open track");
 
-  // first sector from the first track should always have a IP0000.BIN structure that stores unique meta information.
-  // "The structure described below is repeated in the 16 first sectors of the first Mode-1 track on the disc".
-  // https://mc.pp.se/dc/ip0000.bin.html
+  /*first sector from the first track should always have a IP0000.BIN structure that stores unique meta information.
+    "The structure described below is repeated in the 16 first sectors of the first Mode-1 track on the disc".
+    https://mc.pp.se/dc/ip0000.bin.html */
   rc_cd_read_sector(track_handle, 0, buffer, sizeof(buffer));
 
   if (verbose_message_callback)

--- a/src/rhash/hash.c
+++ b/src/rhash/hash.c
@@ -882,10 +882,17 @@ static int rc_hash_dreamcast(char hash[33], const char* path)
     https://mc.pp.se/dc/ip0000.bin.html */
   rc_cd_read_sector(track_handle, 0, buffer, sizeof(buffer));
 
+  if (memcmp(&buffer[0], "SEGA SEGAKATANA ", 16) != 0) 
+  {
+    rc_cd_close_track(track_handle);
+    return rc_hash_error("Not a Dreamcast CD");
+  }
+
   if (verbose_message_callback)
   {
-    char message[300];
-    snprintf(message, sizeof(message), "Meta information:\n%.256s", &buffer[0x00]);
+    char message[256];
+    snprintf(message, sizeof(message), "Meta information:\nSoftware Name = %.127s\nProduct Number = %.9s\nProduct Version = %.5s\n",
+                                        &buffer[0x80], &buffer[0x40], &buffer[0x4A]);
     verbose_message_callback(message);
   }
 


### PR DESCRIPTION
NEW COMMENT
GDI validation is done by hashing a 256 bytes header at track 3 and the boot executable specified on header (usually it is 1ST_READ.BIN). The executable is found at the last track.
Source for information: https://mc.pp.se/dc/ip.bin.html

OLD COMMENT
Dreamcast hashing is almost the same as for Sega CD and Saturn, except that it hashes 256 bytes.

First, i've created a function for reading .GDI files and getting a track, as their format are a bit different from .CUE. Then it reads the first sector from the first track (it should always have unique meta information in the first 16 sectors, see: https://mc.pp.se/dc/ip0000.bin.html) and make a hash with it's contents.