### PR TITLE
allow ranges within rich presence lookups

### DIFF
--- a/include/rcheevos.h
+++ b/include/rcheevos.h
@@ -343,17 +343,20 @@ int rc_format_value(char* buffer, int size, int value, int format);
 typedef struct rc_richpresence_lookup_item_t rc_richpresence_lookup_item_t;
 
 struct rc_richpresence_lookup_item_t {
-  unsigned value;
-  rc_richpresence_lookup_item_t* next_item;
+  unsigned first;
+  unsigned last;
+  rc_richpresence_lookup_item_t* left;
+  rc_richpresence_lookup_item_t* right;
   const char* label;
 };
 
 typedef struct rc_richpresence_lookup_t rc_richpresence_lookup_t;
 
 struct rc_richpresence_lookup_t {
-  rc_richpresence_lookup_item_t* first_item;
+  rc_richpresence_lookup_item_t* root;
   rc_richpresence_lookup_t* next;
   const char* name;
+  const char* default_label;
   unsigned short format;
 };
 
@@ -362,7 +365,7 @@ typedef struct rc_richpresence_display_part_t rc_richpresence_display_part_t;
 struct rc_richpresence_display_part_t {
   rc_richpresence_display_part_t* next;
   const char* text;
-  rc_richpresence_lookup_item_t* first_lookup_item;
+  rc_richpresence_lookup_t* lookup;
   rc_value_t value;
   unsigned short display_type;
 };

--- a/src/rcheevos/alloc.c
+++ b/src/rcheevos/alloc.c
@@ -7,16 +7,23 @@ void* rc_alloc_scratch(void* pointer, int* offset, int size, int alignment, rc_s
 {
   rc_scratch_buffer_t* buffer;
 
+  /* if we have a real buffer, then allocate the data there */
   if (pointer)
     return rc_alloc(pointer, offset, size, alignment, NULL);
 
+  /* update how much space will be required in the real buffer */
+  const int aligned_offset = (*offset + alignment - 1) & ~(alignment - 1);
+  *offset += (aligned_offset - *offset);
+  *offset += size;
+
+  /* find a scratch buffer to hold the temporary data */
   buffer = &scratch->buffer;
   do {
-    const int aligned_offset = (buffer->offset + alignment - 1) & ~(alignment - 1);
-    const int remaining = sizeof(buffer->buffer) - aligned_offset;
+    const int aligned_buffer_offset = (buffer->offset + alignment - 1) & ~(alignment - 1);
+    const int remaining = sizeof(buffer->buffer) - aligned_buffer_offset;
 
     if (remaining >= size) {
-      *offset += size + (aligned_offset - buffer->offset);
+      /* claim the required space from an existing buffer */
       return rc_alloc(buffer->buffer, &buffer->offset, size, alignment, NULL);
     }
 
@@ -26,6 +33,13 @@ void* rc_alloc_scratch(void* pointer, int* offset, int size, int alignment, rc_s
     buffer = buffer->next;
   } while (1);
 
+  /* make sure the caller isn't asking for more than we can provide */
+  if (size > sizeof(buffer->buffer)) {
+    *offset = RC_INVALID_STATE;
+    return NULL;
+  }
+
+  /* not enough space in any existing buffer, allocate more */
   buffer->next = (rc_scratch_buffer_t*)malloc(sizeof(rc_scratch_buffer_t));
   if (!buffer->next) {
     *offset = RC_OUT_OF_MEMORY;
@@ -36,7 +50,7 @@ void* rc_alloc_scratch(void* pointer, int* offset, int size, int alignment, rc_s
   buffer->offset = 0;
   buffer->next = NULL;
 
-  *offset += size;
+  /* claim the required space from the new buffer */
   return rc_alloc(buffer->buffer, &buffer->offset, size, alignment, NULL);
 }
 
@@ -81,7 +95,8 @@ char* rc_alloc_str(rc_parse_state_t* parse, const char* text, int length) {
   *next = rc_alloc_scratch(NULL, &used, sizeof(rc_scratch_string_t), RC_ALIGNOF(rc_scratch_string_t), &parse->scratch);
   ptr = (char*)rc_alloc_scratch(parse->buffer, &parse->offset, length + 1, RC_ALIGNOF(char), &parse->scratch);
   if (!ptr || !*next) {
-    parse->offset = RC_OUT_OF_MEMORY;
+    if (parse->offset >= 0)
+      parse->offset = RC_OUT_OF_MEMORY;
     return NULL;
   }
 

--- a/src/rcheevos/alloc.c
+++ b/src/rcheevos/alloc.c
@@ -12,9 +12,11 @@ void* rc_alloc_scratch(void* pointer, int* offset, int size, int alignment, rc_s
     return rc_alloc(pointer, offset, size, alignment, NULL);
 
   /* update how much space will be required in the real buffer */
-  const int aligned_offset = (*offset + alignment - 1) & ~(alignment - 1);
-  *offset += (aligned_offset - *offset);
-  *offset += size;
+  {
+    const int aligned_offset = (*offset + alignment - 1) & ~(alignment - 1);
+    *offset += (aligned_offset - *offset);
+    *offset += size;
+  }
 
   /* find a scratch buffer to hold the temporary data */
   buffer = &scratch->buffer;

--- a/src/rcheevos/alloc.c
+++ b/src/rcheevos/alloc.c
@@ -15,7 +15,7 @@ void* rc_alloc_scratch(void* pointer, int* offset, int size, int alignment, rc_s
     const int aligned_offset = (buffer->offset + alignment - 1) & ~(alignment - 1);
     const int remaining = sizeof(buffer->buffer) - aligned_offset;
 
-    if (remaining > size) {
+    if (remaining >= size) {
       *offset += size + (aligned_offset - buffer->offset);
       return rc_alloc(buffer->buffer, &buffer->offset, size, alignment, NULL);
     }

--- a/src/rcheevos/alloc.c
+++ b/src/rcheevos/alloc.c
@@ -3,6 +3,43 @@
 #include <stdlib.h>
 #include <string.h>
 
+void* rc_alloc_scratch(void* pointer, int* offset, int size, int alignment, rc_scratch_t* scratch)
+{
+  rc_scratch_buffer_t* buffer;
+
+  if (pointer)
+    return rc_alloc(pointer, offset, size, alignment, NULL);
+
+  buffer = &scratch->buffer;
+  do {
+    const int aligned_offset = (buffer->offset + alignment - 1) & ~(alignment - 1);
+    const int remaining = sizeof(buffer->buffer) - aligned_offset;
+
+    if (remaining > size) {
+      *offset += size;
+      return rc_alloc(buffer->buffer, &buffer->offset, size, alignment, NULL);
+    }
+
+    if (!buffer->next)
+      break;
+
+    buffer = buffer->next;
+  } while (1);
+
+  buffer->next = (rc_scratch_buffer_t*)malloc(sizeof(rc_scratch_buffer_t));
+  if (!buffer->next) {
+    *offset = RC_OUT_OF_MEMORY;
+    return NULL;
+  }
+
+  buffer = buffer->next;
+  buffer->offset = 0;
+  buffer->next = NULL;
+
+  *offset += size;
+  return rc_alloc(buffer->buffer, &buffer->offset, size, alignment, NULL);
+}
+
 void* rc_alloc(void* pointer, int* offset, int size, int alignment, rc_scratch_t* scratch) {
   void* ptr;
 
@@ -40,17 +77,22 @@ void rc_init_parse_state(rc_parse_state_t* parse, void* buffer, lua_State* L, in
   parse->L = L;
   parse->funcs_ndx = funcs_ndx;
   parse->buffer = buffer;
-  parse->scratch.memref = parse->scratch.memref_buffer;
-  parse->scratch.memref_size = sizeof(parse->scratch.memref_buffer) / sizeof(parse->scratch.memref_buffer[0]);
-  parse->scratch.memref_count = 0;
+  parse->scratch.buffer.offset = 0;
+  parse->scratch.buffer.next = NULL;
   parse->first_memref = 0;
   parse->measured_target = 0;
 }
 
 void rc_destroy_parse_state(rc_parse_state_t* parse)
 {
-  if (parse->scratch.memref != parse->scratch.memref_buffer)
-    free(parse->scratch.memref);
+  rc_scratch_buffer_t* buffer = parse->scratch.buffer.next;
+  rc_scratch_buffer_t* next;
+
+  while (buffer) {
+    next = buffer->next;
+    free(buffer);
+    buffer = next;
+  }
 }
 
 const char* rc_error_str(int ret)

--- a/src/rcheevos/alloc.c
+++ b/src/rcheevos/alloc.c
@@ -36,7 +36,7 @@ void* rc_alloc_scratch(void* pointer, int* offset, int size, int alignment, rc_s
   } while (1);
 
   /* make sure the caller isn't asking for more than we can provide */
-  if (size > sizeof(buffer->buffer)) {
+  if (size > (int)sizeof(buffer->buffer)) {
     *offset = RC_INVALID_STATE;
     return NULL;
   }

--- a/src/rcheevos/alloc.c
+++ b/src/rcheevos/alloc.c
@@ -16,7 +16,7 @@ void* rc_alloc_scratch(void* pointer, int* offset, int size, int alignment, rc_s
     const int remaining = sizeof(buffer->buffer) - aligned_offset;
 
     if (remaining > size) {
-      *offset += size;
+      *offset += size + (aligned_offset - buffer->offset);
       return rc_alloc(buffer->buffer, &buffer->offset, size, alignment, NULL);
     }
 

--- a/src/rcheevos/internal.h
+++ b/src/rcheevos/internal.h
@@ -3,6 +3,13 @@
 
 #include "rcheevos.h"
 
+typedef struct rc_scratch_string {
+  char* value;
+  struct rc_scratch_string* left;
+  struct rc_scratch_string* right;
+}
+rc_scratch_string_t;
+
 #define RC_ALLOW_ALIGN(T) struct __align_ ## T { char ch; T t; };
 RC_ALLOW_ALIGN(rc_condition_t)
 RC_ALLOW_ALIGN(rc_condset_t)
@@ -16,6 +23,7 @@ RC_ALLOW_ALIGN(rc_richpresence_lookup_t)
 RC_ALLOW_ALIGN(rc_richpresence_lookup_item_t)
 RC_ALLOW_ALIGN(rc_trigger_t)
 RC_ALLOW_ALIGN(rc_value_t)
+RC_ALLOW_ALIGN(rc_scratch_string_t)
 RC_ALLOW_ALIGN(char)
 
 #define RC_ALIGNOF(T) (sizeof(struct __align_ ## T) - sizeof(T))
@@ -32,6 +40,7 @@ rc_scratch_buffer_t;
 
 typedef struct {
   rc_scratch_buffer_t buffer;
+  rc_scratch_string_t* strings;
 
   union
   {

--- a/src/rcheevos/internal.h
+++ b/src/rcheevos/internal.h
@@ -21,12 +21,17 @@ RC_ALLOW_ALIGN(char)
 #define RC_ALIGNOF(T) (sizeof(struct __align_ ## T) - sizeof(T))
 
 #define RC_ALLOC(t, p) ((t*)rc_alloc((p)->buffer, &(p)->offset, sizeof(t), RC_ALIGNOF(t), &(p)->scratch))
+#define RC_ALLOC_SCRATCH(t, p) ((t*)rc_alloc_scratch((p)->buffer, &(p)->offset, sizeof(t), RC_ALIGNOF(t), &(p)->scratch))
+
+typedef struct rc_scratch_buffer {
+  struct rc_scratch_buffer* next;
+  int offset;
+  unsigned char buffer[512 - 16];
+}
+rc_scratch_buffer_t;
 
 typedef struct {
-  rc_memref_t memref_buffer[16];
-  rc_memref_t *memref;
-  int memref_count;
-  int memref_size;
+  rc_scratch_buffer_t buffer;
 
   union
   {
@@ -82,6 +87,7 @@ void rc_init_parse_state_memrefs(rc_parse_state_t* parse, rc_memref_value_t** me
 void rc_destroy_parse_state(rc_parse_state_t* parse);
 
 void* rc_alloc(void* pointer, int* offset, int size, int alignment, rc_scratch_t* scratch);
+void* rc_alloc_scratch(void* pointer, int* offset, int size, int alignment, rc_scratch_t* scratch);
 char* rc_alloc_str(rc_parse_state_t* parse, const char* text, int length);
 
 rc_memref_value_t* rc_alloc_memref_value(rc_parse_state_t* parse, unsigned address, char size, char is_indirect);

--- a/src/rcheevos/lboard.c
+++ b/src/rcheevos/lboard.c
@@ -139,7 +139,9 @@ void rc_parse_lboard_internal(rc_lboard_t* self, const char* memaddr, rc_parse_s
 int rc_lboard_size(const char* memaddr) {
   rc_lboard_t* self;
   rc_parse_state_t parse;
+  rc_memref_value_t* first_memref;
   rc_init_parse_state(&parse, 0, 0, 0);
+  rc_init_parse_state_memrefs(&parse, &first_memref);
 
   self = RC_ALLOC(rc_lboard_t, &parse);
   rc_parse_lboard_internal(self, memaddr, &parse);
@@ -152,7 +154,7 @@ rc_lboard_t* rc_parse_lboard(void* buffer, const char* memaddr, lua_State* L, in
   rc_lboard_t* self;
   rc_parse_state_t parse;
   rc_init_parse_state(&parse, buffer, L, funcs_ndx);
-  
+
   self = RC_ALLOC(rc_lboard_t, &parse);
   rc_init_parse_state_memrefs(&parse, &self->memrefs);
 
@@ -199,7 +201,7 @@ int rc_evaluate_lboard(rc_lboard_t* self, int* value, rc_peek_t peek, void* peek
         }
         else if (self->start.requirement == 0 && self->start.alternative == 0) {
           /* start condition is empty - this leaderboard is submit-only with no measured progress */
-        } 
+        }
         else {
           /* start the leaderboard attempt */
           self->state = RC_LBOARD_STATE_STARTED;

--- a/src/rcheevos/richpresence.c
+++ b/src/rcheevos/richpresence.c
@@ -195,6 +195,93 @@ static rc_richpresence_display_t* rc_parse_richpresence_display_internal(const c
   return self;
 }
 
+static int rc_richpresence_lookup_item_count(rc_richpresence_lookup_item_t* item)
+{
+  if (item == NULL)
+    return 0;
+
+  return (rc_richpresence_lookup_item_count(item->left) + rc_richpresence_lookup_item_count(item->right) + 1);
+}
+
+static void rc_rebalance_richpresence_lookup_get_items(rc_richpresence_lookup_item_t* root,
+    rc_richpresence_lookup_item_t** items, int* index)
+{
+  if (root->left != NULL)
+    rc_rebalance_richpresence_lookup_get_items(root->left, items, index);
+
+  items[*index] = root;
+  ++(*index);
+
+  if (root->right != NULL)
+    rc_rebalance_richpresence_lookup_get_items(root->right, items, index);
+}
+
+static void rc_rebalance_richpresence_lookup_rebuild(rc_richpresence_lookup_item_t** root,
+    rc_richpresence_lookup_item_t** items, int first, int last)
+{
+  int mid = (first + last) / 2;
+  rc_richpresence_lookup_item_t* item = items[mid];
+  *root = item;
+
+  if (mid == first)
+    item->left = NULL;
+  else
+    rc_rebalance_richpresence_lookup_rebuild(&item->left, items, first, mid - 1);
+
+  if (mid == last)
+    item->right = NULL;
+  else
+    rc_rebalance_richpresence_lookup_rebuild(&item->right, items, mid + 1, last);
+}
+
+static void rc_rebalance_richpresence_lookup(rc_richpresence_lookup_item_t** root, rc_parse_state_t* parse)
+{
+  rc_richpresence_lookup_item_t** items;
+  rc_scratch_buffer_t* buffer;
+  const int alignment = sizeof(rc_richpresence_lookup_item_t*);
+  int index;
+  int size;
+
+  /* don't bother rebalancing one or two items */
+  int count = rc_richpresence_lookup_item_count(*root);
+  if (count < 3)
+    return;
+
+  /* allocate space for the flattened list - prefer scratch memory if available */
+  size = count * sizeof(rc_richpresence_lookup_item_t*);
+  buffer = &parse->scratch.buffer;
+  do {
+    const int aligned_offset = (buffer->offset + alignment - 1) & ~(alignment - 1);
+    const int remaining = sizeof(buffer->buffer) - aligned_offset;
+
+    if (remaining >= size) {
+      items = (rc_richpresence_lookup_item_t**)&buffer->buffer[aligned_offset];
+      break;
+    }
+
+    buffer = buffer->next;
+    if (buffer == NULL) {
+      /* could not find large enough block of scratch memory; allocate. if allocation fails,
+       * we can still use the unbalanced tree, so just bail out */
+      items = (rc_richpresence_lookup_item_t**)malloc(size);
+      if (items == NULL)
+        return;
+
+      break;
+    }
+  } while (1);
+
+  /* flatten the list */
+  index = 0;
+  rc_rebalance_richpresence_lookup_get_items(*root, items, &index);
+
+  /* and rebuild it as a balanced tree */
+  rc_rebalance_richpresence_lookup_rebuild(root, items, 0, count - 1);
+
+  if (buffer == NULL)
+    free(items);
+}
+
 static void rc_insert_richpresence_lookup_item(rc_richpresence_lookup_t* lookup,
     unsigned first, unsigned last, const char* label, int label_len, rc_parse_state_t* parse)
 {
@@ -256,6 +343,8 @@ static const char* rc_parse_richpresence_lookup(rc_richpresence_lookup_t* lookup
         continue;
 
       /* empty line indicates end of lookup */
+      if (lookup->root)
+        rc_rebalance_richpresence_lookup(&lookup->root, parse);
       break;
     }
 
@@ -497,11 +586,13 @@ int rc_evaluate_richpresence(rc_richpresence_t* richpresence, char* buffer, unsi
             text = part->lookup->default_label;
             item = part->lookup->root;
             while (item) {
-              if (item->first > value) {
-                item = item->left;
-              } else if (item->last < value) {
+              if (value > item->last) {
                 item = item->right;
-              } else {
+              }
+              else if (value < item->first) {
+                item = item->left;
+              }
+              else {
                 text = item->label;
                 break;
               }

--- a/src/rcheevos/richpresence.c
+++ b/src/rcheevos/richpresence.c
@@ -382,7 +382,9 @@ void rc_parse_richpresence_internal(rc_richpresence_t* self, const char* script,
 int rc_richpresence_size(const char* script) {
   rc_richpresence_t* self;
   rc_parse_state_t parse;
+  rc_memref_value_t* first_memref;
   rc_init_parse_state(&parse, 0, 0, 0);
+  rc_init_parse_state_memrefs(&parse, &first_memref);
 
   self = RC_ALLOC(rc_richpresence_t, &parse);
   rc_parse_richpresence_internal(self, script, &parse);

--- a/src/rcheevos/richpresence.c
+++ b/src/rcheevos/richpresence.c
@@ -390,6 +390,9 @@ static const char* rc_parse_richpresence_lookup(rc_richpresence_lookup_t* lookup
         last = strtoul(line, &endptr, base);
       }
 
+      while (*endptr == ' ')
+        ++endptr;
+
       if (*endptr == '=') {
         rc_insert_richpresence_lookup_item(lookup, first, last, label, (int)(endline - label), parse);
         break;

--- a/src/rcheevos/richpresence.c
+++ b/src/rcheevos/richpresence.c
@@ -250,9 +250,16 @@ static const char* rc_parse_richpresence_lookup(rc_richpresence_lookup_t* lookup
     line = nextline;
     nextline = rc_parse_line(line, &endline);
 
-    if (endline - line < 2)
-      break;
+    if (endline - line < 2) {
+      /* ignore full line comments inside a lookup */
+      if (line[0] == '/' && line[1] == '/')
+        continue;
 
+      /* empty line indicates end of lookup */
+      break;
+    }
+
+    /* "*=XXX" specifies default label if lookup does not provide a mapping for the value */
     if (line[0] == '*' && line[1] == '=') {
       line += 2;
       lookup->default_label = rc_alloc_str(parse, line, (int)(endline - line));
@@ -270,10 +277,11 @@ static const char* rc_parse_richpresence_lookup(rc_richpresence_lookup_t* lookup
     ++label;
 
     do {
-      base = 10;
       if (line[0] == '0' && line[1] == 'x') {
         line += 2;
         base = 16;
+      } else {
+        base = 10;
       }
 
       first = strtoul(line, &endptr, base);
@@ -283,10 +291,11 @@ static const char* rc_parse_richpresence_lookup(rc_richpresence_lookup_t* lookup
       else {
         line = endptr + 1;
 
-        base = 10;
         if (line[0] == '0' && line[1] == 'x') {
           line += 2;
           base = 16;
+        } else {
+          base = 10;
         }
 
         last = strtoul(line, &endptr, base);

--- a/src/rcheevos/trigger.c
+++ b/src/rcheevos/trigger.c
@@ -48,7 +48,9 @@ void rc_parse_trigger_internal(rc_trigger_t* self, const char** memaddr, rc_pars
 int rc_trigger_size(const char* memaddr) {
   rc_trigger_t* self;
   rc_parse_state_t parse;
+  rc_memref_value_t* memrefs;
   rc_init_parse_state(&parse, 0, 0, 0);
+  rc_init_parse_state_memrefs(&parse, &memrefs);
 
   self = RC_ALLOC(rc_trigger_t, &parse);
   rc_parse_trigger_internal(self, &memaddr, &parse);

--- a/src/rcheevos/value.c
+++ b/src/rcheevos/value.c
@@ -155,7 +155,9 @@ void rc_parse_value_internal(rc_value_t* self, const char** memaddr, rc_parse_st
 int rc_value_size(const char* memaddr) {
   rc_value_t* self;
   rc_parse_state_t parse;
+  rc_memref_value_t* first_memref;
   rc_init_parse_state(&parse, 0, 0, 0);
+  rc_init_parse_state_memrefs(&parse, &first_memref);
 
   self = RC_ALLOC(rc_value_t, &parse);
   rc_parse_value_internal(self, &memaddr, &parse);
@@ -198,7 +200,7 @@ int rc_evaluate_value(rc_value_t* self, rc_peek_t peek, void* ud, lua_State* L) 
       continue;
 
     if (eval_state.was_reset) {
-      /* if any ResetIf condition was true, reset the hit counts 
+      /* if any ResetIf condition was true, reset the hit counts
        * NOTE: ResetIf only affects the current condset when used in values!
        */
       rc_reset_condset(condset);

--- a/test/rcheevos/test_richpresence.c
+++ b/test/rcheevos/test_richpresence.c
@@ -359,6 +359,26 @@ static void test_macro_lookup_simple() {
   assert_richpresence_output(richpresence, &memory, "At ");
 }
 
+static void test_macro_lookup_with_inline_comment() {
+  unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  memory_t memory;
+  rc_richpresence_t* richpresence;
+  char buffer[1024];
+
+  memory.ram = ram;
+  memory.size = sizeof(ram);
+
+  assert_parse_richpresence(&richpresence, buffer, "Lookup:Location\n// Zero\n0=Zero\n// One\n1=One\n//2=Two\n\nDisplay:\nAt @Location(0xH0000)");
+  assert_richpresence_output(richpresence, &memory, "At Zero");
+
+  ram[0] = 1;
+  assert_richpresence_output(richpresence, &memory, "At One");
+
+  /* no entry - default to empty string */
+  ram[0] = 2;
+  assert_richpresence_output(richpresence, &memory, "At ");
+}
+
 static void test_macro_lookup_hex_keys() {
   unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
   memory_t memory;
@@ -855,6 +875,7 @@ void test_richpresence(void) {
 
   /* lookup macros */
   TEST(test_macro_lookup_simple);
+  TEST(test_macro_lookup_with_inline_comment);
   TEST(test_macro_lookup_hex_keys);
   TEST(test_macro_lookup_default);
   TEST(test_macro_lookup_crlf);

--- a/test/rcheevos/test_richpresence.c
+++ b/test/rcheevos/test_richpresence.c
@@ -323,6 +323,25 @@ static void test_macro_value_from_indirect() {
   assert_richpresence_output(richpresence, &memory, "Pointing at 52");
 }
 
+static void test_macro_value_divide_by_zero() {
+  unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  memory_t memory;
+  rc_richpresence_t* richpresence;
+  char buffer[1024];
+
+  memory.ram = ram;
+  memory.size = sizeof(ram);
+
+  assert_parse_richpresence(&richpresence, buffer, "Format:Value\nFormatType=VALUE\n\nDisplay:\nResult is @Value(0xH02/0xH00)");
+  assert_richpresence_output(richpresence, &memory, "Result is 0");
+
+  ram[0] = 1;
+  assert_richpresence_output(richpresence, &memory, "Result is 52");
+
+  ram[0] = 2;
+  assert_richpresence_output(richpresence, &memory, "Result is 26");
+}
+
 static void test_macro_frames() {
   unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
   memory_t memory;
@@ -869,6 +888,7 @@ void test_richpresence(void) {
   TEST(test_macro_value_from_formula);
   TEST(test_macro_value_from_hits);
   TEST(test_macro_value_from_indirect);
+  TEST(test_macro_value_divide_by_zero);
 
   /* frames macros */
   TEST(test_macro_frames);

--- a/validator/validator.c
+++ b/validator/validator.c
@@ -46,7 +46,7 @@ static void validate_trigger(const char* trigger) {
     return;
   }
 
-  printf("OK");
+  printf("%d OK", ret);
   free(buffer);
 }
 
@@ -76,7 +76,7 @@ static void validate_leaderboard(const char* leaderboard)
     return;
   }
 
-  printf("OK");
+  printf("%d OK", ret);
   free(buffer);
 }
 
@@ -106,7 +106,7 @@ static void validate_richpresence(const char* script)
     return;
   }
 
-  printf("OK");
+  printf("%d OK", ret);
   free(buffer);
 }
 


### PR DESCRIPTION
Implements https://github.com/RetroAchievements/RAIntegration/issues/493

Ranges can be specified with dashes, and non-contiguous values can be specified with commas. Both can be used together:
```
0-2,7,9,12-15=Happiness
```
Is the same as:
```
0=Happiness
1=Happiness
2=Happiness
7=Happiness
9=Happiness
12=Happiness
13=Happiness
14=Happiness
15=Happiness
```

Because of the way that the data is stored to support ranges, existing RPs where neighboring items have the same text can automatically be converted into ranges when compiling the rich presence script. This has a benefit of shrinking the overall compiled RP size when neighboring items can be combined. When there are no neighboring items that can benefit from this form of collapsing, the compiled RP size will increase slightly due to the additional fields added to support ranges. 

The logic that collapses neighboring values into ranges will also detect duplicate entries in the list. This will now generate a RC_DUPLICATED_VALUE error (previously the second entry was effectively ignored because the first entry would always be found first).  Approximately 40 of the existing rich presence scripts are currently affected by this.

This PR also implements support for #23. If a line starts with `//` while processing the lookup table, it will be ignored without terminating the lookup table. A single empty line is still treated as the end of the lookup table.
```
Lookup:CharacterTable
// Uppercase letters
0x00=A
0x01=B
0x19=Z
// 0x1a-0x1f are non-letter characters
0x20=a
0x21=b
0x39=z

0x51=1 // empty line above this line causes this to be ignored
```