### PR TITLE
traverse list in reverse order in case items are removed by callback

### DIFF
--- a/src/rcheevos/runtime.c
+++ b/src/rcheevos/runtime.c
@@ -427,14 +427,14 @@ int rc_runtime_get_richpresence(const rc_runtime_t* self, char* buffer, unsigned
 
 void rc_runtime_do_frame(rc_runtime_t* self, rc_runtime_event_handler_t event_handler, rc_peek_t peek, void* ud, lua_State* L) {
   rc_runtime_event_t runtime_event;
-  unsigned i;
+  int i;
 
   runtime_event.value = 0;
 
   rc_update_memref_values(self->memrefs, peek, ud);
   rc_update_variables(self->variables, peek, ud, L);
 
-  for (i = 0; i < self->trigger_count; ++i) {
+  for (i = self->trigger_count - 1; i >= 0; --i) {
     rc_trigger_t* trigger = self->triggers[i].trigger;
     int trigger_state;
 
@@ -483,7 +483,7 @@ void rc_runtime_do_frame(rc_runtime_t* self, rc_runtime_event_handler_t event_ha
     }
   }
 
-  for (i = 0; i < self->lboard_count; ++i) {
+  for (i = self->lboard_count - 1; i >= 0; --i) {
     rc_lboard_t* lboard = self->lboards[i].lboard;
     int lboard_state;
 


### PR DESCRIPTION
Fixes the issue reported [here](http://retroachievements.org/ticketmanager.php?i=35388).

In RetroArch, when an achievement triggers, it's removed from the list so it doesn't have be processed on future frames. However, since this happens _while_ processing the list, it may cause the next achievement in the list to be skipped.

For example, if three achievements exist: `[1, 2, 3]` and achievement 1 triggers, it'll remove 1 from the list, leaving `[2, 3]`, but still advance to the second item in the list, which is now 3, skipping 2 entirely. In our case, 1 is "Grouchy" and 2 is the "Easy Peasy" achievement. When "Easy Peasy" gets skipped in the frame where "Grouchy" triggers, the delta requirement is true. In the next frame where "Easy Peasy" is evaluated, the delta requirement is no longer true, so it doesn't fire.

On a subsequent playthrough, there's no other achievements triggering in the same frame, so it works normally as expected. 

This doesn't affect the DLL, as we don't remove items from the list so devs can examine hit counts in case something triggers at the wrong time. They're just marked inactive instead. This also doesn't affect most achievements in RetroArch as they will trigger on the following frame.

The solution is simply to traverse the list in reverse, so an items removed from the list don't cause the unprocessed part of the list to change.