### PR TITLE
add rc_richpresence_size_lines function for capturing line of parse error

### DIFF
--- a/include/rcheevos.h
+++ b/include/rcheevos.h
@@ -410,6 +410,7 @@ typedef struct {
 rc_richpresence_t;
 
 int rc_richpresence_size(const char* script);
+int rc_richpresence_size_lines(const char* script, int* lines_read);
 rc_richpresence_t* rc_parse_richpresence(void* buffer, const char* script, lua_State* L, int funcs_ndx);
 int rc_evaluate_richpresence(rc_richpresence_t* richpresence, char* buffer, unsigned buffersize, rc_peek_t peek, void* peek_ud, lua_State* L);
 void rc_update_richpresence(rc_richpresence_t* richpresence, rc_peek_t peek, void* peek_ud, lua_State* L);

--- a/src/rcheevos/alloc.c
+++ b/src/rcheevos/alloc.c
@@ -142,6 +142,7 @@ void rc_init_parse_state(rc_parse_state_t* parse, void* buffer, lua_State* L, in
   parse->first_memref = 0;
   parse->variables = 0;
   parse->measured_target = 0;
+  parse->lines_read = 0;
   parse->has_required_hits = 0;
 }
 

--- a/src/rcheevos/rc_internal.h
+++ b/src/rcheevos/rc_internal.h
@@ -96,6 +96,7 @@ typedef struct {
   rc_value_t** variables;
 
   unsigned measured_target;
+  int lines_read;
 
   char has_required_hits;
 }

--- a/src/rurl/url.c
+++ b/src/rurl/url.c
@@ -167,7 +167,7 @@ int rc_url_get_badge_image(char* buffer, size_t size, const char* badge_name) {
 
 int rc_url_login_with_password(char* buffer, size_t size, const char* user_name, const char* password) {
   char urle_user_name[64];
-  char urle_password[64];
+  char urle_password[256];
   int written;
 
   if (rc_url_encode(urle_user_name, sizeof(urle_user_name), user_name) != 0) {

--- a/validator/validator.c
+++ b/validator/validator.c
@@ -84,10 +84,11 @@ static void validate_richpresence(const char* script)
 {
   char* buffer;
   rc_richpresence_t* compiled;
+  int lines;
 
-  int ret = rc_richpresence_size(script);
+  int ret = rc_richpresence_size_lines(script, &lines);
   if (ret < 0) {
-    printf("%s", rc_error_str(ret));
+    printf("Line %d: %s", lines, rc_error_str(ret));
     return;
   }
 


### PR DESCRIPTION
Returns the number of lines read from the script. it will capture the line number where an error occurred, or the total number of lines in the script if no error occurs.

Enables the client to better report on where an error occurs:
```
Line 91: Duplicated value expression
```