### PR TITLE
more platform-independent implementation for implicitly signed integers

### DIFF
--- a/src/rcheevos/operand.c
+++ b/src/rcheevos/operand.c
@@ -204,9 +204,10 @@ int rc_parse_operand(rc_operand_t* self, const char** memaddr, int is_trigger, i
       break;
 
     case 'v': case 'V': /* signed integer constant */
-      negative = 0;
       ++aux;
-
+      /* fallthrough */
+    case '+': case '-': /* signed integer constant */
+      negative = 0;
       if (*aux == '-')
       {
         negative = 1;
@@ -238,7 +239,7 @@ int rc_parse_operand(rc_operand_t* self, const char** memaddr, int is_trigger, i
       break;
 
     case '0':
-      if (aux[1] == 'x' || aux[1] == 'X') {
+      if (aux[1] == 'x' || aux[1] == 'X') { /* hex integer constant */
         /* fall through */
     default:
         ret = rc_parse_operand_memory(self, &aux, parse, is_indirect);
@@ -251,8 +252,7 @@ int rc_parse_operand(rc_operand_t* self, const char** memaddr, int is_trigger, i
       }
 
       /* fall through for case '0' where not '0x' */
-    case '+': case '-':
-    case '1': case '2': case '3': case '4': case '5':
+    case '1': case '2': case '3': case '4': case '5': /* unsigned integer constant */
     case '6': case '7': case '8': case '9':
       value = strtoul(aux, &end, 10);
 


### PR DESCRIPTION
Fixes an issue where a platform-specific implementation of `strtoul` may return 0 when passed a negative number instead of the very large positive number that is the two-complement equivalent of the negative number. 

Signed values are expected to be prefixed with a `v`: `v-1`, but there was some implied support for using `-1` directly, which was being used in the case where the issue was reported.

I've modified the code to treat implicitly signed values (starting with `-` or `+`) the same as if they were explicitly declared using `v`.

