### PR TITLE
support maxof($) for measured values

### DIFF
--- a/src/rcheevos/condition.c
+++ b/src/rcheevos/condition.c
@@ -98,6 +98,8 @@ rc_condition_t* rc_parse_condition(const char** memaddr, rc_parse_state_t* parse
     case '_':
     case ')':
     case '\0':
+    case 'S':
+    case '$':
       self->oper = RC_OPERATOR_NONE;
       self->operand2.type = RC_OPERAND_CONST;
       self->operand2.value.num = 1;

--- a/src/rcheevos/consoleinfo.c
+++ b/src/rcheevos/consoleinfo.c
@@ -464,6 +464,7 @@ static const rc_memory_region_t _rc_memory_regions_pokemini[] = {
 static const rc_memory_regions_t rc_memory_regions_pokemini = { _rc_memory_regions_pokemini, 2 };
 
 /* ===== Sega CD ===== */
+/* https://en.wikibooks.org/wiki/Genesis_Programming */
 static const rc_memory_region_t _rc_memory_regions_segacd[] = {
     { 0x000000U, 0x00FFFFU, 0x00FF0000U, RC_MEMORY_TYPE_SYSTEM_RAM, "68000 RAM" },
     { 0x010000U, 0x08FFFFU, 0x80020000U, RC_MEMORY_TYPE_SAVE_RAM, "CD PRG RAM" } /* normally banked into $020000-$03FFFF */

--- a/src/rcheevos/lboard.c
+++ b/src/rcheevos/lboard.c
@@ -27,6 +27,7 @@ void rc_parse_lboard_internal(rc_lboard_t* self, const char* memaddr, rc_parse_s
 
       found |= RC_LBOARD_START;
       memaddr += 4;
+      parse->measured_target = 0;
       rc_parse_trigger_internal(&self->start, &memaddr, parse);
       self->start.memrefs = 0;
 
@@ -44,6 +45,7 @@ void rc_parse_lboard_internal(rc_lboard_t* self, const char* memaddr, rc_parse_s
 
       found |= RC_LBOARD_CANCEL;
       memaddr += 4;
+      parse->measured_target = 0;
       rc_parse_trigger_internal(&self->cancel, &memaddr, parse);
       self->cancel.memrefs = 0;
 
@@ -61,6 +63,7 @@ void rc_parse_lboard_internal(rc_lboard_t* self, const char* memaddr, rc_parse_s
 
       found |= RC_LBOARD_SUBMIT;
       memaddr += 4;
+      parse->measured_target = 0;
       rc_parse_trigger_internal(&self->submit, &memaddr, parse);
       self->submit.memrefs = 0;
 
@@ -78,6 +81,7 @@ void rc_parse_lboard_internal(rc_lboard_t* self, const char* memaddr, rc_parse_s
 
       found |= RC_LBOARD_VALUE;
       memaddr += 4;
+      parse->measured_target = 0;
       rc_parse_value_internal(&self->value, &memaddr, parse);
       self->value.memrefs = 0;
 
@@ -97,6 +101,7 @@ void rc_parse_lboard_internal(rc_lboard_t* self, const char* memaddr, rc_parse_s
       memaddr += 4;
 
       self->progress = RC_ALLOC(rc_value_t, parse);
+      parse->measured_target = 0;
       rc_parse_value_internal(self->progress, &memaddr, parse);
       self->progress->memrefs = 0;
 

--- a/src/rcheevos/lboard.c
+++ b/src/rcheevos/lboard.c
@@ -27,7 +27,6 @@ void rc_parse_lboard_internal(rc_lboard_t* self, const char* memaddr, rc_parse_s
 
       found |= RC_LBOARD_START;
       memaddr += 4;
-      parse->measured_target = 0;
       rc_parse_trigger_internal(&self->start, &memaddr, parse);
       self->start.memrefs = 0;
 
@@ -45,7 +44,6 @@ void rc_parse_lboard_internal(rc_lboard_t* self, const char* memaddr, rc_parse_s
 
       found |= RC_LBOARD_CANCEL;
       memaddr += 4;
-      parse->measured_target = 0;
       rc_parse_trigger_internal(&self->cancel, &memaddr, parse);
       self->cancel.memrefs = 0;
 
@@ -63,7 +61,6 @@ void rc_parse_lboard_internal(rc_lboard_t* self, const char* memaddr, rc_parse_s
 
       found |= RC_LBOARD_SUBMIT;
       memaddr += 4;
-      parse->measured_target = 0;
       rc_parse_trigger_internal(&self->submit, &memaddr, parse);
       self->submit.memrefs = 0;
 
@@ -81,7 +78,6 @@ void rc_parse_lboard_internal(rc_lboard_t* self, const char* memaddr, rc_parse_s
 
       found |= RC_LBOARD_VALUE;
       memaddr += 4;
-      parse->measured_target = 0;
       rc_parse_value_internal(&self->value, &memaddr, parse);
       self->value.memrefs = 0;
 
@@ -101,7 +97,6 @@ void rc_parse_lboard_internal(rc_lboard_t* self, const char* memaddr, rc_parse_s
       memaddr += 4;
 
       self->progress = RC_ALLOC(rc_value_t, parse);
-      parse->measured_target = 0;
       rc_parse_value_internal(self->progress, &memaddr, parse);
       self->progress->memrefs = 0;
 

--- a/src/rcheevos/trigger.c
+++ b/src/rcheevos/trigger.c
@@ -10,6 +10,8 @@ void rc_parse_trigger_internal(rc_trigger_t* self, const char** memaddr, rc_pars
   aux = *memaddr;
   next = &self->alternative;
 
+  parse->measured_target = 0; /* reset in case multiple triggers are parsed by the same parse_state */
+
   if (*aux == 's' || *aux == 'S') {
     self->requirement = 0;
   }

--- a/src/rcheevos/value.c
+++ b/src/rcheevos/value.c
@@ -10,6 +10,7 @@ static void rc_parse_cond_value(rc_value_t* self, const char** memaddr, rc_parse
 
   do
   {
+    parse->measured_target = 0; /* passing is_value=1 should prevent any conflicts, but clear it out anyway */
     *next_clause = rc_parse_condset(memaddr, parse, 1);
     if (parse->offset < 0) {
       return;

--- a/src/rcheevos/value.c
+++ b/src/rcheevos/value.c
@@ -4,21 +4,35 @@
 #include <ctype.h> /* isdigit */
 
 static void rc_parse_cond_value(rc_value_t* self, const char** memaddr, rc_parse_state_t* parse) {
-  self->conditions = rc_parse_condset(memaddr, parse, 1);
-  if (parse->offset < 0) {
-    return;
-  }
+  rc_condset_t** next_clause;
 
-  if (**memaddr == 'S' || **memaddr == 's') {
-    /* alt groups not supported */
-    parse->offset = RC_INVALID_VALUE_FLAG;
-  }
-  else if (parse->measured_target == 0) {
-    parse->offset = RC_MISSING_VALUE_MEASURED;
-  }
-  else {
-    self->conditions->next = 0;
-  }
+  next_clause = &self->conditions;
+
+  do
+  {
+    *next_clause = rc_parse_condset(memaddr, parse, 1);
+    if (parse->offset < 0) {
+      return;
+    }
+
+    if (**memaddr == 'S' || **memaddr == 's') {
+      /* alt groups not supported */
+      parse->offset = RC_INVALID_VALUE_FLAG;
+    }
+    else if (parse->measured_target == 0) {
+      parse->offset = RC_MISSING_VALUE_MEASURED;
+    }
+    else if (**memaddr == '$') {
+      /* maximum of */
+      ++(*memaddr);
+      next_clause = &(*next_clause)->next;
+      continue;
+    }
+
+    break;
+  } while (1);
+
+  (*next_clause)->next = 0;
 }
 
 void rc_parse_legacy_value(rc_value_t* self, const char** memaddr, rc_parse_state_t* parse) {

--- a/test/rcheevos/test_lboard.c
+++ b/test/rcheevos/test_lboard.c
@@ -508,6 +508,15 @@ static void test_maximum_value_from_conditions() {
   ASSERT_NUM_EQUALS(value, 0);
 }
 
+static void test_measured_value_and_condition()
+{
+    rc_lboard_t* lboard;
+    char buffer[1024];
+
+    /* a Measured is irrelevant in the STA/CAN/SUB conditions, but if present, allow them to be unique */
+    assert_parse_lboard(&lboard, buffer, "STA:M:0xH00=0::CAN:M:0xH00=2::SUB:M:0xH00=3::VAL:M:0xH04");
+}
+
 static void test_unparsable_lboard(const char* memaddr, int expected_error) {
   ASSERT_NUM_EQUALS(rc_lboard_size(memaddr), expected_error);
 }
@@ -553,6 +562,7 @@ void test_lboard(void) {
   TEST(test_value_from_hitcount);
   TEST(test_value_from_addhits);
   TEST(test_maximum_value_from_conditions);
+  TEST(test_measured_value_and_condition);
 
   test_unparsable_strings();
 

--- a/test/rcheevos/test_lboard.c
+++ b/test/rcheevos/test_lboard.c
@@ -470,6 +470,44 @@ static void test_value_from_addhits() {
   ASSERT_NUM_EQUALS(value, 1);
 }
 
+static void test_maximum_value_from_conditions() {
+  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  memory_t memory;
+  rc_lboard_t* lboard;
+  char buffer[1024];
+  int value;
+
+  memory.ram = ram;
+  memory.size = sizeof(ram);
+
+  assert_parse_lboard(&lboard, buffer, "STA:0xH00=0::CAN:0xH00=2::SUB:0xH00=3::VAL:Q:0xH01=1_M:0x 02$Q:0xH01=2_M:0x 03");
+  lboard->state = RC_LBOARD_STATE_ACTIVE;
+
+  /* started, neither value is active */
+  ASSERT_NUM_EQUALS(evaluate_lboard(lboard, &memory, &value), RC_LBOARD_STATE_STARTED);
+  ASSERT_NUM_EQUALS(value, 0);
+
+  /* first value is active */
+  ram[1] = 1;
+  ASSERT_NUM_EQUALS(evaluate_lboard(lboard, &memory, &value), RC_LBOARD_STATE_STARTED);
+  ASSERT_NUM_EQUALS(value, 0xAB34);
+
+  /* second value is active */
+  ram[1] = 2;
+  ASSERT_NUM_EQUALS(evaluate_lboard(lboard, &memory, &value), RC_LBOARD_STATE_STARTED);
+  ASSERT_NUM_EQUALS(value, 0x56AB);
+
+  /* value updated */
+  ram[3] = 0x12;
+  ASSERT_NUM_EQUALS(evaluate_lboard(lboard, &memory, &value), RC_LBOARD_STATE_STARTED);
+  ASSERT_NUM_EQUALS(value, 0x5612);
+
+  /* neither value is active */
+  ram[1] = 3;
+  ASSERT_NUM_EQUALS(evaluate_lboard(lboard, &memory, &value), RC_LBOARD_STATE_STARTED);
+  ASSERT_NUM_EQUALS(value, 0);
+}
+
 static void test_unparsable_lboard(const char* memaddr, int expected_error) {
   ASSERT_NUM_EQUALS(rc_lboard_size(memaddr), expected_error);
 }
@@ -489,6 +527,8 @@ static void test_unparsable_strings() {
   TEST_PARAMS2(test_unparsable_lboard, "STA:0xH00=0::CAN:0xH00=2::SUB:0xH00=3::VAL:M:0xH01=1_T:0xH01=2", RC_INVALID_VALUE_FLAG);
   TEST_PARAMS2(test_unparsable_lboard, "STA:0xH00=0::CAN:0xH00=2::SUB:0xH00=3::VAL:R:0xH01=1_0xH01=2", RC_INVALID_VALUE_FLAG);
   TEST_PARAMS2(test_unparsable_lboard, "STA:0xH00=0::CAN:0xH00=2::SUB:0xH00=3::VAL:R:0xH01=1", RC_MISSING_VALUE_MEASURED);
+  TEST_PARAMS2(test_unparsable_lboard, "STA:0xH00=0::CAN:0xH00=2::SUB:0xH00=3::VAL:R:0xH01=1$M:0xH03", RC_MISSING_VALUE_MEASURED);
+  TEST_PARAMS2(test_unparsable_lboard, "STA:0xH00=0::CAN:0xH00=2::SUB:0xH00=3::VAL:M:0xH02SM:0xH03", RC_INVALID_VALUE_FLAG);
 }
 
 void test_lboard(void) {
@@ -512,6 +552,7 @@ void test_lboard(void) {
 
   TEST(test_value_from_hitcount);
   TEST(test_value_from_addhits);
+  TEST(test_maximum_value_from_conditions);
 
   test_unparsable_strings();
 

--- a/validator/validator.c
+++ b/validator/validator.c
@@ -263,7 +263,7 @@ static void validate_patchdata_file(const char* patchdata_file) {
 }
 
 #ifdef _CRT_SECURE_NO_WARNINGS
-static void validate_pathdata_directory(const char* patchdata_directory) {
+static void validate_patchdata_directory(const char* patchdata_directory) {
   WIN32_FIND_DATA fdFile;
   HANDLE hFind = NULL;
 
@@ -359,7 +359,7 @@ int main(int argc, char* argv[]) {
 
     case 'd':
       printf("Directory: %s: ", argv[2]);
-      validate_pathdata_directory(argv[2]);
+      validate_patchdata_directory(argv[2]);
       break;
 
     default:


### PR DESCRIPTION
supports https://github.com/RetroAchievements/RAWeb/issues/513

Allows the MAXOF operator ($) to be applied to multiple values defined by the condition syntax:

```
Q:0xH01=1_M:0x 02$Q:0xH01=2_M:0x 03
```
Defines two values using the condition syntax: `Q:0xH01=1_M:0x 02` and `Q:0xH01=2_M:0x 03`. Each will be evaluated separately, and the higher of the resulting values will be used.

The `Q` flag ensures that a value is 0 unless it's applicable for the current state - for example, correct version as suggested in the linked issue; but it could be something like a game mode trigger in case the memory changes by game mode.

I believe this will also address https://github.com/RetroAchievements/RAIntegration/issues/184, as a MeasuredIf can be used to determine whether or not logic should be applied.