### PR TITLE
derive prev from value or prior; simplify indirection

### DIFF
--- a/include/rcheevos.h
+++ b/include/rcheevos.h
@@ -78,19 +78,19 @@ enum {
 };
 
 typedef struct rc_memref_value_t {
-  /* The value of this memory reference. */
+  /* The current value of this memory reference. */
   unsigned value;
-  /* The previous value of this memory reference. */
-  unsigned previous;
   /* The last differing value of this memory reference. */
   unsigned prior;
 
-  /* The size of the variable. */
+  /* The size of the value. */
   char size;
-  /* True if the reference will be used in indirection. */
+  /* True if the value changed this frame. */
+  char changed;
+  /* True if the reference will be used in indirection.
+   * NOTE: This is actually a property of the rc_memref_t, but we put it here to save space */
   char is_indirect;
 } rc_memref_value_t;
-
 
 typedef struct rc_memref_t rc_memref_t;
 

--- a/src/rcheevos/internal.h
+++ b/src/rcheevos/internal.h
@@ -103,8 +103,8 @@ char* rc_alloc_str(rc_parse_state_t* parse, const char* text, int length);
 
 rc_memref_t* rc_alloc_memref(rc_parse_state_t* parse, unsigned address, char size, char is_indirect);
 void rc_update_memref_values(rc_memref_t* memref, rc_peek_t peek, void* ud);
-void rc_update_memref_value(rc_memref_t* memref, rc_peek_t peek, void* ud);
-rc_memref_value_t* rc_get_indirect_memref(rc_memref_t* memref, rc_eval_state_t* eval_state);
+void rc_update_memref_value(rc_memref_value_t* memref, unsigned value);
+unsigned rc_get_memref_value(rc_memref_t* memref, int operand_type, rc_eval_state_t* eval_state);
 
 void rc_parse_trigger_internal(rc_trigger_t* self, const char** memaddr, rc_parse_state_t* parse);
 

--- a/src/rcheevos/memref.c
+++ b/src/rcheevos/memref.c
@@ -8,10 +8,9 @@
 rc_memref_t* rc_alloc_memref(rc_parse_state_t* parse, unsigned address, char size, char is_indirect) {
   rc_memref_t** next_memref;
   rc_memref_t* memref;
-  rc_memref_t* indirect_memref;
 
   if (!is_indirect) {
-    /* attempt to find an existing rc_memref_value_t */
+    /* attempt to find an existing memref that can be shared */
     next_memref = parse->first_memref;
     while (*next_memref) {
       memref = *next_memref;
@@ -20,109 +19,90 @@ rc_memref_t* rc_alloc_memref(rc_parse_state_t* parse, unsigned address, char siz
 
       next_memref = &memref->next;
     }
+
+    /* no match found, create a new entry */
+    memref = RC_ALLOC_SCRATCH(rc_memref_t, parse);
+    *next_memref = memref;
   }
   else {
-    /* indirect address always creates two new entries - one for the original address, and one for
-       the indirect dereference */
-    if (!parse->buffer) {
-      /* in sizing mode, only allocate space for the two entries, but don't add them to the chain */
-      memref = RC_ALLOC(rc_memref_t, parse);
-      indirect_memref = RC_ALLOC(rc_memref_t, parse);
-      return memref;
-    }
-
-    /* non-sizing mode - just skip ahead to the end of the list so we can append the new entries */
-    next_memref = parse->first_memref;
-    while (*next_memref)
-      next_memref = &(*next_memref)->next;
+    /* indirect references always create a new entry because we can't guarantee that the 
+     * indirection amount will be the same between references. because they aren't shared,
+     * don't bother putting them in the chain.
+     */
+    memref = RC_ALLOC(rc_memref_t, parse);
   }
 
-  /* no match found, create a new entry */
-  memref = RC_ALLOC_SCRATCH(rc_memref_t, parse);
   memset(memref, 0, sizeof(*memref));
   memref->address = address;
   memref->value.size = size;
   memref->value.is_indirect = is_indirect;
 
-  *next_memref = memref;
-
-  /* also create the indirect deference entry for indirect references */
-  if (is_indirect) {
-    indirect_memref = RC_ALLOC(rc_memref_t, parse);
-    memset(indirect_memref, 0, sizeof(*indirect_memref));
-    indirect_memref->address = MEMREF_PLACEHOLDER_ADDRESS;
-    indirect_memref->value.size = size;
-    indirect_memref->value.is_indirect = 1;
-
-    memref->next = indirect_memref;
-  }
-
   return memref;
 }
 
-static unsigned rc_memref_get_value(rc_memref_t* self, rc_peek_t peek, void* ud) {
+static unsigned rc_peek_value(unsigned address, char size, rc_peek_t peek, void* ud) {
   unsigned value;
 
   if (!peek)
     return 0;
 
-  switch (self->value.size)
+  switch (size)
   {
     case RC_MEMSIZE_BIT_0:
-      value = (peek(self->address, 1, ud) >> 0) & 1;
+      value = (peek(address, 1, ud) >> 0) & 1;
       break;
 
     case RC_MEMSIZE_BIT_1:
-      value = (peek(self->address, 1, ud) >> 1) & 1;
+      value = (peek(address, 1, ud) >> 1) & 1;
       break;
 
     case RC_MEMSIZE_BIT_2:
-      value = (peek(self->address, 1, ud) >> 2) & 1;
+      value = (peek(address, 1, ud) >> 2) & 1;
       break;
 
     case RC_MEMSIZE_BIT_3:
-      value = (peek(self->address, 1, ud) >> 3) & 1;
+      value = (peek(address, 1, ud) >> 3) & 1;
       break;
 
     case RC_MEMSIZE_BIT_4:
-      value = (peek(self->address, 1, ud) >> 4) & 1;
+      value = (peek(address, 1, ud) >> 4) & 1;
       break;
 
     case RC_MEMSIZE_BIT_5:
-      value = (peek(self->address, 1, ud) >> 5) & 1;
+      value = (peek(address, 1, ud) >> 5) & 1;
       break;
 
     case RC_MEMSIZE_BIT_6:
-      value = (peek(self->address, 1, ud) >> 6) & 1;
+      value = (peek(address, 1, ud) >> 6) & 1;
       break;
 
     case RC_MEMSIZE_BIT_7:
-      value = (peek(self->address, 1, ud) >> 7) & 1;
+      value = (peek(address, 1, ud) >> 7) & 1;
       break;
 
     case RC_MEMSIZE_LOW:
-      value = peek(self->address, 1, ud) & 0x0f;
+      value = peek(address, 1, ud) & 0x0f;
       break;
 
     case RC_MEMSIZE_HIGH:
-      value = (peek(self->address, 1, ud) >> 4) & 0x0f;
+      value = (peek(address, 1, ud) >> 4) & 0x0f;
       break;
 
     case RC_MEMSIZE_8_BITS:
-      value = peek(self->address, 1, ud);
+      value = peek(address, 1, ud);
       break;
 
     case RC_MEMSIZE_16_BITS:
-      value = peek(self->address, 2, ud);
+      value = peek(address, 2, ud);
       break;
 
     case RC_MEMSIZE_24_BITS:
       /* peek 4 bytes - don't expect the caller to understand 24-bit numbers */
-      value = peek(self->address, 4, ud) & 0x00FFFFFF;
+      value = peek(address, 4, ud) & 0x00FFFFFF;
       break;
 
     case RC_MEMSIZE_32_BITS:
-      value = peek(self->address, 4, ud);
+      value = peek(address, 4, ud);
       break;
 
     default:
@@ -133,17 +113,23 @@ static unsigned rc_memref_get_value(rc_memref_t* self, rc_peek_t peek, void* ud)
   return value;
 }
 
-void rc_update_memref_value(rc_memref_t* memref, rc_peek_t peek, void* ud) {
-  memref->value.previous = memref->value.value;
-  memref->value.value = rc_memref_get_value(memref, peek, ud);
-  if (memref->value.value != memref->value.previous)
-    memref->value.prior = memref->value.previous;
+void rc_update_memref_value(rc_memref_value_t* memref, unsigned new_value) {
+  if (memref->value == new_value) {
+    memref->changed = 0;
+  }
+  else {
+    memref->prior = memref->value;
+    memref->value = new_value;
+    memref->changed = 1;
+  }
 }
 
 void rc_update_memref_values(rc_memref_t* memref, rc_peek_t peek, void* ud) {
   while (memref) {
-    if (memref->address != MEMREF_PLACEHOLDER_ADDRESS)
-      rc_update_memref_value(memref, peek, ud);
+    /* indirect memory references are not shared and will be updated in rc_get_memref_value */
+    if (!memref->value.is_indirect)
+      rc_update_memref_value(&memref->value, rc_peek_value(memref->address, memref->value.size, peek, ud));
+
     memref = memref->next;
   }
 }
@@ -153,25 +139,28 @@ void rc_init_parse_state_memrefs(rc_parse_state_t* parse, rc_memref_t** memrefs)
   *memrefs = 0;
 }
 
-rc_memref_value_t* rc_get_indirect_memref(rc_memref_t* memref, rc_eval_state_t* eval_state) {
-  unsigned new_address;
-
-  if (eval_state->add_address == 0)
-    return &memref->value;
-
-  if (!memref->value.is_indirect)
-    return &memref->value;
-
-  new_address = memref->address + eval_state->add_address;
-
-  /* an extra rc_memref_value_t is allocated for offset calculations */
-  memref = memref->next;
-
-  /* if the adjusted address has changed, update the record */
-  if (memref->address != new_address) {
-    memref->address = new_address;
-    rc_update_memref_value(memref, eval_state->peek, eval_state->peek_userdata);
+unsigned rc_get_memref_value(rc_memref_t* memref, int operand_type, rc_eval_state_t* eval_state) {
+  /* if this is an indirect reference, handle the indirection. */
+  if (memref->value.is_indirect) {
+    const unsigned new_address = memref->address + eval_state->add_address;
+    rc_update_memref_value(&memref->value, rc_peek_value(new_address, memref->value.size, eval_state->peek, eval_state->peek_userdata));
   }
 
-  return &memref->value;
+  switch (operand_type)
+  {
+    /* most common case explicitly first, even though it could be handled by default case.
+     * this helps the compiler to optimize if it turns the switch into a series of if/elses */
+    case RC_OPERAND_ADDRESS:
+      return memref->value.value;
+
+    case RC_OPERAND_DELTA:
+      if (!memref->value.changed) {
+        // fallthrough
+    default:
+        return memref->value.value;
+      }
+      // fallthrough
+    case RC_OPERAND_PRIOR:
+      return memref->value.prior;
+  }
 }

--- a/src/rcheevos/memref.c
+++ b/src/rcheevos/memref.c
@@ -155,11 +155,11 @@ unsigned rc_get_memref_value(rc_memref_t* memref, int operand_type, rc_eval_stat
 
     case RC_OPERAND_DELTA:
       if (!memref->value.changed) {
-        // fallthrough
+        /* fallthrough */
     default:
         return memref->value.value;
       }
-      // fallthrough
+      /* fallthrough */
     case RC_OPERAND_PRIOR:
       return memref->value.prior;
   }

--- a/src/rcheevos/operand.c
+++ b/src/rcheevos/operand.c
@@ -353,15 +353,7 @@ unsigned rc_evaluate_operand(rc_operand_t* self, rc_eval_state_t* eval_state) {
       break;
 
     default:
-      value = rc_get_indirect_memref(self->value.memref, eval_state)->value;
-      break;
-
-    case RC_OPERAND_DELTA:
-      value = rc_get_indirect_memref(self->value.memref, eval_state)->previous;
-      break;
-
-    case RC_OPERAND_PRIOR:
-      value = rc_get_indirect_memref(self->value.memref, eval_state)->prior;
+      value = rc_get_memref_value(self->value.memref, self->type, eval_state);
       break;
   }
 

--- a/src/rcheevos/runtime_progress.c
+++ b/src/rcheevos/runtime_progress.c
@@ -24,7 +24,7 @@ typedef struct rc_runtime_progress_t {
 
 #define RC_TRIGGER_STATE_UNUPDATED 0x7F
 
-#define RC_MEMREF_FLAG_PREV_IS_PRIOR 0x00010000
+#define RC_MEMREF_FLAG_CHANGED_THIS_FRAME 0x00010000
 
 static void rc_runtime_progress_write_uint(rc_runtime_progress_t* progress, unsigned value)
 {
@@ -112,8 +112,8 @@ static int rc_runtime_progress_write_memrefs(rc_runtime_progress_t* progress)
 
   while (memref) {
     flags = memref->value.size;
-    if (memref->value.previous == memref->value.prior)
-      flags |= RC_MEMREF_FLAG_PREV_IS_PRIOR;
+    if (memref->value.changed)
+      flags |= RC_MEMREF_FLAG_CHANGED_THIS_FRAME;
 
     rc_runtime_progress_write_uint(progress, memref->address);
     rc_runtime_progress_write_uint(progress, flags);
@@ -150,7 +150,7 @@ static int rc_runtime_progress_read_memrefs(rc_runtime_progress_t* progress)
     while (memref) {
       if (memref->address == address && memref->value.size == size) {
         memref->value.value = value;
-        memref->value.previous = (flags & RC_MEMREF_FLAG_PREV_IS_PRIOR) ? prior : value;
+        memref->value.changed = (flags & RC_MEMREF_FLAG_CHANGED_THIS_FRAME) ? 1 : 0;
         memref->value.prior = prior;
       }
 

--- a/src/rcheevos/value.c
+++ b/src/rcheevos/value.c
@@ -149,7 +149,8 @@ void rc_parse_value_internal(rc_value_t* self, const char** memaddr, rc_parse_st
   }
 
   self->name = "(unnamed)";
-  self->value.value = self->value.previous = self->value.prior = 0;
+  self->value.value = self->value.prior = 0;
+  self->value.changed = 0;
   self->next = 0;
 }
 
@@ -227,10 +228,7 @@ int rc_evaluate_value(rc_value_t* self, rc_peek_t peek, void* ud, lua_State* L) 
 
   if (!paused) {
     /* if not paused, store the value so that it's available when paused. */
-    self->value.previous = self->value.value;
-    self->value.value = result;
-    if (self->value.value != self->value.previous)
-      self->value.prior = self->value.previous;
+    rc_update_memref_value(&self->value, result);
   }
   else {
     /* when paused, the Measured value will not be captured, use the last captured value. */
@@ -247,7 +245,8 @@ void rc_reset_value(rc_value_t* self) {
     condset = condset->next;
   }
 
-  self->value.value = self->value.previous = self->value.prior = 0;
+  self->value.value = self->value.prior = 0;
+  self->value.changed = 0;
 }
 
 void rc_init_parse_state_variables(rc_parse_state_t* parse, rc_value_t** variables) {

--- a/test/rcheevos/test_memref.c
+++ b/test/rcheevos/test_memref.c
@@ -67,7 +67,7 @@ static void test_allocate_shared_address2() {
   ASSERT_NUM_EQUALS(memref1->value.size, RC_MEMSIZE_8_BITS);
   ASSERT_NUM_EQUALS(memref1->value.is_indirect, 0);
   ASSERT_NUM_EQUALS(memref1->value.value, 0);
-  ASSERT_NUM_EQUALS(memref1->value.previous, 0);
+  ASSERT_NUM_EQUALS(memref1->value.changed, 0);
   ASSERT_NUM_EQUALS(memref1->value.prior, 0);
   ASSERT_PTR_EQUALS(memref1->next, 0);
 
@@ -146,40 +146,40 @@ static void test_update_memref_values() {
   rc_update_memref_values(memrefs, peek, &memory);
 
   ASSERT_NUM_EQUALS(memref1->value.value, 0x12);
-  ASSERT_NUM_EQUALS(memref1->value.previous, 0);
+  ASSERT_NUM_EQUALS(memref1->value.changed, 1);
   ASSERT_NUM_EQUALS(memref1->value.prior, 0);
   ASSERT_NUM_EQUALS(memref2->value.value, 0x34);
-  ASSERT_NUM_EQUALS(memref2->value.previous, 0);
+  ASSERT_NUM_EQUALS(memref2->value.changed, 1);
   ASSERT_NUM_EQUALS(memref2->value.prior, 0);
 
   ram[1] = 3;
   rc_update_memref_values(memrefs, peek, &memory);
 
   ASSERT_NUM_EQUALS(memref1->value.value, 3);
-  ASSERT_NUM_EQUALS(memref1->value.previous, 0x12);
+  ASSERT_NUM_EQUALS(memref1->value.changed, 1);
   ASSERT_NUM_EQUALS(memref1->value.prior, 0x12);
   ASSERT_NUM_EQUALS(memref2->value.value, 0x34);
-  ASSERT_NUM_EQUALS(memref2->value.previous, 0x34);
+  ASSERT_NUM_EQUALS(memref2->value.changed, 0);
   ASSERT_NUM_EQUALS(memref2->value.prior, 0);
 
   ram[1] = 5;
   rc_update_memref_values(memrefs, peek, &memory);
 
   ASSERT_NUM_EQUALS(memref1->value.value, 5);
-  ASSERT_NUM_EQUALS(memref1->value.previous, 3);
+  ASSERT_NUM_EQUALS(memref1->value.changed, 1);
   ASSERT_NUM_EQUALS(memref1->value.prior, 3);
   ASSERT_NUM_EQUALS(memref2->value.value, 0x34);
-  ASSERT_NUM_EQUALS(memref2->value.previous, 0x34);
+  ASSERT_NUM_EQUALS(memref2->value.changed, 0);
   ASSERT_NUM_EQUALS(memref2->value.prior, 0);
 
   ram[2] = 7;
   rc_update_memref_values(memrefs, peek, &memory);
 
   ASSERT_NUM_EQUALS(memref1->value.value, 5);
-  ASSERT_NUM_EQUALS(memref1->value.previous, 5);
+  ASSERT_NUM_EQUALS(memref1->value.changed, 0);
   ASSERT_NUM_EQUALS(memref1->value.prior, 3);
   ASSERT_NUM_EQUALS(memref2->value.value, 7);
-  ASSERT_NUM_EQUALS(memref2->value.previous, 0x34);
+  ASSERT_NUM_EQUALS(memref2->value.changed, 1);
   ASSERT_NUM_EQUALS(memref2->value.prior, 0x34);
 
   rc_destroy_parse_state(&parse);

--- a/test/rcheevos/test_runtime_progress.c
+++ b/test/rcheevos/test_runtime_progress.c
@@ -55,8 +55,16 @@ static void _assert_sized_memref(rc_runtime_t* runtime, unsigned address, char s
     if (memref->address == address && memref->value.size == size)
     {
       ASSERT_NUM_EQUALS(memref->value.value, value);
-      ASSERT_NUM_EQUALS(memref->value.previous, prev);
       ASSERT_NUM_EQUALS(memref->value.prior, prior);
+
+      if (value == prior)
+      {
+        ASSERT_NUM_EQUALS(memref->value.changed, 0);
+      }
+      else
+      {
+        ASSERT_NUM_EQUALS(memref->value.changed, (prev == prior) ? 1 : 0);
+      }
       return;
     }
 
@@ -151,7 +159,7 @@ static void reset_runtime(rc_runtime_t* runtime)
   while (memref)
   {
     memref->value.value = 0xFF;
-    memref->value.previous = 0xFF;
+    memref->value.changed = 0;
     memref->value.prior = 0xFF;
 
     memref = memref->next;

--- a/test/rcheevos/test_trigger.c
+++ b/test/rcheevos/test_trigger.c
@@ -1152,7 +1152,7 @@ static void test_evaluate_trigger_inactive() {
 
   /* memrefs should be updated while inactive */
   ASSERT_NUM_EQUALS(trigger_get_cond(trigger, 0, 1)->operand1.value.memref->value.value, 24U);
-  ASSERT_NUM_EQUALS(trigger_get_cond(trigger, 0, 1)->operand1.value.memref->value.previous, 24U);
+  ASSERT_NUM_EQUALS(trigger_get_cond(trigger, 0, 1)->operand1.value.memref->value.changed, 0);
   ASSERT_NUM_EQUALS(trigger_get_cond(trigger, 0, 1)->operand1.value.memref->value.prior, 52U);
 
   /* reset should be ignored while inactive */
@@ -1263,7 +1263,7 @@ static void test_evaluate_trigger_triggered() {
 
   /* triggered trigger does not update deltas */
   ASSERT_NUM_EQUALS(trigger_get_cond(trigger, 0, 0)->operand1.value.memref->value.value, 18U);
-  ASSERT_NUM_EQUALS(trigger_get_cond(trigger, 0, 0)->operand1.value.memref->value.previous, 0U);
+  ASSERT_NUM_EQUALS(trigger_get_cond(trigger, 0, 0)->operand1.value.memref->value.changed, 1U);
 }
 
 static void test_evaluate_trigger_paused() {


### PR DESCRIPTION
removes 4 bytes from each memref, and an entire memref for each AddAddress