### PR TITLE
Ignore 7800 header if detected

### DIFF
--- a/src/rhash/hash.c
+++ b/src/rhash/hash.c
@@ -502,9 +502,8 @@ static int rc_hash_3do(char hash[33], const char* path)
 
 static int rc_hash_7800(char hash[33], uint8_t* buffer, size_t buffer_size)
 {
-  /* if the file contains a header, ignore it (expect ROM data to be multiple of 4KB) */
-  uint32_t calc_size = ((uint32_t)buffer_size / 0x1000) * 0x1000;
-  if (buffer_size - calc_size == 128)
+  /* if the file contains a header, ignore it */
+  if (memcmp(&buffer[1], "ATARI7800", 9) == 0)
   {
     rc_hash_verbose("Ignoring 7800 header");
 

--- a/src/rhash/hash.c
+++ b/src/rhash/hash.c
@@ -500,6 +500,21 @@ static int rc_hash_3do(char hash[33], const char* path)
   return rc_hash_finalize(&md5, hash);
 }
 
+static int rc_hash_7800(char hash[33], uint8_t* buffer, size_t buffer_size)
+{
+  /* if the file contains a header, ignore it (expect ROM data to be multiple of 4KB) */
+  uint32_t calc_size = ((uint32_t)buffer_size / 0x1000) * 0x1000;
+  if (buffer_size - calc_size == 128)
+  {
+    rc_hash_verbose("Ignoring 7800 header");
+
+    buffer += 128;
+    buffer_size -= 128;
+  }
+
+  return rc_hash_buffer(hash, buffer, buffer_size);
+}
+
 static int rc_hash_arcade(char hash[33], const char* path)
 {
   /* arcade hash is just the hash of the filename (no extension) - the cores are pretty stringent about having the right ROM data */
@@ -1217,7 +1232,6 @@ int rc_hash_generate_from_buffer(char hash[33], int console_id, uint8_t* buffer,
 
     case RC_CONSOLE_APPLE_II:
     case RC_CONSOLE_ATARI_2600:
-    case RC_CONSOLE_ATARI_7800:
     case RC_CONSOLE_ATARI_JAGUAR:
     case RC_CONSOLE_COLECOVISION:
     case RC_CONSOLE_GAMEBOY:
@@ -1240,6 +1254,9 @@ int rc_hash_generate_from_buffer(char hash[33], int console_id, uint8_t* buffer,
     case RC_CONSOLE_VIRTUAL_BOY:
     case RC_CONSOLE_WONDERSWAN:
       return rc_hash_buffer(hash, buffer, buffer_size);
+
+    case RC_CONSOLE_ATARI_7800:
+      return rc_hash_7800(hash, buffer, buffer_size);
 
     case RC_CONSOLE_ATARI_LYNX:
       return rc_hash_lynx(hash, buffer, buffer_size);
@@ -1492,7 +1509,6 @@ int rc_hash_generate_from_file(char hash[33], int console_id, const char* path)
 
     case RC_CONSOLE_APPLE_II:
     case RC_CONSOLE_ATARI_2600:
-    case RC_CONSOLE_ATARI_7800:
     case RC_CONSOLE_ATARI_JAGUAR:
     case RC_CONSOLE_COLECOVISION:
     case RC_CONSOLE_GAMEBOY:
@@ -1523,6 +1539,7 @@ int rc_hash_generate_from_file(char hash[33], int console_id, const char* path)
 
       return rc_hash_whole_file(hash, console_id, path);
 
+    case RC_CONSOLE_ATARI_7800:
     case RC_CONSOLE_ATARI_LYNX:
     case RC_CONSOLE_NINTENDO:
     case RC_CONSOLE_SUPER_NINTENDO:

--- a/test/rhash/data.c
+++ b/test/rhash/data.c
@@ -134,6 +134,44 @@ uint8_t* generate_fds_file(size_t sides, int with_header, size_t* image_size)
   return image;
 }
 
+uint8_t* generate_atari_7800_file(size_t kb, int with_header, size_t* image_size)
+{
+  uint8_t* image;
+  size_t size_needed = kb * 1024;
+  if (with_header)
+    size_needed += 128;
+
+  image = (uint8_t*)calloc(size_needed, 1);
+  if (image != NULL)
+  {
+    if (with_header)
+    {
+      const uint8_t header[128] = {
+        3, 'A', 'T', 'A', 'R', 'I', '7', '8', '0', '0', 0, 0, 0, 0, 0, 0, /* version + magic text */
+        0, 'G', 'a', 'm', 'e', 'N', 'a', 'm', 'e', 0, 0, 0, 0, 0, 0, 0,   /* game name */
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                   /* game name (cont'd) */
+        0, 0, 2, 0, 0, 0, 3, 1, 1, 0, 0, 0, 0, 0, 0, 0,                   /* attributes */
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                   /* unused */
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                   /* unused */
+        0, 0, 0, 0, 'A', 'C', 'T', 'U', 'A', 'L', ' ', 'C', 'A', 'R', 'T',/* magic text*/
+        'D', 'A', 'T', 'A', ' ', 'S', 'T', 'A', 'R', 'T', 'S', ' ', 'H', 'E', 'R', 'E' /* magic text */
+      };
+      memcpy(image, header, sizeof(header));
+      image[50] = (uint8_t)(kb / 4); /* 4-byte value starting at address 49 is the ROM size without header */
+
+      fill_image(image + 128, size_needed - 128);
+    }
+    else
+    {
+      fill_image(image, size_needed);
+    }
+  }
+
+  if (image_size)
+    *image_size = size_needed;
+  return image;
+}
+
 uint8_t* generate_3do_bin(unsigned root_directory_sectors, unsigned binary_size, size_t* image_size)
 {
   const uint8_t volume_header[] = {

--- a/test/rhash/data.h
+++ b/test/rhash/data.h
@@ -15,6 +15,7 @@ uint8_t* generate_dreamcast_bin(unsigned track_first_sector, unsigned binary_siz
 uint8_t* generate_pce_cd_bin(unsigned binary_sectors, size_t* image_size);
 uint8_t* generate_pcfx_bin(unsigned binary_sectors, size_t* image_size);
 
+uint8_t* generate_atari_7800_file(size_t kb, int with_header, size_t* image_size);
 uint8_t* generate_nes_file(size_t kb, int with_header, size_t* image_size);
 uint8_t* generate_fds_file(size_t sides, int with_header, size_t* image_size);
 

--- a/test/rhash/test_hash.c
+++ b/test/rhash/test_hash.c
@@ -959,7 +959,7 @@ void test_hash(void) {
 
   /* Atari 7800 - includes 128-byte header */
   TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_ATARI_7800, "test.a78", 16384, "455f07d8500f3fabc54906737866167f");
-  TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_ATARI_7800, "test.a78", 16384 + 128, "6473a1bb6573ca5a33017bf2ddd6bc70");
+  TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_ATARI_7800, "test.a78", 16384 + 128, "f063cca169b2e49afc339a253a9abadb");
 
   /* Atari Jaguar */
   TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_ATARI_JAGUAR, "test.jag", 0x400000, "a247ec8a8c42e18fcb80702dfadac14b");

--- a/test/rhash/test_hash.c
+++ b/test/rhash/test_hash.c
@@ -321,6 +321,35 @@ static void test_hash_3do_long_directory()
 
 /* ========================================================================= */
 
+static void test_hash_atari_7800()
+{
+  size_t image_size;
+  uint8_t* image = generate_atari_7800_file(16, 0, &image_size);
+  char hash[33];
+  int result = rc_hash_generate_from_buffer(hash, RC_CONSOLE_ATARI_7800, image, image_size);
+  free(image);
+
+  ASSERT_NUM_EQUALS(result, 1);
+  ASSERT_STR_EQUALS(hash, "455f07d8500f3fabc54906737866167f");
+  ASSERT_NUM_EQUALS(image_size, 16384);
+}
+
+static void test_hash_atari_7800_with_header()
+{
+  size_t image_size;
+  uint8_t* image = generate_atari_7800_file(16, 1, &image_size);
+  char hash[33];
+  int result = rc_hash_generate_from_buffer(hash, RC_CONSOLE_ATARI_7800, image, image_size);
+  free(image);
+
+  /* NOTE: expectation is that this hash matches the hash in test_hash_atari_7800 */
+  ASSERT_NUM_EQUALS(result, 1);
+  ASSERT_STR_EQUALS(hash, "455f07d8500f3fabc54906737866167f");
+  ASSERT_NUM_EQUALS(image_size, 16384 + 128);
+}
+
+/* ========================================================================= */
+
 static void test_hash_dreamcast_single_bin()
 {
   size_t image_size;
@@ -957,9 +986,9 @@ void test_hash(void) {
   /* Atari 2600 */
   TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_ATARI_2600, "test.bin", 2048, "02c3f2fa186388ba8eede9147fb431c4");
 
-  /* Atari 7800 - includes 128-byte header */
-  TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_ATARI_7800, "test.a78", 16384, "455f07d8500f3fabc54906737866167f");
-  TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_ATARI_7800, "test.a78", 16384 + 128, "f063cca169b2e49afc339a253a9abadb");
+  /* Atari 7800 */
+  TEST(test_hash_atari_7800);
+  TEST(test_hash_atari_7800_with_header);
 
   /* Atari Jaguar */
   TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_ATARI_JAGUAR, "test.jag", 0x400000, "a247ec8a8c42e18fcb80702dfadac14b");

--- a/test/rhash/test_hash.c
+++ b/test/rhash/test_hash.c
@@ -958,7 +958,8 @@ void test_hash(void) {
   TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_ATARI_2600, "test.bin", 2048, "02c3f2fa186388ba8eede9147fb431c4");
 
   /* Atari 7800 - includes 128-byte header */
-  TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_ATARI_7800, "test.a78", 16384 + 128, "f063cca169b2e49afc339a253a9abadb");
+  TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_ATARI_7800, "test.a78", 16384, "455f07d8500f3fabc54906737866167f");
+  TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_ATARI_7800, "test.a78", 16384 + 128, "6473a1bb6573ca5a33017bf2ddd6bc70");
 
   /* Atari Jaguar */
   TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_ATARI_JAGUAR, "test.jag", 0x400000, "a247ec8a8c42e18fcb80702dfadac14b");


### PR DESCRIPTION
I essentially cloned the PCE header skip method for this. The smallest game I found was 4KiB and I verified all other games were a multiple of that value. Atari 7800 headers do have a detectable string that can be used if preferred, but I wasn't sure how to go about doing that properly. If desired, this is the No-Intro header skipper method:
```xml
<rule start_offset="80" end_offset="EOF" operation="none">
	<data offset="1" value="415441524937383030" result="true"/>
	<data offset="60" value="0000000041435455414C20434152542044415441205354415254532048455245" result="true"/>
```
Details of the header can be found here:
http://7800.8bitdev.org/index.php/A78_Header_Specification