### PR TITLE
fix rich presence value memref of less than a byte returning whole byte

### DIFF
--- a/src/rcheevos/memref.c
+++ b/src/rcheevos/memref.c
@@ -40,6 +40,61 @@ rc_memref_t* rc_alloc_memref(rc_parse_state_t* parse, unsigned address, char siz
   return memref;
 }
 
+int rc_parse_memref(const char** memaddr, char* size, unsigned* address) {
+  const char* aux = *memaddr;
+  char* end;
+  unsigned long value;
+
+  if (*aux++ != '0')
+    return RC_INVALID_MEMORY_OPERAND;
+
+  if (*aux != 'x' && *aux != 'X')
+    return RC_INVALID_MEMORY_OPERAND;
+  aux++;
+
+  switch (*aux++) {
+    case 'm': case 'M': *size = RC_MEMSIZE_BIT_0; break;
+    case 'n': case 'N': *size = RC_MEMSIZE_BIT_1; break;
+    case 'o': case 'O': *size = RC_MEMSIZE_BIT_2; break;
+    case 'p': case 'P': *size = RC_MEMSIZE_BIT_3; break;
+    case 'q': case 'Q': *size = RC_MEMSIZE_BIT_4; break;
+    case 'r': case 'R': *size = RC_MEMSIZE_BIT_5; break;
+    case 's': case 'S': *size = RC_MEMSIZE_BIT_6; break;
+    case 't': case 'T': *size = RC_MEMSIZE_BIT_7; break;
+    case 'l': case 'L': *size = RC_MEMSIZE_LOW; break;
+    case 'u': case 'U': *size = RC_MEMSIZE_HIGH; break;
+    case 'k': case 'K': *size = RC_MEMSIZE_BITCOUNT; break;
+    case 'h': case 'H': *size = RC_MEMSIZE_8_BITS; break;
+    case 'w': case 'W': *size = RC_MEMSIZE_24_BITS; break;
+    case 'x': case 'X': *size = RC_MEMSIZE_32_BITS; break;
+
+    case '0': case '1': case '2': case '3': case '4':
+    case '5': case '6': case '7': case '8': case '9':
+    case 'a': case 'b': case 'c': case 'd': case 'e': case 'f':
+    case 'A': case 'B': case 'C': case 'D': case 'E': case 'F':
+      aux--;
+      /* fallthrough */
+    case ' ':
+      *size = RC_MEMSIZE_16_BITS;
+      break;
+
+    default:
+      return RC_INVALID_MEMORY_OPERAND;
+  }
+
+  value = strtoul(aux, &end, 16);
+
+  if (end == aux)
+    return RC_INVALID_MEMORY_OPERAND;
+
+  if (value > 0xffffffffU)
+    value = 0xffffffffU;
+
+  *address = (unsigned)value;
+  *memaddr = end;
+  return RC_OK;
+}
+
 static unsigned rc_peek_value(unsigned address, char size, rc_peek_t peek, void* ud) {
   unsigned value;
 

--- a/src/rcheevos/rc_internal.h
+++ b/src/rcheevos/rc_internal.h
@@ -111,6 +111,7 @@ void* rc_alloc_scratch(void* pointer, int* offset, int size, int alignment, rc_s
 char* rc_alloc_str(rc_parse_state_t* parse, const char* text, int length);
 
 rc_memref_t* rc_alloc_memref(rc_parse_state_t* parse, unsigned address, char size, char is_indirect);
+int rc_parse_memref(const char** memaddr, char* size, unsigned* address);
 void rc_update_memref_values(rc_memref_t* memref, rc_peek_t peek, void* ud);
 void rc_update_memref_value(rc_memref_value_t* memref, unsigned value);
 unsigned rc_get_memref_value(rc_memref_t* memref, int operand_type, rc_eval_state_t* eval_state);

--- a/test/rcheevos/test_richpresence.c
+++ b/test/rcheevos/test_richpresence.c
@@ -252,6 +252,43 @@ static void test_macro_value() {
   assert_richpresence_output(richpresence, &memory, "13332 Points");
 }
 
+static void test_macro_value_nibble() {
+  unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  memory_t memory;
+  rc_richpresence_t* richpresence;
+  char buffer[1024];
+
+  memory.ram = ram;
+  memory.size = sizeof(ram);
+
+  /* nibble first, see if byte overwrites */
+  assert_parse_richpresence(&richpresence, buffer, "Format:Points\nFormatType=VALUE\n\nDisplay:\n@Points(0xL0001)@Points(0xH0001) Points");
+  assert_richpresence_output(richpresence, &memory, "218 Points");
+
+  ram[1] = 20;
+  assert_richpresence_output(richpresence, &memory, "420 Points");
+
+  /* put byte first, see if nibble overwrites */
+  assert_parse_richpresence(&richpresence, buffer, "Format:Points\nFormatType=VALUE\n\nDisplay:\n@Points(0xH0001)@Points(0xL0001) Points");
+  assert_richpresence_output(richpresence, &memory, "204 Points");
+}
+
+static void test_macro_value_bcd() {
+  unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  memory_t memory;
+  rc_richpresence_t* richpresence;
+  char buffer[1024];
+
+  memory.ram = ram;
+  memory.size = sizeof(ram);
+
+  assert_parse_richpresence(&richpresence, buffer, "Format:Points\nFormatType=VALUE\n\nDisplay:\n@Points(b0xH0001) Points");
+  assert_richpresence_output(richpresence, &memory, "12 Points");
+
+  ram[1] = 20;
+  assert_richpresence_output(richpresence, &memory, "14 Points");
+}
+
 static void test_conditional_display_indirect() {
   unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
   memory_t memory;
@@ -963,6 +1000,8 @@ void test_richpresence(void) {
 
   /* value macros */
   TEST(test_macro_value);
+  TEST(test_macro_value_nibble);
+  TEST(test_macro_value_bcd);
   TEST(test_macro_value_adjusted_negative);
   TEST(test_macro_value_from_formula);
   TEST(test_macro_value_from_hits);


### PR DESCRIPTION
Fixes an issue introduced by #100.

When optimizing a memref parameter (i.e. `0xL1234`), any size less than 8-bits (like `lower4`) would return the whole 8-bit value because operands share memrefs for sizes less than 8-bits. The memref optimization discards the operand information, so the 8-bit value wasn't being masked before being displayed.

Solution: separate memref parsing logic out of operand parser and only do the size sharing for operands.