### PR TITLE
allocate separate memory chunks for each type of scratch object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,39 @@
+# v9.3.0
+
+* allow ranges in rich presence lookups
+* support MAXOF($) for leaderboard values using trigger syntax
+* allow RC_CONDITION_PAUSE_IF and RC_CONDITION_RESET_IF in leaderboard value expression
+* changed track parameter of rc_hash_cdreader_open_track_handler to support three virtual tracks:
+  RC_HASH_CDTRACK_FIRST_DATA, RC_HASH_CDTRACK_LAST and RC_HASH_CDTRACK_LARGEST.
+* reset to default cd reader if NULL is passed to rc_hash_init_custom_cdreader
+* add hash support for RC_CONSOLE_DREAMCAST
+* ignore headers for RC_CONSOLE_PC_ENGINE
+* rename RC_CONSOLE_MAGNAVOX_ODYSSEY -> RC_CONSOLE_MAGNAVOX_ODYSSEY2
+* rename RC_CONSOLE_AMIGA_ST -> RC_CONSOLE_ATARI_ST
+* fix error identifying largest track when track has multiple bins
+* fix memory corruption error when cue track has more than 6 INDEXs
+* several improvements to data storage for conditions (rc_memref_t and rc_memref_value_t structures have been modified)
+
+# v9.2.0
+
+* fix issue identifying some PC-FX titles where the boot code is not in the first data track
+* add enums and labels for RC_CONSOLE_MAGNAVOX_ODYSSEY, RC_CONSOLE_SUPER_CASSETTEVISION, RC_CONSOLE_NEO_GEO_CD,
+  RC_CONSOLE_FAIRCHILD_CHANNEL_F, RC_CONSOLE_FM_TOWNS, RC_CONSOLE_ZX_SPECTRUM, RC_CONSOLE_GAME_AND_WATCH,
+  RC_CONSOLE_NOKIA_NGAGE, RC_CONSOLE_NINTENDO_3DS
+
+# v9.1.0
+
+* add hash support and memory map for RC_CONSOLE_MSX
+* add hash support and memory map for RC_CONSOLE_PCFX
+* include parent directory when hashing non-arcade titles in arcade mode
+* support absolute paths in m3u
+* make cue scanning case-insensitive
+* expand SRAM mapping for RC_CONSOLE_WONDERSWAN
+* fix display of measured value when another group has an unmeasured hit count
+* fix memory read error when hashing file with no extension
+* fix possible divide by zero when using RC_CONDITION_ADD_SOURCE/RC_CONDITION_SUB_SOURCE
+* fix classification of secondary RC_CONSOLE_SATURN memory region
+
 # v9.0.0
 
 * new size: RC_MEMSIZE_BITCOUNT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * reset to default cd reader if NULL is passed to rc_hash_init_custom_cdreader
 * add hash support for RC_CONSOLE_DREAMCAST
 * ignore headers for RC_CONSOLE_PC_ENGINE
+* look for unique identifier in RC_CONSOLE_SEGA_CD and RC_CONSOLE_SATURN discs
 * rename RC_CONSOLE_MAGNAVOX_ODYSSEY -> RC_CONSOLE_MAGNAVOX_ODYSSEY2
 * rename RC_CONSOLE_AMIGA_ST -> RC_CONSOLE_ATARI_ST
 * fix error identifying largest track when track has multiple bins

--- a/include/rcheevos.h
+++ b/include/rcheevos.h
@@ -118,8 +118,8 @@ enum {
   RC_OPERAND_FP,             /* A floating point value. */
   RC_OPERAND_LUA,            /* A Lua function that provides the value. */
   RC_OPERAND_PRIOR,          /* The last differing value at this address. */
-  RC_OPERAND_BCD,            /* The BCD-decoded value of a live address in RAM */
-  RC_OPERAND_INVERTED        /* The twos-complement value of a live address in RAM */
+  RC_OPERAND_BCD,            /* The BCD-decoded value of a live address in RAM. */
+  RC_OPERAND_INVERTED        /* The twos-complement value of a live address in RAM. */
 };
 
 typedef struct {
@@ -278,6 +278,9 @@ void rc_reset_trigger(rc_trigger_t* self);
 typedef struct rc_value_t rc_value_t;
 
 struct rc_value_t {
+  /* The current value of the variable. */
+  rc_memref_value_t value;
+
   /* The list of conditions to evaluate. */
   rc_condset_t* conditions;
 
@@ -286,9 +289,6 @@ struct rc_value_t {
 
   /* The name of the variable. */
   const char* name;
-
-  /* The current value of the variable. */
-  rc_memref_value_t value;
 
   /* The next variable in the chain. */
   rc_value_t* next;

--- a/src/rcheevos/alloc.c
+++ b/src/rcheevos/alloc.c
@@ -3,13 +3,13 @@
 #include <stdlib.h>
 #include <string.h>
 
-void* rc_alloc_scratch(void* pointer, int* offset, int size, int alignment, rc_scratch_t* scratch)
+void* rc_alloc_scratch(void* pointer, int* offset, int size, int alignment, rc_scratch_t* scratch, int scratch_object_pointer_offset)
 {
   rc_scratch_buffer_t* buffer;
 
   /* if we have a real buffer, then allocate the data there */
   if (pointer)
-    return rc_alloc(pointer, offset, size, alignment, NULL);
+    return rc_alloc(pointer, offset, size, alignment, NULL, scratch_object_pointer_offset);
 
   /* update how much space will be required in the real buffer */
   {
@@ -26,7 +26,7 @@ void* rc_alloc_scratch(void* pointer, int* offset, int size, int alignment, rc_s
 
     if (remaining >= size) {
       /* claim the required space from an existing buffer */
-      return rc_alloc(buffer->buffer, &buffer->offset, size, alignment, NULL);
+      return rc_alloc(buffer->buffer, &buffer->offset, size, alignment, NULL, -1);
     }
 
     if (!buffer->next)
@@ -59,22 +59,30 @@ void* rc_alloc_scratch(void* pointer, int* offset, int size, int alignment, rc_s
   buffer->next = NULL;
 
   /* claim the required space from the new buffer */
-  return rc_alloc(buffer->buffer, &buffer->offset, size, alignment, NULL);
+  return rc_alloc(buffer->buffer, &buffer->offset, size, alignment, NULL, -1);
 }
 
-void* rc_alloc(void* pointer, int* offset, int size, int alignment, rc_scratch_t* scratch) {
+void* rc_alloc(void* pointer, int* offset, int size, int alignment, rc_scratch_t* scratch, int scratch_object_pointer_offset) {
   void* ptr;
 
   *offset = (*offset + alignment - 1) & ~(alignment - 1);
 
   if (pointer != 0) {
+    /* valid buffer, grab the next chunk */
     ptr = (void*)((char*)pointer + *offset);
   }
-  else if (scratch != 0) {
-    ptr = &scratch->obj;
+  else if (scratch != 0 && scratch_object_pointer_offset >= 0) {
+    /* only allocate one instance of each object type (indentified by scratch_object_pointer_offset) */
+    void** scratch_object_pointer = (void**)((char*)&scratch->objs + scratch_object_pointer_offset);
+    ptr = *scratch_object_pointer;
+    if (!ptr) {
+      int used;
+      ptr = *scratch_object_pointer = rc_alloc_scratch(NULL, &used, size, alignment, scratch, -1);
+    }
   }
   else {
-    ptr = 0;
+    /* nowhere to get memory from, return NULL */
+    ptr = NULL;
   }
 
   *offset += size;
@@ -100,8 +108,8 @@ char* rc_alloc_str(rc_parse_state_t* parse, const char* text, int length) {
       next = &(*next)->right;
   }
 
-  *next = rc_alloc_scratch(NULL, &used, sizeof(rc_scratch_string_t), RC_ALIGNOF(rc_scratch_string_t), &parse->scratch);
-  ptr = (char*)rc_alloc_scratch(parse->buffer, &parse->offset, length + 1, RC_ALIGNOF(char), &parse->scratch);
+  *next = rc_alloc_scratch(NULL, &used, sizeof(rc_scratch_string_t), RC_ALIGNOF(rc_scratch_string_t), &parse->scratch, RC_OFFSETOF(parse->scratch.objs, __rc_scratch_string_t));
+  ptr = (char*)rc_alloc_scratch(parse->buffer, &parse->offset, length + 1, RC_ALIGNOF(char), &parse->scratch, -1);
 
   if (!ptr || !*next) {
     if (parse->offset >= 0)
@@ -122,6 +130,7 @@ char* rc_alloc_str(rc_parse_state_t* parse, const char* text, int length) {
 
 void rc_init_parse_state(rc_parse_state_t* parse, void* buffer, lua_State* L, int funcs_ndx)
 {
+  /* could use memset here, but rc_parse_state_t contains a 512 byte buffer that doesn't need to be initialized */
   parse->offset = 0;
   parse->L = L;
   parse->funcs_ndx = funcs_ndx;
@@ -129,7 +138,9 @@ void rc_init_parse_state(rc_parse_state_t* parse, void* buffer, lua_State* L, in
   parse->scratch.buffer.offset = 0;
   parse->scratch.buffer.next = NULL;
   parse->scratch.strings = NULL;
+  memset(&parse->scratch.objs, 0, sizeof(parse->scratch.objs));
   parse->first_memref = 0;
+  parse->variables = 0;
   parse->measured_target = 0;
 }
 

--- a/src/rcheevos/condition.c
+++ b/src/rcheevos/condition.c
@@ -2,6 +2,64 @@
 
 #include <stdlib.h>
 
+char rc_parse_operator(const char** memaddr) {
+  const char* oper = *memaddr;
+
+  switch (*oper) {
+    case '=':
+      ++(*memaddr);
+      (*memaddr) += (**memaddr == '=');
+      return RC_OPERATOR_EQ;
+
+    case '!':
+      if (oper[1] == '=') {
+        (*memaddr) += 2;
+        return RC_OPERATOR_NE;
+      }
+      /* fall through */
+    default:
+      return RC_INVALID_OPERATOR;
+
+    case '<':
+      if (oper[1] == '=') {
+        (*memaddr) += 2;
+        return RC_OPERATOR_LE;
+      }
+
+      ++(*memaddr);
+      return RC_OPERATOR_LT;
+
+    case '>':
+      if (oper[1] == '=') {
+        (*memaddr) += 2;
+        return RC_OPERATOR_GE;
+      }
+
+      ++(*memaddr);
+      return RC_OPERATOR_GT;
+
+    case '*':
+      ++(*memaddr);
+      return RC_OPERATOR_MULT;
+
+    case '/':
+      ++(*memaddr);
+      return RC_OPERATOR_DIV;
+
+    case '&':
+      ++(*memaddr);
+      return RC_OPERATOR_AND;
+
+    case '\0':/* end of string */
+    case '_': /* next condition */
+    case 'S': /* next condset */
+    case ')': /* end of macro */
+    case '$': /* maximum of values */
+      /* valid condition separator, condition may not have an operator */
+      return RC_OPERATOR_NONE;
+  }
+}
+
 rc_condition_t* rc_parse_condition(const char** memaddr, rc_parse_state_t* parse, int is_indirect) {
   rc_condition_t* self;
   const char* aux;
@@ -46,78 +104,37 @@ rc_condition_t* rc_parse_condition(const char** memaddr, rc_parse_state_t* parse
     return 0;
   }
 
-  switch (*aux++) {
-    case '=':
-      self->oper = RC_OPERATOR_EQ;
-      aux += *aux == '=';
-      break;
-    
-    case '!':
-      if (*aux++ != '=') {
-        /* fall through */
-    default:
-        parse->offset = RC_INVALID_OPERATOR;
-        return 0;
+  self->oper = rc_parse_operator(&aux);
+
+  switch (self->oper) {
+    case RC_OPERATOR_NONE:
+      /* non-modifying statements must have a second operand */
+      if (!can_modify) {
+        /* measured does not require a second operand when used in a value */
+        if (self->type != RC_CONDITION_MEASURED) {
+          parse->offset = RC_INVALID_OPERATOR;
+          return 0;
+        }
       }
 
-      self->oper = RC_OPERATOR_NE;
-      break;
-    
-    case '<':
-      self->oper = RC_OPERATOR_LT;
-
-      if (*aux == '=') {
-        self->oper = RC_OPERATOR_LE;
-        aux++;
-      }
-
-      break;
-    
-    case '>':
-      self->oper = RC_OPERATOR_GT;
-
-      if (*aux == '=') {
-        self->oper = RC_OPERATOR_GE;
-        aux++;
-      }
-
-      break;
-
-    case '*':
-      self->oper = RC_OPERATOR_MULT;
-      break;
-
-    case '/':
-      self->oper = RC_OPERATOR_DIV;
-      break;
-
-    case '&':
-      self->oper = RC_OPERATOR_AND;
-      break;
-
-    case '_':
-    case ')':
-    case '\0':
-    case 'S':
-    case '$':
-      self->oper = RC_OPERATOR_NONE;
+      /* provide dummy operand of '1' and no required hits */
       self->operand2.type = RC_OPERAND_CONST;
       self->operand2.value.num = 1;
       self->required_hits = 0;
-      *memaddr = aux - 1;
+      *memaddr = aux;
       return self;
-  }
 
-  switch (self->oper) {
     case RC_OPERATOR_MULT:
     case RC_OPERATOR_DIV:
     case RC_OPERATOR_AND:
       /* modifying operators are only valid on modifying statements */
-      if (!can_modify) {
-        parse->offset = RC_INVALID_OPERATOR;
-        return 0;
-      }
-      break;
+      if (can_modify)
+        break;
+      /* fallthrough */
+
+    case RC_INVALID_OPERATOR:
+      parse->offset = RC_INVALID_OPERATOR;
+      return 0;
 
     default:
       /* comparison operators are not valid on modifying statements */

--- a/src/rcheevos/condset.c
+++ b/src/rcheevos/condset.c
@@ -130,7 +130,6 @@ rc_condset_t* rc_parse_condset(const char** memaddr, rc_parse_state_t* parse, in
 
   *next = 0;
 
-
   if (parse->buffer != 0) {
     in_pause = 0;
     rc_update_condition_pause(self->conditions, &in_pause);

--- a/src/rcheevos/memref.c
+++ b/src/rcheevos/memref.c
@@ -146,21 +146,25 @@ unsigned rc_get_memref_value(rc_memref_t* memref, int operand_type, rc_eval_stat
     rc_update_memref_value(&memref->value, rc_peek_value(new_address, memref->value.size, eval_state->peek, eval_state->peek_userdata));
   }
 
+  return rc_get_memref_value_value(&memref->value, operand_type);
+}
+
+unsigned rc_get_memref_value_value(rc_memref_value_t* memref, int operand_type) {
   switch (operand_type)
   {
     /* most common case explicitly first, even though it could be handled by default case.
      * this helps the compiler to optimize if it turns the switch into a series of if/elses */
     case RC_OPERAND_ADDRESS:
-      return memref->value.value;
+      return memref->value;
 
     case RC_OPERAND_DELTA:
-      if (!memref->value.changed) {
+      if (!memref->changed) {
         /* fallthrough */
     default:
-        return memref->value.value;
+        return memref->value;
       }
       /* fallthrough */
     case RC_OPERAND_PRIOR:
-      return memref->value.prior;
+      return memref->prior;
   }
 }

--- a/src/rcheevos/runtime.c
+++ b/src/rcheevos/runtime.c
@@ -147,7 +147,7 @@ int rc_runtime_activate_achievement(rc_runtime_t* self, unsigned id, const char*
     if (self->triggers[i].id == id && memcmp(self->triggers[i].md5, md5, 16) == 0) {
       /* retrieve the trigger pointer from the buffer */
       size = 0;
-      trigger = (rc_trigger_t*)rc_alloc(self->triggers[i].buffer, &size, sizeof(rc_trigger_t), RC_ALIGNOF(rc_trigger_t), 0);
+      trigger = (rc_trigger_t*)rc_alloc(self->triggers[i].buffer, &size, sizeof(rc_trigger_t), RC_ALIGNOF(rc_trigger_t), NULL, -1);
       self->triggers[i].trigger = trigger;
 
       rc_reset_trigger(trigger);
@@ -281,7 +281,7 @@ int rc_runtime_activate_lboard(rc_runtime_t* self, unsigned id, const char* mema
     if (self->lboards[i].id == id && memcmp(self->lboards[i].md5, md5, 16) == 0) {
       /* retrieve the lboard pointer from the buffer */
       size = 0;
-      lboard = (rc_lboard_t*)rc_alloc(self->lboards[i].buffer, &size, sizeof(rc_lboard_t), RC_ALIGNOF(rc_lboard_t), 0);
+      lboard = (rc_lboard_t*)rc_alloc(self->lboards[i].buffer, &size, sizeof(rc_lboard_t), RC_ALIGNOF(rc_lboard_t), NULL, -1);
       self->lboards[i].lboard = lboard;
 
       rc_reset_lboard(lboard);

--- a/test/rcheevos/test_condition.c
+++ b/test/rcheevos/test_condition.c
@@ -234,15 +234,15 @@ void test_condition(void) {
   /* shorthard for modifier conditions */
   TEST_PARAMS2(test_parse_modifier_shorthand, "A:0xH1234", RC_CONDITION_ADD_SOURCE);
   TEST_PARAMS2(test_parse_modifier_shorthand, "B:0xH1234", RC_CONDITION_SUB_SOURCE);
-  TEST_PARAMS2(test_parse_modifier_shorthand, "C:0xH1234", RC_CONDITION_ADD_HITS);
-  TEST_PARAMS2(test_parse_modifier_shorthand, "N:0xH1234", RC_CONDITION_AND_NEXT);
-  TEST_PARAMS2(test_parse_modifier_shorthand, "O:0xH1234", RC_CONDITION_OR_NEXT);
   TEST_PARAMS2(test_parse_modifier_shorthand, "I:0xH1234", RC_CONDITION_ADD_ADDRESS);
 
   /* parse errors */
   TEST_PARAMS2(test_parse_condition_error, "0xH1234==0", RC_OK);
   TEST_PARAMS2(test_parse_condition_error, "H0x1234==0", RC_INVALID_CONST_OPERAND);
   TEST_PARAMS2(test_parse_condition_error, "0x1234", RC_INVALID_OPERATOR);
+  TEST_PARAMS2(test_parse_condition_error, "C:0x1234", RC_INVALID_OPERATOR); /* shorthand only valid on modifier conditions */
+  TEST_PARAMS2(test_parse_condition_error, "N:0x1234", RC_INVALID_OPERATOR);
+  TEST_PARAMS2(test_parse_condition_error, "O:0x1234", RC_INVALID_OPERATOR);
   TEST_PARAMS2(test_parse_condition_error, "P:0x1234", RC_INVALID_OPERATOR);
   TEST_PARAMS2(test_parse_condition_error, "R:0x1234", RC_INVALID_OPERATOR);
   TEST_PARAMS2(test_parse_condition_error, "M:0x1234", RC_INVALID_OPERATOR);


### PR DESCRIPTION
Fixes a bug introduced by #104 

Indirect memref objects are now allocated directly within the object buffer. The sizing code was using a single buffer for all parseable objects, which means that as soon as a the indirect memref parser was invoked, the thing holding the indirect memref would be overwritten. This affected the logic such that some internal validations failed, resulting in errors parsing specific conditions containing indirect memref objects.

This PR fixes that issue by allocating space for each type of parseable object in the temporary space used for string deduplication. Additional unit tests were added for the identified issues.