### PR TITLE
include current/prev value for indirect memory addresses in serialized state

### DIFF
--- a/include/rcheevos.h
+++ b/include/rcheevos.h
@@ -419,6 +419,7 @@ typedef struct rc_runtime_trigger_t {
   void* buffer;
   rc_memref_t* invalid_memref;
   unsigned char md5[16];
+  int serialized_size;
   char owns_memrefs;
 }
 rc_runtime_trigger_t;

--- a/src/rcheevos/runtime.c
+++ b/src/rcheevos/runtime.c
@@ -108,6 +108,7 @@ void rc_runtime_deactivate_achievement(rc_runtime_t* self, unsigned id) {
 int rc_runtime_activate_achievement(rc_runtime_t* self, unsigned id, const char* memaddr, lua_State* L, int funcs_idx) {
   void* trigger_buffer;
   rc_trigger_t* trigger;
+  rc_runtime_trigger_t* runtime_trigger;
   rc_parse_state_t parse;
   unsigned char md5[16];
   int size;
@@ -188,12 +189,14 @@ int rc_runtime_activate_achievement(rc_runtime_t* self, unsigned id, const char*
   }
 
   /* assign the new trigger */
-  self->triggers[self->trigger_count].id = id;
-  self->triggers[self->trigger_count].trigger = trigger;
-  self->triggers[self->trigger_count].buffer = trigger_buffer;
-  self->triggers[self->trigger_count].invalid_memref = NULL;
-  memcpy(self->triggers[self->trigger_count].md5, md5, 16);
-  self->triggers[self->trigger_count].owns_memrefs = rc_runtime_allocated_memrefs(self);
+  runtime_trigger = &self->triggers[self->trigger_count];
+  runtime_trigger->id = id;
+  runtime_trigger->trigger = trigger;
+  runtime_trigger->buffer = trigger_buffer;
+  runtime_trigger->invalid_memref = NULL;
+  memcpy(runtime_trigger->md5, md5, 16);
+  runtime_trigger->serialized_size = 0;
+  runtime_trigger->owns_memrefs = rc_runtime_allocated_memrefs(self);
   ++self->trigger_count;
 
   /* reset it, and return it */

--- a/src/rcheevos/runtime_progress.c
+++ b/src/rcheevos/runtime_progress.c
@@ -322,7 +322,7 @@ static int rc_runtime_progress_read_trigger(rc_runtime_progress_t* progress, rc_
 static int rc_runtime_progress_write_achievements(rc_runtime_progress_t* progress)
 {
   unsigned i;
-  int offset;
+  int offset = 0;
   int result;
 
   for (i = 0; i < progress->runtime->trigger_count; ++i) {

--- a/src/rcheevos/runtime_progress.c
+++ b/src/rcheevos/runtime_progress.c
@@ -26,6 +26,12 @@ typedef struct rc_runtime_progress_t {
 
 #define RC_MEMREF_FLAG_CHANGED_THIS_FRAME 0x00010000
 
+#define RC_COND_FLAG_IS_TRUE                            0x00000001
+#define RC_COND_FLAG_OPERAND1_IS_INDIRECT_MEMREF        0x00010000
+#define RC_COND_FLAG_OPERAND1_MEMREF_CHANGED_THIS_FRAME 0x00020000
+#define RC_COND_FLAG_OPERAND2_IS_INDIRECT_MEMREF        0x00100000
+#define RC_COND_FLAG_OPERAND2_MEMREF_CHANGED_THIS_FRAME 0x00200000
+
 static void rc_runtime_progress_write_uint(rc_runtime_progress_t* progress, unsigned value)
 {
   if (progress->buffer) {
@@ -110,17 +116,25 @@ static int rc_runtime_progress_write_memrefs(rc_runtime_progress_t* progress)
 
   rc_runtime_progress_start_chunk(progress, RC_RUNTIME_CHUNK_MEMREFS);
 
-  while (memref) {
-    flags = memref->value.size;
-    if (memref->value.changed)
-      flags |= RC_MEMREF_FLAG_CHANGED_THIS_FRAME;
+  if (!progress->buffer) {
+    while (memref) {
+      progress->offset += 16;
+      memref = memref->next;
+    }
+  }
+  else {
+    while (memref) {
+      flags = memref->value.size;
+      if (memref->value.changed)
+        flags |= RC_MEMREF_FLAG_CHANGED_THIS_FRAME;
 
-    rc_runtime_progress_write_uint(progress, memref->address);
-    rc_runtime_progress_write_uint(progress, flags);
-    rc_runtime_progress_write_uint(progress, memref->value.value);
-    rc_runtime_progress_write_uint(progress, memref->value.prior);
+      rc_runtime_progress_write_uint(progress, memref->address);
+      rc_runtime_progress_write_uint(progress, flags);
+      rc_runtime_progress_write_uint(progress, memref->value.value);
+      rc_runtime_progress_write_uint(progress, memref->value.prior);
 
-    memref = memref->next;
+      memref = memref->next;
+    }
   }
 
   rc_runtime_progress_end_chunk(progress);
@@ -163,16 +177,57 @@ static int rc_runtime_progress_read_memrefs(rc_runtime_progress_t* progress)
   return RC_OK;
 }
 
+static int rc_runtime_progress_is_indirect_memref(rc_operand_t* oper)
+{
+  switch (oper->type)
+  {
+    case RC_OPERAND_CONST:
+    case RC_OPERAND_FP:
+    case RC_OPERAND_LUA:
+      return 0;
+
+    default:
+      return oper->value.memref->value.is_indirect;
+  }
+}
+
 static int rc_runtime_progress_write_condset(rc_runtime_progress_t* progress, rc_condset_t* condset)
 {
   rc_condition_t* cond;
+  unsigned flags;
 
   rc_runtime_progress_write_uint(progress, condset->is_paused);
 
   cond = condset->conditions;
   while (cond) {
+    flags = 0;
+    if (cond->is_true)
+      flags |= RC_COND_FLAG_IS_TRUE;
+
+    if (rc_runtime_progress_is_indirect_memref(&cond->operand1)) {
+      flags |= RC_COND_FLAG_OPERAND1_IS_INDIRECT_MEMREF;
+      if (cond->operand1.value.memref->value.changed)
+        flags |= RC_COND_FLAG_OPERAND1_MEMREF_CHANGED_THIS_FRAME;
+    }
+
+    if (rc_runtime_progress_is_indirect_memref(&cond->operand2)) {
+      flags |= RC_COND_FLAG_OPERAND2_IS_INDIRECT_MEMREF;
+      if (cond->operand2.value.memref->value.changed)
+        flags |= RC_COND_FLAG_OPERAND2_MEMREF_CHANGED_THIS_FRAME;
+    }
+
     rc_runtime_progress_write_uint(progress, cond->current_hits);
-    rc_runtime_progress_write_uint(progress, cond->is_true);
+    rc_runtime_progress_write_uint(progress, flags);
+
+    if (flags & RC_COND_FLAG_OPERAND1_IS_INDIRECT_MEMREF) {
+      rc_runtime_progress_write_uint(progress, cond->operand1.value.memref->value.value);
+      rc_runtime_progress_write_uint(progress, cond->operand1.value.memref->value.prior);
+    }
+
+    if (flags & RC_COND_FLAG_OPERAND2_IS_INDIRECT_MEMREF) {
+      rc_runtime_progress_write_uint(progress, cond->operand2.value.memref->value.value);
+      rc_runtime_progress_write_uint(progress, cond->operand2.value.memref->value.prior);
+    }
 
     cond = cond->next;
   }
@@ -183,13 +238,28 @@ static int rc_runtime_progress_write_condset(rc_runtime_progress_t* progress, rc
 static int rc_runtime_progress_read_condset(rc_runtime_progress_t* progress, rc_condset_t* condset)
 {
   rc_condition_t* cond;
+  unsigned flags;
 
   condset->is_paused = rc_runtime_progress_read_uint(progress);
 
   cond = condset->conditions;
   while (cond) {
     cond->current_hits = rc_runtime_progress_read_uint(progress);
-    cond->is_true = rc_runtime_progress_read_uint(progress) & 0xFF;
+    flags = rc_runtime_progress_read_uint(progress);
+
+    cond->is_true = (flags & RC_COND_FLAG_IS_TRUE) ? 1 : 0;
+
+    if (flags & RC_COND_FLAG_OPERAND1_IS_INDIRECT_MEMREF) {
+      cond->operand1.value.memref->value.value = rc_runtime_progress_read_uint(progress);
+      cond->operand1.value.memref->value.prior = rc_runtime_progress_read_uint(progress);
+      cond->operand1.value.memref->value.changed = (flags & RC_COND_FLAG_OPERAND1_MEMREF_CHANGED_THIS_FRAME) ? 1 : 0;
+    }
+
+    if (flags & RC_COND_FLAG_OPERAND2_IS_INDIRECT_MEMREF) {
+      cond->operand2.value.memref->value.value = rc_runtime_progress_read_uint(progress);
+      cond->operand2.value.memref->value.prior = rc_runtime_progress_read_uint(progress);
+      cond->operand2.value.memref->value.changed = (flags & RC_COND_FLAG_OPERAND2_MEMREF_CHANGED_THIS_FRAME) ? 1 : 0;
+    }
 
     cond = cond->next;
   }
@@ -212,8 +282,7 @@ static int rc_runtime_progress_write_trigger(rc_runtime_progress_t* progress, rc
   }
 
   condset = trigger->alternative;
-  while (condset)
-  {
+  while (condset) {
     result = rc_runtime_progress_write_condset(progress, condset);
     if (result != RC_OK)
       return result;
@@ -239,8 +308,7 @@ static int rc_runtime_progress_read_trigger(rc_runtime_progress_t* progress, rc_
   }
 
   condset = trigger->alternative;
-  while (condset)
-  {
+  while (condset) {
     result = rc_runtime_progress_read_condset(progress, condset);
     if (result != RC_OK)
       return result;
@@ -254,10 +322,10 @@ static int rc_runtime_progress_read_trigger(rc_runtime_progress_t* progress, rc_
 static int rc_runtime_progress_write_achievements(rc_runtime_progress_t* progress)
 {
   unsigned i;
+  int offset;
   int result;
 
-  for (i = 0; i < progress->runtime->trigger_count; ++i)
-  {
+  for (i = 0; i < progress->runtime->trigger_count; ++i) {
     rc_runtime_trigger_t* runtime_trigger = &progress->runtime->triggers[i];
     if (!runtime_trigger->trigger)
       continue;
@@ -274,6 +342,15 @@ static int rc_runtime_progress_write_achievements(rc_runtime_progress_t* progres
         break;
     }
 
+    if (!progress->buffer) {
+      if (runtime_trigger->serialized_size) {
+        progress->offset += runtime_trigger->serialized_size;
+        continue;
+      }
+
+      offset = progress->offset;
+    }
+
     rc_runtime_progress_start_chunk(progress, RC_RUNTIME_CHUNK_ACHIEVEMENT);
     rc_runtime_progress_write_uint(progress, runtime_trigger->id);
     rc_runtime_progress_write_md5(progress, runtime_trigger->md5);
@@ -283,6 +360,9 @@ static int rc_runtime_progress_write_achievements(rc_runtime_progress_t* progres
       return result;
 
     rc_runtime_progress_end_chunk(progress);
+
+    if (!progress->buffer)
+      runtime_trigger->serialized_size = progress->offset - offset;
   }
 
   return RC_OK;
@@ -318,10 +398,10 @@ static int rc_runtime_progress_serialize_internal(rc_runtime_progress_t* progres
   rc_runtime_progress_write_uint(progress, RC_RUNTIME_MARKER);
 
   if ((result = rc_runtime_progress_write_memrefs(progress)) != RC_OK)
-      return result;
+    return result;
 
   if ((result = rc_runtime_progress_write_achievements(progress)) != RC_OK)
-      return result;
+    return result;
 
   rc_runtime_progress_write_uint(progress, RC_RUNTIME_CHUNK_DONE);
   rc_runtime_progress_write_uint(progress, 16);


### PR DESCRIPTION
The indirection simplification in #104 prevented indirect memory reference values from being serialized in the save state. This corrects for that without changing the simplification.

This also includes an optimization to cache the serialization size for an achievement so it doesn't have to be recalculated every frame when states are created frequently (like when rewinding). This is safe to do because the size is completely dependent on the achievement definition.