### PR TITLE
invert rc_memref_t and rc_memref_value_t

### DIFF
--- a/src/rcheevos/internal.h
+++ b/src/rcheevos/internal.h
@@ -14,7 +14,7 @@ rc_scratch_string_t;
 RC_ALLOW_ALIGN(rc_condition_t)
 RC_ALLOW_ALIGN(rc_condset_t)
 RC_ALLOW_ALIGN(rc_lboard_t)
-RC_ALLOW_ALIGN(rc_memref_value_t)
+RC_ALLOW_ALIGN(rc_memref_t)
 RC_ALLOW_ALIGN(rc_operand_t)
 RC_ALLOW_ALIGN(rc_richpresence_t)
 RC_ALLOW_ALIGN(rc_richpresence_display_t)
@@ -85,7 +85,7 @@ typedef struct {
   void* buffer;
   rc_scratch_t scratch;
 
-  rc_memref_value_t** first_memref;
+  rc_memref_t** first_memref;
   rc_value_t** variables;
 
   unsigned measured_target;
@@ -93,7 +93,7 @@ typedef struct {
 rc_parse_state_t;
 
 void rc_init_parse_state(rc_parse_state_t* parse, void* buffer, lua_State* L, int funcs_ndx);
-void rc_init_parse_state_memrefs(rc_parse_state_t* parse, rc_memref_value_t** memrefs);
+void rc_init_parse_state_memrefs(rc_parse_state_t* parse, rc_memref_t** memrefs);
 void rc_init_parse_state_variables(rc_parse_state_t* parse, rc_value_t** variables);
 void rc_destroy_parse_state(rc_parse_state_t* parse);
 
@@ -101,10 +101,10 @@ void* rc_alloc(void* pointer, int* offset, int size, int alignment, rc_scratch_t
 void* rc_alloc_scratch(void* pointer, int* offset, int size, int alignment, rc_scratch_t* scratch);
 char* rc_alloc_str(rc_parse_state_t* parse, const char* text, int length);
 
-rc_memref_value_t* rc_alloc_memref_value(rc_parse_state_t* parse, unsigned address, char size, char is_indirect);
-void rc_update_memref_values(rc_memref_value_t* memref, rc_peek_t peek, void* ud);
-void rc_update_memref_value(rc_memref_value_t* memref, rc_peek_t peek, void* ud);
-rc_memref_value_t* rc_get_indirect_memref(rc_memref_value_t* memref, rc_eval_state_t* eval_state);
+rc_memref_t* rc_alloc_memref(rc_parse_state_t* parse, unsigned address, char size, char is_indirect);
+void rc_update_memref_values(rc_memref_t* memref, rc_peek_t peek, void* ud);
+void rc_update_memref_value(rc_memref_t* memref, rc_peek_t peek, void* ud);
+rc_memref_value_t* rc_get_indirect_memref(rc_memref_t* memref, rc_eval_state_t* eval_state);
 
 void rc_parse_trigger_internal(rc_trigger_t* self, const char** memaddr, rc_parse_state_t* parse);
 

--- a/src/rcheevos/lboard.c
+++ b/src/rcheevos/lboard.c
@@ -139,7 +139,7 @@ void rc_parse_lboard_internal(rc_lboard_t* self, const char* memaddr, rc_parse_s
 int rc_lboard_size(const char* memaddr) {
   rc_lboard_t* self;
   rc_parse_state_t parse;
-  rc_memref_value_t* first_memref;
+  rc_memref_t* first_memref;
   rc_init_parse_state(&parse, 0, 0, 0);
   rc_init_parse_state_memrefs(&parse, &first_memref);
 

--- a/src/rcheevos/operand.c
+++ b/src/rcheevos/operand.c
@@ -145,7 +145,7 @@ static int rc_parse_operand_memory(rc_operand_t* self, const char** memaddr, rc_
     address = 0xffffffffU;
   }
 
-  self->value.memref = rc_alloc_memref_value(parse, address, size, is_indirect);
+  self->value.memref = rc_alloc_memref(parse, address, size, is_indirect);
   if (parse->offset < 0)
     return parse->offset;
 
@@ -445,6 +445,7 @@ unsigned rc_evaluate_operand(rc_operand_t* self, rc_eval_state_t* eval_state) {
           break;
 
         case RC_MEMSIZE_32_BITS:
+        case RC_MEMSIZE_VARIABLE:
           value = ((value >> 28) & 0x0f) * 10000000
                 + ((value >> 24) & 0x0f) * 1000000
                 + ((value >> 20) & 0x0f) * 100000
@@ -481,6 +482,7 @@ unsigned rc_evaluate_operand(rc_operand_t* self, rc_eval_state_t* eval_state) {
           break;
 
         case RC_MEMSIZE_32_BITS:
+        case RC_MEMSIZE_VARIABLE:
           value ^= 0xffffffff;
           break;
 

--- a/src/rcheevos/richpresence.c
+++ b/src/rcheevos/richpresence.c
@@ -523,7 +523,7 @@ void rc_parse_richpresence_internal(rc_richpresence_t* self, const char* script,
 int rc_richpresence_size(const char* script) {
   rc_richpresence_t* self;
   rc_parse_state_t parse;
-  rc_memref_value_t* first_memref;
+  rc_memref_t* first_memref;
   rc_value_t* variables;
   rc_init_parse_state(&parse, 0, 0, 0);
   rc_init_parse_state_memrefs(&parse, &first_memref);

--- a/src/rcheevos/runtime.c
+++ b/src/rcheevos/runtime.c
@@ -77,7 +77,7 @@ static char rc_runtime_allocated_memrefs(rc_runtime_t* self) {
     owns_memref = 1;
     /* advance through the new variables so we're ready for the next allocation */
     do {
-      self->next_variable = (rc_value_t**)&(*self->next_variable)->value.next;
+      self->next_variable = &(*self->next_variable)->next;
     } while (*self->next_variable != NULL);
   }
 
@@ -605,6 +605,6 @@ void rc_runtime_reset(rc_runtime_t* self) {
     }
   }
 
-  for (variable = self->variables; variable; variable = (rc_value_t*)variable->value.next)
+  for (variable = self->variables; variable; variable = variable->next)
     rc_reset_value(variable);
 }

--- a/src/rcheevos/runtime_progress.c
+++ b/src/rcheevos/runtime_progress.c
@@ -105,20 +105,20 @@ static void rc_runtime_progress_init(rc_runtime_progress_t* progress, rc_runtime
 
 static int rc_runtime_progress_write_memrefs(rc_runtime_progress_t* progress)
 {
-  rc_memref_value_t* memref = progress->runtime->memrefs;
+  rc_memref_t* memref = progress->runtime->memrefs;
   unsigned int flags = 0;
 
   rc_runtime_progress_start_chunk(progress, RC_RUNTIME_CHUNK_MEMREFS);
 
   while (memref) {
-    flags = memref->memref.size;
-    if (memref->previous == memref->prior)
+    flags = memref->value.size;
+    if (memref->value.previous == memref->value.prior)
       flags |= RC_MEMREF_FLAG_PREV_IS_PRIOR;
 
-    rc_runtime_progress_write_uint(progress, memref->memref.address);
+    rc_runtime_progress_write_uint(progress, memref->address);
     rc_runtime_progress_write_uint(progress, flags);
-    rc_runtime_progress_write_uint(progress, memref->value);
-    rc_runtime_progress_write_uint(progress, memref->prior);
+    rc_runtime_progress_write_uint(progress, memref->value.value);
+    rc_runtime_progress_write_uint(progress, memref->value.prior);
 
     memref = memref->next;
   }
@@ -132,7 +132,7 @@ static int rc_runtime_progress_read_memrefs(rc_runtime_progress_t* progress)
   unsigned entries;
   unsigned address, flags, value, prior;
   char size;
-  rc_memref_value_t* memref;
+  rc_memref_t* memref;
 
   /* re-read the chunk size to determine how many memrefs are present */
   progress->offset -= 4;
@@ -148,10 +148,10 @@ static int rc_runtime_progress_read_memrefs(rc_runtime_progress_t* progress)
 
     memref = progress->runtime->memrefs;
     while (memref) {
-      if (memref->memref.address == address && memref->memref.size == size) {
-        memref->value = value;
-        memref->previous = (flags & RC_MEMREF_FLAG_PREV_IS_PRIOR) ? prior : value;
-        memref->prior = prior;
+      if (memref->address == address && memref->value.size == size) {
+        memref->value.value = value;
+        memref->value.previous = (flags & RC_MEMREF_FLAG_PREV_IS_PRIOR) ? prior : value;
+        memref->value.prior = prior;
       }
 
       memref = memref->next;

--- a/src/rcheevos/trigger.c
+++ b/src/rcheevos/trigger.c
@@ -48,7 +48,7 @@ void rc_parse_trigger_internal(rc_trigger_t* self, const char** memaddr, rc_pars
 int rc_trigger_size(const char* memaddr) {
   rc_trigger_t* self;
   rc_parse_state_t parse;
-  rc_memref_value_t* memrefs;
+  rc_memref_t* memrefs;
   rc_init_parse_state(&parse, 0, 0, 0);
   rc_init_parse_state_memrefs(&parse, &memrefs);
 

--- a/test/rcheevos/test_condition.c
+++ b/test/rcheevos/test_condition.c
@@ -11,7 +11,7 @@ static void _assert_operand(rc_operand_t* self, char expected_type, char expecte
     case RC_OPERAND_DELTA:
     case RC_OPERAND_PRIOR:
       ASSERT_NUM_EQUALS(self->size, expected_size);
-      ASSERT_NUM_EQUALS(self->value.memref->memref.address, expected_address);
+      ASSERT_NUM_EQUALS(self->value.memref->address, expected_address);
       break;
 
     case RC_OPERAND_CONST:
@@ -30,7 +30,7 @@ static void _assert_parse_condition(
 ) {
     rc_condition_t* self;
     rc_parse_state_t parse;
-    rc_memref_value_t* memrefs;
+    rc_memref_t* memrefs;
     char buffer[512];
 
     rc_init_parse_state(&parse, buffer, 0, 0);
@@ -106,7 +106,7 @@ static void test_parse_condition_error(const char* memaddr, int expected_error) 
   }
 }
 
-static int evaluate_condition(rc_condition_t* cond, memory_t* memory, rc_memref_value_t* memrefs) {
+static int evaluate_condition(rc_condition_t* cond, memory_t* memory, rc_memref_t* memrefs) {
   rc_eval_state_t eval_state;
 
   memset(&eval_state, 0, sizeof(eval_state));
@@ -121,7 +121,7 @@ static void test_evaluate_condition(const char* memaddr, int expected_result) {
   rc_condition_t* self;
   rc_parse_state_t parse;
   char buffer[512];
-  rc_memref_value_t* memrefs;
+  rc_memref_t* memrefs;
   int ret;
   unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
@@ -152,7 +152,7 @@ static void test_condition_compare_delta() {
   rc_condition_t* cond;
   rc_parse_state_t parse;
   char buffer[512];
-  rc_memref_value_t* memrefs;
+  rc_memref_t* memrefs;
 
   const char* cond_str = "0xH0001>d0xH0001";
   rc_init_parse_state(&parse, buffer, 0, 0);

--- a/test/rcheevos/test_condset.c
+++ b/test/rcheevos/test_condset.c
@@ -1209,7 +1209,7 @@ static void test_subsource_overflow_comparison_greater_or_equal() {
   unsigned char ram[] = {0x00, 0x6C, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;

--- a/test/rcheevos/test_condset.c
+++ b/test/rcheevos/test_condset.c
@@ -3,7 +3,7 @@
 #include "../test_framework.h"
 #include "mock_memory.h"
 
-static void _assert_parse_condset(rc_condset_t** condset, rc_memref_value_t** memrefs, void* buffer, const char* memaddr)
+static void _assert_parse_condset(rc_condset_t** condset, rc_memref_t** memrefs, void* buffer, const char* memaddr)
 {
   rc_parse_state_t parse;
   int size;
@@ -20,7 +20,7 @@ static void _assert_parse_condset(rc_condset_t** condset, rc_memref_value_t** me
 }
 #define assert_parse_condset(condset, memrefs_out, buffer, memaddr) ASSERT_HELPER(_assert_parse_condset(condset, memrefs_out, buffer, memaddr), "assert_parse_condset")
 
-static void _assert_evaluate_condset(rc_condset_t* condset, rc_memref_value_t* memrefs, memory_t* memory, int expected_result) {
+static void _assert_evaluate_condset(rc_condset_t* condset, rc_memref_t* memrefs, memory_t* memory, int expected_result) {
   int result;
   rc_eval_state_t eval_state;
 
@@ -66,7 +66,7 @@ static void test_hitcount_increment_when_true() {
   unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -83,7 +83,7 @@ static void test_hitcount_does_not_increment_when_false() {
   unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -100,7 +100,7 @@ static void test_hitcount_target() {
   unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -136,7 +136,7 @@ static void test_hitcount_two_conditions(const char* memaddr, unsigned expected_
   unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -153,7 +153,7 @@ static void test_hitcount_three_conditions(const char* memaddr, unsigned expecte
   unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -170,7 +170,7 @@ static void test_pauseif() {
   unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -203,7 +203,7 @@ static void test_pauseif_hitcount_one() {
   unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -226,7 +226,7 @@ static void test_pauseif_hitcount_two() {
   unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -255,7 +255,7 @@ static void test_pauseif_hitcount_with_reset() {
   unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -288,7 +288,7 @@ static void test_pauseif_does_not_increment_hits() {
   unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -335,7 +335,7 @@ static void test_pauseif_delta_updated() {
   unsigned char ram[] = {0x00, 0x00, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -373,7 +373,7 @@ static void test_resetif() {
   unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -417,7 +417,7 @@ static void test_resetif_cond_with_hittarget() {
   unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -467,7 +467,7 @@ static void test_resetif_hitcount() {
   unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -506,7 +506,7 @@ static void test_resetif_hitcount_one() {
   unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -539,7 +539,7 @@ static void test_resetif_hitcount_addhits() {
   unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -564,7 +564,7 @@ static void test_pauseif_resetif_hitcounts() {
   unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -605,7 +605,7 @@ static void test_addsource() {
   unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -642,7 +642,7 @@ static void test_addsource_overflow() {
   unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -664,7 +664,7 @@ static void test_subsource() {
   unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -708,7 +708,7 @@ static void test_subsource_overflow() {
   unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -730,7 +730,7 @@ static void test_addsource_subsource() {
   unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -779,7 +779,7 @@ static void test_addsource_multiply() {
   unsigned char ram[] = {0x00, 0x06, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -816,7 +816,7 @@ static void test_subsource_multiply() {
   unsigned char ram[] = {0x00, 0x06, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -853,7 +853,7 @@ static void test_addsource_multiply_fraction() {
   unsigned char ram[] = {0x00, 0x08, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -890,7 +890,7 @@ static void test_addsource_multiply_address() {
   unsigned char ram[] = {0x00, 0x06, 0x04, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -927,7 +927,7 @@ static void test_addsource_divide() {
   unsigned char ram[] = {0x00, 0x06, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -964,7 +964,7 @@ static void test_subsource_divide() {
   unsigned char ram[] = {0x00, 0x06, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -1001,7 +1001,7 @@ static void test_addsource_divide_address() {
   unsigned char ram[] = {0x00, 0x06, 0x10, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -1038,7 +1038,7 @@ static void test_addsource_mask() {
   unsigned char ram[] = {0x00, 0x06, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -1075,7 +1075,7 @@ static void test_subsource_mask() {
   unsigned char ram[] = {0x00, 0x6C, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -1112,7 +1112,7 @@ static void test_subsource_overflow_comparison_equal() {
   unsigned char ram[] = {0x00, 0x6C, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -1160,7 +1160,7 @@ static void test_subsource_overflow_comparison_greater() {
   unsigned char ram[] = {0x00, 0x6C, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -1258,7 +1258,7 @@ static void test_subsource_overflow_comparison_lesser() {
   unsigned char ram[] = {0x00, 0x6C, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -1307,7 +1307,7 @@ static void test_subsource_overflow_comparison_lesser_or_equal() {
   unsigned char ram[] = {0x00, 0x6C, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -1356,7 +1356,7 @@ static void test_addhits() {
   unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -1404,7 +1404,7 @@ static void test_addhits_multiple() {
   unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -1436,7 +1436,7 @@ static void test_addhits_no_target() {
   unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -1468,7 +1468,7 @@ static void test_addhits_with_addsource() {
   unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -1497,7 +1497,7 @@ static void test_andnext() {
   unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -1579,7 +1579,7 @@ static void test_andnext_boundaries() {
   unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -1628,7 +1628,7 @@ static void test_andnext_resetif() {
   unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -1705,7 +1705,7 @@ static void test_andnext_pauseif() {
   unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -1782,7 +1782,7 @@ static void test_andnext_addsource() {
   unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -1823,7 +1823,7 @@ static void test_andnext_addhits() {
   unsigned char ram[] = {0x00, 0x00, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -1869,7 +1869,7 @@ static void test_andnext_between_addhits() {
   unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -1940,7 +1940,7 @@ static void test_andnext_with_hits_chain() {
   unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -2023,7 +2023,7 @@ static void test_andnext_changes_to() {
   unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -2054,7 +2054,7 @@ static void test_ornext() {
   unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -2124,7 +2124,7 @@ static void test_andnext_ornext_interaction() {
   unsigned char ram[] = {0, 0, 0, 0, 0};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -2149,7 +2149,7 @@ static void test_addaddress_direct_pointer() {
   unsigned char ram[] = {0x01, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -2186,7 +2186,7 @@ static void test_addaddress_indirect_pointer() {
   unsigned char ram[] = {0x01, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -2227,7 +2227,7 @@ static void test_addaddress_indirect_pointer_negative() {
   unsigned char ram[] = {0x02, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -2268,7 +2268,7 @@ static void test_addaddress_indirect_pointer_out_of_range() {
   unsigned char ram[] = {0x01, 0x12, 0x34, 0xAB, 0x56, 0x16};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -2295,7 +2295,7 @@ static void test_addaddress_indirect_pointer_multiple() {
     unsigned char ram[] = {0x01, 0x02, 0x03, 0x34, 0xAB, 0x56};
     memory_t memory;
     rc_condset_t* condset;
-    rc_memref_value_t* memrefs = NULL;
+    rc_memref_t* memrefs = NULL;
     char buffer[2048];
 
     memory.ram = ram;
@@ -2339,7 +2339,7 @@ static void test_addaddress_pointer_data_size_differs_from_pointer_size() {
   unsigned char ram[] = {0x01, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -2373,7 +2373,7 @@ static void test_addaddress_double_indirection() {
   unsigned char ram[] = {0x01, 0x02, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -2411,7 +2411,7 @@ static void test_addaddress_adjust_both_sides() {
   unsigned char ram[] = {0x02, 0x11, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -2445,7 +2445,7 @@ static void test_addaddress_adjust_both_sides_different_bases() {
   unsigned char ram[] = {0x02, 0x11, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;
@@ -2472,7 +2472,7 @@ static void test_addaddress_scaled() {
   unsigned char ram[] = {0x01, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
-  rc_memref_value_t* memrefs = NULL;
+  rc_memref_t* memrefs = NULL;
   char buffer[2048];
 
   memory.ram = ram;

--- a/test/rcheevos/test_memref.c
+++ b/test/rcheevos/test_memref.c
@@ -5,7 +5,7 @@
 
 static int get_memref_count(rc_parse_state_t* parse) {
   int count = 0;
-  rc_memref_value_t *memref = *parse->first_memref;
+  rc_memref_t *memref = *parse->first_memref;
   while (memref) {
     ++count;
     memref = memref->next;
@@ -16,35 +16,35 @@ static int get_memref_count(rc_parse_state_t* parse) {
 
 static void test_allocate_shared_address() {
   rc_parse_state_t parse;
-  rc_memref_value_t* memrefs;
+  rc_memref_t* memrefs;
   rc_init_parse_state(&parse, NULL, 0, 0);
   rc_init_parse_state_memrefs(&parse, &memrefs);
 
-  rc_alloc_memref_value(&parse, 1, RC_MEMSIZE_8_BITS, 0);
+  rc_alloc_memref(&parse, 1, RC_MEMSIZE_8_BITS, 0);
   ASSERT_NUM_EQUALS(get_memref_count(&parse), 1);
 
-  rc_alloc_memref_value(&parse, 1, RC_MEMSIZE_16_BITS, 0); /* differing size will not match */
+  rc_alloc_memref(&parse, 1, RC_MEMSIZE_16_BITS, 0); /* differing size will not match */
   ASSERT_NUM_EQUALS(get_memref_count(&parse), 2);
 
-  rc_alloc_memref_value(&parse, 1, RC_MEMSIZE_LOW, 0); /* differing size will not match */
+  rc_alloc_memref(&parse, 1, RC_MEMSIZE_LOW, 0); /* differing size will not match */
   ASSERT_NUM_EQUALS(get_memref_count(&parse), 3);
 
-  rc_alloc_memref_value(&parse, 1, RC_MEMSIZE_BIT_2, 0); /* differing size will not match */
+  rc_alloc_memref(&parse, 1, RC_MEMSIZE_BIT_2, 0); /* differing size will not match */
   ASSERT_NUM_EQUALS(get_memref_count(&parse), 4);
 
-  rc_alloc_memref_value(&parse, 2, RC_MEMSIZE_8_BITS, 0); /* differing address will not match */
+  rc_alloc_memref(&parse, 2, RC_MEMSIZE_8_BITS, 0); /* differing address will not match */
   ASSERT_NUM_EQUALS(get_memref_count(&parse), 5);
 
-  rc_alloc_memref_value(&parse, 1, RC_MEMSIZE_8_BITS, 0); /* match */
+  rc_alloc_memref(&parse, 1, RC_MEMSIZE_8_BITS, 0); /* match */
   ASSERT_NUM_EQUALS(get_memref_count(&parse), 5);
 
-  rc_alloc_memref_value(&parse, 1, RC_MEMSIZE_16_BITS, 0); /* match */
+  rc_alloc_memref(&parse, 1, RC_MEMSIZE_16_BITS, 0); /* match */
   ASSERT_NUM_EQUALS(get_memref_count(&parse), 5);
 
-  rc_alloc_memref_value(&parse, 1, RC_MEMSIZE_BIT_2, 0); /* match */
+  rc_alloc_memref(&parse, 1, RC_MEMSIZE_BIT_2, 0); /* match */
   ASSERT_NUM_EQUALS(get_memref_count(&parse), 5);
 
-  rc_alloc_memref_value(&parse, 2, RC_MEMSIZE_8_BITS, 0); /* match */
+  rc_alloc_memref(&parse, 2, RC_MEMSIZE_8_BITS, 0); /* match */
   ASSERT_NUM_EQUALS(get_memref_count(&parse), 5);
 
   rc_destroy_parse_state(&parse);
@@ -52,43 +52,43 @@ static void test_allocate_shared_address() {
 
 static void test_allocate_shared_address2() {
   rc_parse_state_t parse;
-  rc_memref_value_t* memrefs;
-  rc_memref_value_t* memref1;
-  rc_memref_value_t* memref2;
-  rc_memref_value_t* memref3;
-  rc_memref_value_t* memref4;
-  rc_memref_value_t* memref5;
-  rc_memref_value_t* memrefX;
+  rc_memref_t* memrefs;
+  rc_memref_t* memref1;
+  rc_memref_t* memref2;
+  rc_memref_t* memref3;
+  rc_memref_t* memref4;
+  rc_memref_t* memref5;
+  rc_memref_t* memrefX;
   rc_init_parse_state(&parse, NULL, 0, 0);
   rc_init_parse_state_memrefs(&parse, &memrefs);
 
-  memref1 = rc_alloc_memref_value(&parse, 1, RC_MEMSIZE_8_BITS, 0);
-  ASSERT_NUM_EQUALS(memref1->memref.address, 1);
-  ASSERT_NUM_EQUALS(memref1->memref.size, RC_MEMSIZE_8_BITS);
-  ASSERT_NUM_EQUALS(memref1->memref.is_indirect, 0);
-  ASSERT_NUM_EQUALS(memref1->value, 0);
-  ASSERT_NUM_EQUALS(memref1->previous, 0);
-  ASSERT_NUM_EQUALS(memref1->prior, 0);
+  memref1 = rc_alloc_memref(&parse, 1, RC_MEMSIZE_8_BITS, 0);
+  ASSERT_NUM_EQUALS(memref1->address, 1);
+  ASSERT_NUM_EQUALS(memref1->value.size, RC_MEMSIZE_8_BITS);
+  ASSERT_NUM_EQUALS(memref1->value.is_indirect, 0);
+  ASSERT_NUM_EQUALS(memref1->value.value, 0);
+  ASSERT_NUM_EQUALS(memref1->value.previous, 0);
+  ASSERT_NUM_EQUALS(memref1->value.prior, 0);
   ASSERT_PTR_EQUALS(memref1->next, 0);
 
-  memref2 = rc_alloc_memref_value(&parse, 1, RC_MEMSIZE_16_BITS, 0); /* differing size will not match */
-  memref3 = rc_alloc_memref_value(&parse, 1, RC_MEMSIZE_LOW, 0); /* differing size will not match */
-  memref4 = rc_alloc_memref_value(&parse, 1, RC_MEMSIZE_BIT_2, 0); /* differing size will not match */
-  memref5 = rc_alloc_memref_value(&parse, 2, RC_MEMSIZE_8_BITS, 0); /* differing address will not match */
+  memref2 = rc_alloc_memref(&parse, 1, RC_MEMSIZE_16_BITS, 0); /* differing size will not match */
+  memref3 = rc_alloc_memref(&parse, 1, RC_MEMSIZE_LOW, 0); /* differing size will not match */
+  memref4 = rc_alloc_memref(&parse, 1, RC_MEMSIZE_BIT_2, 0); /* differing size will not match */
+  memref5 = rc_alloc_memref(&parse, 2, RC_MEMSIZE_8_BITS, 0); /* differing address will not match */
 
-  memrefX = rc_alloc_memref_value(&parse, 1, RC_MEMSIZE_8_BITS, 0); /* match */
+  memrefX = rc_alloc_memref(&parse, 1, RC_MEMSIZE_8_BITS, 0); /* match */
   ASSERT_PTR_EQUALS(memrefX, memref1);
 
-  memrefX = rc_alloc_memref_value(&parse, 1, RC_MEMSIZE_16_BITS, 0); /* match */
+  memrefX = rc_alloc_memref(&parse, 1, RC_MEMSIZE_16_BITS, 0); /* match */
   ASSERT_PTR_EQUALS(memrefX, memref2);
 
-  memrefX = rc_alloc_memref_value(&parse, 1, RC_MEMSIZE_LOW, 0); /* match */
+  memrefX = rc_alloc_memref(&parse, 1, RC_MEMSIZE_LOW, 0); /* match */
   ASSERT_PTR_EQUALS(memrefX, memref3);
 
-  memrefX = rc_alloc_memref_value(&parse, 1, RC_MEMSIZE_BIT_2, 0); /* match */
+  memrefX = rc_alloc_memref(&parse, 1, RC_MEMSIZE_BIT_2, 0); /* match */
   ASSERT_PTR_EQUALS(memrefX, memref4);
 
-  memrefX = rc_alloc_memref_value(&parse, 2, RC_MEMSIZE_8_BITS, 0); /* match */
+  memrefX = rc_alloc_memref(&parse, 2, RC_MEMSIZE_8_BITS, 0); /* match */
   ASSERT_PTR_EQUALS(memrefX, memref5);
 
   rc_destroy_parse_state(&parse);
@@ -97,30 +97,30 @@ static void test_allocate_shared_address2() {
 static void test_sizing_mode_grow_buffer() {
   int i;
   rc_parse_state_t parse;
-  rc_memref_value_t* memrefs;
+  rc_memref_t* memrefs;
   rc_init_parse_state(&parse, NULL, 0, 0);
   rc_init_parse_state_memrefs(&parse, &memrefs);
 
   /* memrefs are allocated 16 at a time */
   for (i = 0; i < 100; i++) {
-      rc_alloc_memref_value(&parse, i, RC_MEMSIZE_8_BITS, 0);
+      rc_alloc_memref(&parse, i, RC_MEMSIZE_8_BITS, 0);
   }
   ASSERT_NUM_EQUALS(get_memref_count(&parse), 100);
 
   /* 100 have been allocated, make sure we can still access items at various addresses without allocating more */
-  rc_alloc_memref_value(&parse, 1, RC_MEMSIZE_8_BITS, 0);
+  rc_alloc_memref(&parse, 1, RC_MEMSIZE_8_BITS, 0);
   ASSERT_NUM_EQUALS(get_memref_count(&parse), 100);
 
-  rc_alloc_memref_value(&parse, 25, RC_MEMSIZE_8_BITS, 0);
+  rc_alloc_memref(&parse, 25, RC_MEMSIZE_8_BITS, 0);
   ASSERT_NUM_EQUALS(get_memref_count(&parse), 100);
 
-  rc_alloc_memref_value(&parse, 50, RC_MEMSIZE_8_BITS, 0);
+  rc_alloc_memref(&parse, 50, RC_MEMSIZE_8_BITS, 0);
   ASSERT_NUM_EQUALS(get_memref_count(&parse), 100);
 
-  rc_alloc_memref_value(&parse, 75, RC_MEMSIZE_8_BITS, 0);
+  rc_alloc_memref(&parse, 75, RC_MEMSIZE_8_BITS, 0);
   ASSERT_NUM_EQUALS(get_memref_count(&parse), 100);
 
-  rc_alloc_memref_value(&parse, 99, RC_MEMSIZE_8_BITS, 0);
+  rc_alloc_memref(&parse, 99, RC_MEMSIZE_8_BITS, 0);
   ASSERT_NUM_EQUALS(get_memref_count(&parse), 100);
 
   rc_destroy_parse_state(&parse);
@@ -128,9 +128,9 @@ static void test_sizing_mode_grow_buffer() {
 
 static void test_update_memref_values() {
   rc_parse_state_t parse;
-  rc_memref_value_t* memrefs;
-  rc_memref_value_t* memref1;
-  rc_memref_value_t* memref2;
+  rc_memref_t* memrefs;
+  rc_memref_t* memref1;
+  rc_memref_t* memref2;
 
   unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
   memory_t memory;
@@ -140,47 +140,47 @@ static void test_update_memref_values() {
   rc_init_parse_state(&parse, NULL, 0, 0);
   rc_init_parse_state_memrefs(&parse, &memrefs);
 
-  memref1 = rc_alloc_memref_value(&parse, 1, RC_MEMSIZE_8_BITS, 0);
-  memref2 = rc_alloc_memref_value(&parse, 2, RC_MEMSIZE_8_BITS, 0);
+  memref1 = rc_alloc_memref(&parse, 1, RC_MEMSIZE_8_BITS, 0);
+  memref2 = rc_alloc_memref(&parse, 2, RC_MEMSIZE_8_BITS, 0);
 
   rc_update_memref_values(memrefs, peek, &memory);
 
-  ASSERT_NUM_EQUALS(memref1->value, 0x12);
-  ASSERT_NUM_EQUALS(memref1->previous, 0);
-  ASSERT_NUM_EQUALS(memref1->prior, 0);
-  ASSERT_NUM_EQUALS(memref2->value, 0x34);
-  ASSERT_NUM_EQUALS(memref2->previous, 0);
-  ASSERT_NUM_EQUALS(memref2->prior, 0);
+  ASSERT_NUM_EQUALS(memref1->value.value, 0x12);
+  ASSERT_NUM_EQUALS(memref1->value.previous, 0);
+  ASSERT_NUM_EQUALS(memref1->value.prior, 0);
+  ASSERT_NUM_EQUALS(memref2->value.value, 0x34);
+  ASSERT_NUM_EQUALS(memref2->value.previous, 0);
+  ASSERT_NUM_EQUALS(memref2->value.prior, 0);
 
   ram[1] = 3;
   rc_update_memref_values(memrefs, peek, &memory);
 
-  ASSERT_NUM_EQUALS(memref1->value, 3);
-  ASSERT_NUM_EQUALS(memref1->previous, 0x12);
-  ASSERT_NUM_EQUALS(memref1->prior, 0x12);
-  ASSERT_NUM_EQUALS(memref2->value, 0x34);
-  ASSERT_NUM_EQUALS(memref2->previous, 0x34);
-  ASSERT_NUM_EQUALS(memref2->prior, 0);
+  ASSERT_NUM_EQUALS(memref1->value.value, 3);
+  ASSERT_NUM_EQUALS(memref1->value.previous, 0x12);
+  ASSERT_NUM_EQUALS(memref1->value.prior, 0x12);
+  ASSERT_NUM_EQUALS(memref2->value.value, 0x34);
+  ASSERT_NUM_EQUALS(memref2->value.previous, 0x34);
+  ASSERT_NUM_EQUALS(memref2->value.prior, 0);
 
   ram[1] = 5;
   rc_update_memref_values(memrefs, peek, &memory);
 
-  ASSERT_NUM_EQUALS(memref1->value, 5);
-  ASSERT_NUM_EQUALS(memref1->previous, 3);
-  ASSERT_NUM_EQUALS(memref1->prior, 3);
-  ASSERT_NUM_EQUALS(memref2->value, 0x34);
-  ASSERT_NUM_EQUALS(memref2->previous, 0x34);
-  ASSERT_NUM_EQUALS(memref2->prior, 0);
+  ASSERT_NUM_EQUALS(memref1->value.value, 5);
+  ASSERT_NUM_EQUALS(memref1->value.previous, 3);
+  ASSERT_NUM_EQUALS(memref1->value.prior, 3);
+  ASSERT_NUM_EQUALS(memref2->value.value, 0x34);
+  ASSERT_NUM_EQUALS(memref2->value.previous, 0x34);
+  ASSERT_NUM_EQUALS(memref2->value.prior, 0);
 
   ram[2] = 7;
   rc_update_memref_values(memrefs, peek, &memory);
 
-  ASSERT_NUM_EQUALS(memref1->value, 5);
-  ASSERT_NUM_EQUALS(memref1->previous, 5);
-  ASSERT_NUM_EQUALS(memref1->prior, 3);
-  ASSERT_NUM_EQUALS(memref2->value, 7);
-  ASSERT_NUM_EQUALS(memref2->previous, 0x34);
-  ASSERT_NUM_EQUALS(memref2->prior, 0x34);
+  ASSERT_NUM_EQUALS(memref1->value.value, 5);
+  ASSERT_NUM_EQUALS(memref1->value.previous, 5);
+  ASSERT_NUM_EQUALS(memref1->value.prior, 3);
+  ASSERT_NUM_EQUALS(memref2->value.value, 7);
+  ASSERT_NUM_EQUALS(memref2->value.previous, 0x34);
+  ASSERT_NUM_EQUALS(memref2->value.prior, 0x34);
 
   rc_destroy_parse_state(&parse);
 }

--- a/test/rcheevos/test_operand.c
+++ b/test/rcheevos/test_operand.c
@@ -6,7 +6,7 @@
 static void _assert_parse_operand(rc_operand_t* self, const char** memaddr) {
   rc_parse_state_t parse;
   char buffer[256];
-  rc_memref_value_t* memrefs;
+  rc_memref_t* memrefs;
   int ret;
 
   rc_init_parse_state(&parse, buffer, 0, 0);
@@ -26,7 +26,7 @@ static void _assert_operand(rc_operand_t* self, char expected_type, char expecte
     case RC_OPERAND_DELTA:
     case RC_OPERAND_PRIOR:
       ASSERT_NUM_EQUALS(expected_size, self->size);
-      ASSERT_UNUM_EQUALS(expected_address, self->value.memref->memref.address);
+      ASSERT_UNUM_EQUALS(expected_address, self->value.memref->address);
       break;
 
     case RC_OPERAND_CONST:
@@ -62,7 +62,7 @@ static void test_parse_error_operand(const char* memaddr, int valid_chars, int e
   rc_parse_state_t parse;
   int ret;
   const char* begin = memaddr;
-  rc_memref_value_t* memrefs;
+  rc_memref_t* memrefs;
 
   rc_init_parse_state(&parse, 0, 0, 0);
   rc_init_parse_state_memrefs(&parse, &memrefs);
@@ -73,7 +73,7 @@ static void test_parse_error_operand(const char* memaddr, int valid_chars, int e
   ASSERT_NUM_EQUALS(memaddr - begin, valid_chars);
 }
 
-static unsigned evaluate_operand(rc_operand_t* op, memory_t* memory, rc_memref_value_t* memrefs)
+static unsigned evaluate_operand(rc_operand_t* op, memory_t* memory, rc_memref_t* memrefs)
 {
   rc_eval_state_t eval_state;
 
@@ -88,7 +88,7 @@ static unsigned evaluate_operand(rc_operand_t* op, memory_t* memory, rc_memref_v
 static void test_evaluate_operand(const char* memaddr, memory_t* memory, unsigned expected_value) {
   rc_operand_t self;
   rc_parse_state_t parse;
-  rc_memref_value_t* memrefs;
+  rc_memref_t* memrefs;
   char buffer[512];
   unsigned value;
 
@@ -384,7 +384,7 @@ static void test_evaluate_delta_memory_reference() {
   const char* memaddr;
   rc_parse_state_t parse;
   char buffer[256];
-  rc_memref_value_t* memrefs;
+  rc_memref_t* memrefs;
 
   memory.ram = ram;
   memory.size = sizeof(ram);
@@ -422,7 +422,7 @@ void test_evaluate_prior_memory_reference() {
   const char* memaddr;
   rc_parse_state_t parse;
   char buffer[256];
-  rc_memref_value_t* memrefs;
+  rc_memref_t* memrefs;
 
   memory.ram = ram;
   memory.size = sizeof(ram);

--- a/test/rcheevos/test_runtime.c
+++ b/test/rcheevos/test_runtime.c
@@ -182,8 +182,8 @@ static void test_shared_memref(void)
   unsigned char ram[] = { 0, 10, 10 };
   memory_t memory;
   rc_runtime_t runtime;
-  rc_memref_value_t* memref1;
-  rc_memref_value_t* memref2;
+  rc_memref_t* memref1;
+  rc_memref_t* memref2;
 
   memory.ram = ram;
   memory.size = sizeof(ram);

--- a/test/rcheevos/test_runtime_progress.c
+++ b/test/rcheevos/test_runtime_progress.c
@@ -49,14 +49,14 @@ static void _assert_deserialize(rc_runtime_t* runtime, unsigned char* buffer)
 
 static void _assert_sized_memref(rc_runtime_t* runtime, unsigned address, char size, unsigned value, unsigned prev, unsigned prior)
 {
-  rc_memref_value_t* memref = runtime->memrefs;
+  rc_memref_t* memref = runtime->memrefs;
   while (memref)
   {
-    if (memref->memref.address == address && memref->memref.size == size)
+    if (memref->address == address && memref->value.size == size)
     {
-      ASSERT_NUM_EQUALS(memref->value, value);
-      ASSERT_NUM_EQUALS(memref->previous, prev);
-      ASSERT_NUM_EQUALS(memref->prior, prior);
+      ASSERT_NUM_EQUALS(memref->value.value, value);
+      ASSERT_NUM_EQUALS(memref->value.previous, prev);
+      ASSERT_NUM_EQUALS(memref->value.prior, prior);
       return;
     }
 
@@ -141,7 +141,7 @@ static void update_md5(unsigned char* buffer)
 
 static void reset_runtime(rc_runtime_t* runtime)
 {
-  rc_memref_value_t* memref;
+  rc_memref_t* memref;
   rc_trigger_t* trigger;
   rc_condition_t* cond;
   rc_condset_t* condset;
@@ -150,9 +150,9 @@ static void reset_runtime(rc_runtime_t* runtime)
   memref = runtime->memrefs;
   while (memref)
   {
-    memref->value = 0xFF;
-    memref->previous = 0xFF;
-    memref->prior = 0xFF;
+    memref->value.value = 0xFF;
+    memref->value.previous = 0xFF;
+    memref->value.prior = 0xFF;
 
     memref = memref->next;
   }

--- a/test/rcheevos/test_trigger.c
+++ b/test/rcheevos/test_trigger.c
@@ -1151,9 +1151,9 @@ static void test_evaluate_trigger_inactive() {
   assert_hit_count(trigger, 0, 1, 0U);
 
   /* memrefs should be updated while inactive */
-  ASSERT_NUM_EQUALS(trigger_get_cond(trigger, 0, 1)->operand1.value.memref->value, 24U);
-  ASSERT_NUM_EQUALS(trigger_get_cond(trigger, 0, 1)->operand1.value.memref->previous, 24U);
-  ASSERT_NUM_EQUALS(trigger_get_cond(trigger, 0, 1)->operand1.value.memref->prior, 52U);
+  ASSERT_NUM_EQUALS(trigger_get_cond(trigger, 0, 1)->operand1.value.memref->value.value, 24U);
+  ASSERT_NUM_EQUALS(trigger_get_cond(trigger, 0, 1)->operand1.value.memref->value.previous, 24U);
+  ASSERT_NUM_EQUALS(trigger_get_cond(trigger, 0, 1)->operand1.value.memref->value.prior, 52U);
 
   /* reset should be ignored while inactive */
   ram[4] = 4;
@@ -1262,8 +1262,8 @@ static void test_evaluate_trigger_triggered() {
   assert_hit_count(trigger, 0, 1, 1U);
 
   /* triggered trigger does not update deltas */
-  ASSERT_NUM_EQUALS(trigger_get_cond(trigger, 0, 0)->operand1.value.memref->value, 18U);
-  ASSERT_NUM_EQUALS(trigger_get_cond(trigger, 0, 0)->operand1.value.memref->previous, 0U);
+  ASSERT_NUM_EQUALS(trigger_get_cond(trigger, 0, 0)->operand1.value.memref->value.value, 18U);
+  ASSERT_NUM_EQUALS(trigger_get_cond(trigger, 0, 0)->operand1.value.memref->value.previous, 0U);
 }
 
 static void test_evaluate_trigger_paused() {
@@ -1449,8 +1449,8 @@ static void test_prev_prior_share_memref() {
 
   assert_parse_trigger(&trigger, buffer, "0xH0001=d0xH0001_0xH0001!=p0xH0001");
 
-  ASSERT_NUM_EQUALS(trigger->memrefs->memref.address, 1U);
-  ASSERT_NUM_EQUALS(trigger->memrefs->memref.size, RC_MEMSIZE_8_BITS);
+  ASSERT_NUM_EQUALS(trigger->memrefs->address, 1U);
+  ASSERT_NUM_EQUALS(trigger->memrefs->value.size, RC_MEMSIZE_8_BITS);
   ASSERT_PTR_NULL(trigger->memrefs->next);
 
   ASSERT_NUM_EQUALS(trigger_get_cond(trigger, 0, 0)->operand1.type, RC_OPERAND_ADDRESS);
@@ -1465,8 +1465,8 @@ static void test_bit_lookups_share_memref() {
 
   assert_parse_trigger(&trigger, buffer, "0xM0001=1_0xN0x0001=0_0xO0x0001=1");
 
-  ASSERT_NUM_EQUALS(trigger->memrefs->memref.address, 1U);
-  ASSERT_NUM_EQUALS(trigger->memrefs->memref.size, RC_MEMSIZE_8_BITS);
+  ASSERT_NUM_EQUALS(trigger->memrefs->address, 1U);
+  ASSERT_NUM_EQUALS(trigger->memrefs->value.size, RC_MEMSIZE_8_BITS);
   ASSERT_PTR_NULL(trigger->memrefs->next);
 
   ASSERT_NUM_EQUALS(trigger_get_cond(trigger, 0, 0)->operand1.size, RC_MEMSIZE_BIT_0);
@@ -1480,8 +1480,8 @@ static void test_bitcount_shares_memref() {
 
   assert_parse_trigger(&trigger, buffer, "0xH0001>5_0xK0001!=3");
 
-  ASSERT_NUM_EQUALS(trigger->memrefs->memref.address, 1U);
-  ASSERT_NUM_EQUALS(trigger->memrefs->memref.size, RC_MEMSIZE_8_BITS);
+  ASSERT_NUM_EQUALS(trigger->memrefs->address, 1U);
+  ASSERT_NUM_EQUALS(trigger->memrefs->value.size, RC_MEMSIZE_8_BITS);
   ASSERT_PTR_NULL(trigger->memrefs->next);
 
   ASSERT_NUM_EQUALS(trigger_get_cond(trigger, 0, 0)->operand1.type, RC_OPERAND_ADDRESS);
@@ -1497,12 +1497,12 @@ static void test_large_memref_not_shared() {
   assert_parse_trigger(&trigger, buffer, "0xH1234=1_0xX1234>d0xX1234");
 
   /* this could be shared, but isn't currently */
-  ASSERT_NUM_EQUALS(trigger->memrefs->memref.address, 0x1234);
-  ASSERT_NUM_EQUALS(trigger->memrefs->memref.size, RC_MEMSIZE_8_BITS);
+  ASSERT_NUM_EQUALS(trigger->memrefs->address, 0x1234);
+  ASSERT_NUM_EQUALS(trigger->memrefs->value.size, RC_MEMSIZE_8_BITS);
   ASSERT_PTR_NOT_NULL(trigger->memrefs->next);
 
-  ASSERT_NUM_EQUALS(trigger->memrefs->next->memref.address, 0x1234);
-  ASSERT_NUM_EQUALS(trigger->memrefs->next->memref.size, RC_MEMSIZE_32_BITS);
+  ASSERT_NUM_EQUALS(trigger->memrefs->next->address, 0x1234);
+  ASSERT_NUM_EQUALS(trigger->memrefs->next->value.size, RC_MEMSIZE_32_BITS);
   ASSERT_PTR_NULL(trigger->memrefs->next->next);
 }
 


### PR DESCRIPTION
inverts the `rc_memref_value_t`/`rc_memref_t` relationship so an `rc_value_t` can use a `rc_memref_value_t` without dragging along unnecessary fields.