### PR TITLE
process rich presence conditions every frame

### DIFF
--- a/include/rcheevos.h
+++ b/include/rcheevos.h
@@ -400,6 +400,8 @@ rc_richpresence_t;
 int rc_richpresence_size(const char* script);
 rc_richpresence_t* rc_parse_richpresence(void* buffer, const char* script, lua_State* L, int funcs_ndx);
 int rc_evaluate_richpresence(rc_richpresence_t* richpresence, char* buffer, unsigned buffersize, rc_peek_t peek, void* peek_ud, lua_State* L);
+void rc_update_richpresence(rc_richpresence_t* richpresence, rc_peek_t peek, void* peek_ud, lua_State* L);
+int rc_get_richpresence_display_string(rc_richpresence_t* richpresence, char* buffer, unsigned buffersize, rc_peek_t peek, void* peek_ud, lua_State* L);
 
 /*****************************************************************************\
 | Runtime                                                                     |

--- a/include/rcheevos.h
+++ b/include/rcheevos.h
@@ -262,6 +262,9 @@ typedef struct {
 
   /* True if at least one condition has a non-zero hit count */
   char has_hits;
+
+  /* True if at least one condition has a non-zero required hit count */
+  char has_required_hits;
 }
 rc_trigger_t;
 
@@ -444,8 +447,6 @@ typedef struct rc_runtime_t {
   unsigned lboard_capacity;
 
   rc_runtime_richpresence_t* richpresence;
-  char* richpresence_display_buffer;
-  char  richpresence_update_timer;
 
   rc_memref_t* memrefs;
   rc_memref_t** next_memref;
@@ -467,7 +468,7 @@ void rc_runtime_deactivate_lboard(rc_runtime_t* runtime, unsigned id);
 rc_lboard_t* rc_runtime_get_lboard(const rc_runtime_t* runtime, unsigned id);
 
 int rc_runtime_activate_richpresence(rc_runtime_t* runtime, const char* script, lua_State* L, int funcs_idx);
-const char* rc_runtime_get_richpresence(const rc_runtime_t* runtime);
+int rc_runtime_get_richpresence(const rc_runtime_t* self, char* buffer, unsigned buffersize, rc_peek_t peek, void* peek_ud, lua_State* L);
 
 enum {
   RC_RUNTIME_EVENT_ACHIEVEMENT_ACTIVATED, /* from WAITING, PAUSED, or PRIMED to ACTIVE */

--- a/src/rcheevos/alloc.c
+++ b/src/rcheevos/alloc.c
@@ -142,6 +142,7 @@ void rc_init_parse_state(rc_parse_state_t* parse, void* buffer, lua_State* L, in
   parse->first_memref = 0;
   parse->variables = 0;
   parse->measured_target = 0;
+  parse->has_required_hits = 0;
 }
 
 void rc_destroy_parse_state(rc_parse_state_t* parse)

--- a/src/rcheevos/condition.c
+++ b/src/rcheevos/condition.c
@@ -182,6 +182,7 @@ rc_condition_t* rc_parse_condition(const char** memaddr, rc_parse_state_t* parse
       return 0;
     }
 
+    parse->has_required_hits = 1;
     aux = end + 1;
   }
   else if (*aux == '.') {
@@ -193,6 +194,7 @@ rc_condition_t* rc_parse_condition(const char** memaddr, rc_parse_state_t* parse
       return 0;
     }
 
+    parse->has_required_hits = 1;
     aux = end + 1;
   }
   else {

--- a/src/rcheevos/internal.h
+++ b/src/rcheevos/internal.h
@@ -91,6 +91,8 @@ typedef struct {
   rc_value_t** variables;
 
   unsigned measured_target;
+
+  char has_required_hits;
 }
 rc_parse_state_t;
 

--- a/src/rcheevos/richpresence.c
+++ b/src/rcheevos/richpresence.c
@@ -591,87 +591,110 @@ rc_richpresence_t* rc_parse_richpresence(void* buffer, const char* script, lua_S
   return parse.offset >= 0 ? self : 0;
 }
 
-int rc_evaluate_richpresence(rc_richpresence_t* richpresence, char* buffer, unsigned buffersize, rc_peek_t peek, void* peek_ud, lua_State* L) {
+void rc_update_richpresence(rc_richpresence_t* richpresence, rc_peek_t peek, void* peek_ud, lua_State* L) {
   rc_richpresence_display_t* display;
-  rc_richpresence_display_part_t* part;
-  rc_richpresence_lookup_item_t* item;
-  char tmp[256];
-  char* ptr;
-  const char* text;
-  size_t chars;
-  unsigned value;
 
   rc_update_memref_values(richpresence->memrefs, peek, peek_ud);
   rc_update_variables(richpresence->variables, peek, peek_ud, L);
 
-  ptr = buffer;
-  display = richpresence->first_display;
-  while (display) {
-    if (!display->next || rc_test_trigger(&display->trigger, peek, peek_ud, L)) {
-      part = display->display;
-      while (part) {
-        switch (part->display_type) {
-          case RC_FORMAT_STRING:
-            text = part->text;
-            chars = strlen(text);
-            break;
+  for (display = richpresence->first_display; display; display = display->next) {
+    if (display->trigger.has_hits)
+      rc_test_trigger(&display->trigger, peek, peek_ud, L);
+  }
+}
 
-          case RC_FORMAT_LOOKUP:
-            value = part->value->value;
-            text = part->lookup->default_label;
-            item = part->lookup->root;
-            while (item) {
-              if (value > item->last) {
-                item = item->right;
-              }
-              else if (value < item->first) {
-                item = item->left;
-              }
-              else {
-                text = item->label;
-                break;
-              }
-            }
+static int rc_evaluate_richpresence_display(rc_richpresence_display_part_t* part, char* buffer, unsigned buffersize)
+{
+  rc_richpresence_lookup_item_t* item;
+  char tmp[256];
+  char* ptr = buffer;
+  const char* text;
+  size_t chars;
+  unsigned value;
 
-            chars = strlen(text);
-            break;
+  *ptr = '\0';
+  while (part) {
+    switch (part->display_type) {
+      case RC_FORMAT_STRING:
+        text = part->text;
+        chars = strlen(text);
+        break;
 
-          case RC_FORMAT_UNKNOWN_MACRO:
-            chars = snprintf(tmp, sizeof(tmp), "[Unknown macro]%s", part->text);
-            text = tmp;
-            break;
-
-          default:
-            value = part->value->value;
-            chars = rc_format_value(tmp, sizeof(tmp), value, part->display_type);
-            text = tmp;
-            break;
-        }
-
-        if (chars > 0 && buffersize > 0) {
-          if ((unsigned)chars >= buffersize) {
-            /* prevent write past end of buffer */
-            memcpy(ptr, text, buffersize - 1);
-            ptr[buffersize - 1] = '\0';
-            buffersize = 0;
+      case RC_FORMAT_LOOKUP:
+        value = part->value->value;
+        text = part->lookup->default_label;
+        item = part->lookup->root;
+        while (item) {
+          if (value > item->last) {
+            item = item->right;
+          }
+          else if (value < item->first) {
+            item = item->left;
           }
           else {
-            memcpy(ptr, text, chars);
-            ptr[chars] = '\0';
-            buffersize -= (unsigned)chars;
+            text = item->label;
+            break;
           }
         }
 
-        ptr += chars;
-        part = part->next;
-      }
+        chars = strlen(text);
+        break;
 
-      return (int)(ptr - buffer);
+      case RC_FORMAT_UNKNOWN_MACRO:
+        chars = snprintf(tmp, sizeof(tmp), "[Unknown macro]%s", part->text);
+        text = tmp;
+        break;
+
+      default:
+        value = part->value->value;
+        chars = rc_format_value(tmp, sizeof(tmp), value, part->display_type);
+        text = tmp;
+        break;
     }
 
-    display = display->next;
+    if (chars > 0 && buffersize > 0) {
+      if ((unsigned)chars >= buffersize) {
+        /* prevent write past end of buffer */
+        memcpy(ptr, text, buffersize - 1);
+        ptr[buffersize - 1] = '\0';
+        buffersize = 0;
+      }
+      else {
+        memcpy(ptr, text, chars);
+        ptr[chars] = '\0';
+        buffersize -= (unsigned)chars;
+      }
+    }
+
+    ptr += chars;
+    part = part->next;
+  }
+
+  return (int)(ptr - buffer);
+}
+
+int rc_get_richpresence_display_string(rc_richpresence_t* richpresence, char* buffer, unsigned buffersize, rc_peek_t peek, void* peek_ud, lua_State* L) {
+  rc_richpresence_display_t* display;
+
+  for (display = richpresence->first_display; display; display = display->next) {
+    /* if we've reached the end of the condition list, process it */
+    if (!display->next)
+      return rc_evaluate_richpresence_display(display->display, buffer, buffersize);
+
+    /* triggers with hits will be updated in rc_update_richpresence */
+    if (!display->trigger.has_hits)
+      rc_test_trigger(&display->trigger, peek, peek_ud, L);
+
+    /* if we've found a valid condition, process it */
+    if (display->trigger.state == RC_TRIGGER_STATE_TRIGGERED)
+      return rc_evaluate_richpresence_display(display->display, buffer, buffersize);
   }
 
   buffer[0] = '\0';
   return 0;
+}
+
+int rc_evaluate_richpresence(rc_richpresence_t* richpresence, char* buffer, unsigned buffersize, rc_peek_t peek, void* peek_ud, lua_State* L) {
+  rc_update_richpresence(richpresence, peek, peek_ud, L);
+  return rc_get_richpresence_display_string(richpresence, buffer, buffersize, peek, peek_ud, L);
 }

--- a/src/rcheevos/richpresence.c
+++ b/src/rcheevos/richpresence.c
@@ -598,7 +598,7 @@ void rc_update_richpresence(rc_richpresence_t* richpresence, rc_peek_t peek, voi
   rc_update_variables(richpresence->variables, peek, peek_ud, L);
 
   for (display = richpresence->first_display; display; display = display->next) {
-    if (display->trigger.has_hits)
+    if (display->trigger.has_required_hits)
       rc_test_trigger(&display->trigger, peek, peek_ud, L);
   }
 }
@@ -681,8 +681,8 @@ int rc_get_richpresence_display_string(rc_richpresence_t* richpresence, char* bu
     if (!display->next)
       return rc_evaluate_richpresence_display(display->display, buffer, buffersize);
 
-    /* triggers with hits will be updated in rc_update_richpresence */
-    if (!display->trigger.has_hits)
+    /* triggers with required hits will be updated in rc_update_richpresence */
+    if (!display->trigger.has_required_hits)
       rc_test_trigger(&display->trigger, peek, peek_ud, L);
 
     /* if we've found a valid condition, process it */

--- a/src/rcheevos/trigger.c
+++ b/src/rcheevos/trigger.c
@@ -10,7 +10,9 @@ void rc_parse_trigger_internal(rc_trigger_t* self, const char** memaddr, rc_pars
   aux = *memaddr;
   next = &self->alternative;
 
-  parse->measured_target = 0; /* reset in case multiple triggers are parsed by the same parse_state */
+  /* reset in case multiple triggers are parsed by the same parse_state */
+  parse->measured_target = 0;
+  parse->has_required_hits = 0;
 
   if (*aux == 's' || *aux == 'S') {
     self->requirement = 0;
@@ -43,6 +45,7 @@ void rc_parse_trigger_internal(rc_trigger_t* self, const char** memaddr, rc_pars
   self->measured_target = parse->measured_target;
   self->state = RC_TRIGGER_STATE_WAITING;
   self->has_hits = 0;
+  self->has_required_hits = parse->has_required_hits;
 }
 
 int rc_trigger_size(const char* memaddr) {

--- a/test/rcheevos/test_runtime.c
+++ b/test/rcheevos/test_runtime.c
@@ -560,7 +560,6 @@ static void test_richpresence(void)
   unsigned char ram[] = { 2, 10, 10 };
   memory_t memory;
   rc_runtime_t runtime;
-  int frame_count = 0;
 
   memory.ram = ram;
   memory.size = sizeof(ram);
@@ -633,7 +632,6 @@ static void test_richpresence_conditional(void)
   unsigned char ram[] = { 2, 10, 10 };
   memory_t memory;
   rc_runtime_t runtime;
-  int frame_count = 0;
 
   memory.ram = ram;
   memory.size = sizeof(ram);
@@ -663,7 +661,6 @@ static void test_richpresence_conditional_with_hits(void)
   unsigned char ram[] = { 2, 10, 10 };
   memory_t memory;
   rc_runtime_t runtime;
-  int frame_count = 0;
 
   memory.ram = ram;
   memory.size = sizeof(ram);
@@ -712,7 +709,6 @@ static void test_richpresence_conditional_with_hits_after_match(void)
   unsigned char ram[] = { 2, 10, 10 };
   memory_t memory;
   rc_runtime_t runtime;
-  int frame_count = 0;
 
   memory.ram = ram;
   memory.size = sizeof(ram);


### PR DESCRIPTION
This allows more natural use of hit targets in rich presence conditions.

Previously, conditions were only evaluated every 60 frames when the rich presence display string was updated. As a result, the condition could only accumulate one hit every 60 frames. Additionally, once a matching condition was found, later conditions in the chain would not be evaluated, so they would never accumulate any hits.

This changes the logic to process _all_ conditions every frame. Then, when requesting the display string, each condition is examined to see if it's true (without reprocessing it) to determine which display string to process.

Note that hit counts in conditions must be managed by the condition itself. Hit counts in a condition are only reset when a ResetIf _in the same condition_ is true. This behavior has not changed.