### PR TITLE
move memory mapping and settings blacklist code from ralibretro/retroarch

### DIFF
--- a/src/rcheevos/rc_libretro.c
+++ b/src/rcheevos/rc_libretro.c
@@ -1,0 +1,509 @@
+/* This file provides a series of functions for integrating RetroAchievements with libretro.
+ * These functions will be called by a libretro frontend to validate certain expected behaviors
+ * and simplify mapping core data to the RAIntegration DLL.
+ * 
+ * Originally designed to be shared between RALibretro and RetroArch, but will simplify
+ * integrating with any other frontends.
+ */
+
+#include "rc_libretro.h"
+
+#include "rcheevos.h"
+#include "rc_compat.h"
+
+#include <ctype.h>
+#include <string.h>
+
+static rc_libretro_message_callback verbose_message_callback = NULL;
+
+/* a value that starts with a comma is a CSV.
+ * if it starts with an exclamation point, it's everything but the provided value.
+ * if it starts with an exclamntion point followed by a comma, it's everything but the CSV values.
+ * values are case-insensitive */
+typedef struct rc_disallowed_core_settings_t
+{
+  const char* library_name;
+  const rc_disallowed_setting_t* disallowed_settings;
+} rc_disallowed_core_settings_t;
+
+static const rc_disallowed_setting_t _rc_disallowed_bsnes_settings[] = {
+  { "bsnes_region", "pal" },
+  { NULL, NULL }
+};
+
+static const rc_disallowed_setting_t _rc_disallowed_dolphin_settings[] = {
+  { "dolphin_cheats_enabled", "enabled" },
+  { NULL, NULL }
+};
+
+static const rc_disallowed_setting_t _rc_disallowed_ecwolf_settings[] = {
+  { "ecwolf-invulnerability", "enabled" },
+  { NULL, NULL }
+};
+
+static const rc_disallowed_setting_t _rc_disallowed_fbneo_settings[] = {
+  { "fbneo-allow-patched-romsets", "enabled" },
+  { "fbneo-cheat-*", "!,Disabled,0 - Disabled" },
+  { NULL, NULL }
+};
+
+static const rc_disallowed_setting_t _rc_disallowed_fceumm_settings[] = {
+  { "fceumm_region", ",PAL,Dendy" },
+  { NULL, NULL }
+};
+
+static const rc_disallowed_setting_t _rc_disallowed_gpgx_settings[] = {
+  { "genesis_plus_gx_lock_on", ",action replay (pro),game genie" },
+  { "genesis_plus_gx_region_detect", "pal" },
+  { NULL, NULL }
+};
+
+static const rc_disallowed_setting_t _rc_disallowed_gpgx_wide_settings[] = {
+  { "genesis_plus_gx_wide_lock_on", ",action replay (pro),game genie" },
+  { "genesis_plus_gx_wide_region_detect", "pal" },
+  { NULL, NULL }
+};
+
+static const rc_disallowed_setting_t _rc_disallowed_mesen_settings[] = {
+  { "mesen_region", ",PAL,Dendy" },
+  { NULL, NULL }
+};
+
+static const rc_disallowed_setting_t _rc_disallowed_mesen_s_settings[] = {
+  { "mesen-s_region", "PAL" },
+  { NULL, NULL }
+};
+
+static const rc_disallowed_setting_t _rc_disallowed_pcsx_rearmed_settings[] = {
+  { "pcsx_rearmed_region", "pal" },
+  { NULL, NULL }
+};
+
+static const rc_disallowed_setting_t _rc_disallowed_picodrive_settings[] = {
+  { "picodrive_region", ",Europe,Japan PAL" },
+  { NULL, NULL }
+};
+
+static const rc_disallowed_setting_t _rc_disallowed_ppsspp_settings[] = {
+  { "ppsspp_cheats", "enabled" },
+  { NULL, NULL }
+};
+
+static const rc_disallowed_setting_t _rc_disallowed_snes9x_settings[] = {
+  { "snes9x_region", "pal" },
+  { NULL, NULL }
+};
+
+static const rc_disallowed_setting_t _rc_disallowed_virtual_jaguar_settings[] = {
+  { "virtualjaguar_pal", "enabled" },
+  { NULL, NULL }
+};
+
+static const rc_disallowed_core_settings_t rc_disallowed_core_settings[] = {
+  { "bsnes-mercury", _rc_disallowed_bsnes_settings },
+  { "dolphin-emu", _rc_disallowed_dolphin_settings },
+  { "ecwolf", _rc_disallowed_ecwolf_settings },
+  { "FCEUmm", _rc_disallowed_fceumm_settings },
+  { "FinalBurn Neo", _rc_disallowed_fbneo_settings },
+  { "Genesis Plus GX", _rc_disallowed_gpgx_settings },
+  { "Genesis Plus GX Wide", _rc_disallowed_gpgx_wide_settings },
+  { "Mesen", _rc_disallowed_mesen_settings },
+  { "Mesen-S", _rc_disallowed_mesen_s_settings },
+  { "PPSSPP", _rc_disallowed_ppsspp_settings },
+  { "PCSX-ReARMed", _rc_disallowed_pcsx_rearmed_settings },
+  { "PicoDrive", _rc_disallowed_picodrive_settings },
+  { "Snes9x", _rc_disallowed_snes9x_settings },
+  { "Virtual Jaguar", _rc_disallowed_virtual_jaguar_settings },
+  { NULL, NULL }
+};
+
+static int rc_libretro_string_equal_nocase(const char* test, const char* value) {
+  while (*test) {
+    if (tolower(*test++) != tolower(*value++))
+      return 0;
+  }
+
+  return (*value == '\0');
+}
+
+static int rc_libretro_match_value(const char* val, const char* match) {
+  /* if value starts with a comma, it's a CSV list of potential matches */
+  if (*match == ',') {
+    do {
+      const char* ptr = ++match;
+      int size;
+
+      while (*match && *match != ',')
+        ++match;
+
+      size = match - ptr;
+      if (val[size] == '\0') {
+        if (memcmp(ptr, val, size) == 0) {
+          return 1;
+        }
+        else {
+          char buffer[128];
+          memcpy(buffer, ptr, size);
+          buffer[size] = '\0';
+          if (rc_libretro_string_equal_nocase(buffer, val))
+            return 1;
+        }
+      }
+    } while (*match == ',');
+
+    return 0;
+  }
+
+  /* a leading exclamation point means the provided value(s) are not forbidden (are allowed) */
+  if (*match == '!')
+    return !rc_libretro_match_value(val, &match[1]);
+
+  /* just a single value, attempt to match it */
+  return rc_libretro_string_equal_nocase(val, match);
+}
+
+int rc_libretro_is_setting_allowed(const rc_disallowed_setting_t* disallowed_settings, const char* setting, const char* value) {
+  const char* key;
+  size_t key_len;
+
+  for (; disallowed_settings->setting; ++disallowed_settings) {
+    key = disallowed_settings->setting;
+    key_len = strlen(key);
+
+    if (key[key_len - 1] == '*') {
+      if (memcmp(setting, key, key_len - 1) == 0) {
+        if (rc_libretro_match_value(value, disallowed_settings->value))
+          return 0;
+      }
+    }
+    else {
+      if (memcmp(setting, key, key_len + 1) == 0) {
+        if (rc_libretro_match_value(value, disallowed_settings->value))
+          return 0;
+      }
+    }
+  }
+
+  return 1;
+}
+
+const rc_disallowed_setting_t* rc_libretro_get_disallowed_settings(const char* library_name) {
+  const rc_disallowed_core_settings_t* core_filter = rc_disallowed_core_settings;
+  size_t library_name_length;
+
+  if (!library_name || !library_name[0])
+    return NULL;
+
+  library_name_length = strlen(library_name) + 1;
+  while (core_filter->library_name) {
+    if (memcmp(core_filter->library_name, library_name, library_name_length) == 0)
+      return core_filter->disallowed_settings;
+
+    ++core_filter;
+  }
+
+  return NULL;
+}
+
+
+unsigned char* rc_libretro_memory_find(const rc_libretro_memory_regions_t* regions, unsigned address) {
+  unsigned i;
+
+  for (i = 0; i < regions->count; ++i) {
+    const size_t size = regions->size[i];
+    if (address < size) {
+      if (regions->data[i] == NULL)
+        break;
+
+      return &regions->data[i][address];
+    }
+
+    address -= size;
+  }
+
+  return NULL;
+}
+
+void rc_libretro_init_verbose_message_callback(rc_libretro_message_callback callback) {
+  verbose_message_callback = callback;
+}
+
+static void rc_libretro_verbose(const char* message) {
+  if (verbose_message_callback)
+    verbose_message_callback(message);
+}
+
+static const char* rc_memory_type_str(int type) {
+  switch (type)
+  {
+    case RC_MEMORY_TYPE_SAVE_RAM:
+      return "SRAM";
+    case RC_MEMORY_TYPE_VIDEO_RAM:
+      return "VRAM";
+    case RC_MEMORY_TYPE_UNUSED:
+      return "UNUSED";
+    default:
+      break;
+  }
+
+  return "SYSTEM RAM";
+}
+
+static void rc_libretro_memory_register_region(rc_libretro_memory_regions_t* regions, int type,
+                                               unsigned char* data, size_t size, const char* description) {
+  if (size == 0)
+    return;
+
+  if (regions->count == (sizeof(regions->size) / sizeof(regions->size[0]))) {
+    rc_libretro_verbose("Too many memory memory regions to register");
+    return;
+  }
+
+  if (!data && regions->count > 0 && !regions->data[regions->count - 1]) {
+    /* extend null region */
+    regions->size[regions->count - 1] += size;
+  }
+  else if (data && regions->count > 0 &&
+           data == (regions->data[regions->count - 1] + regions->size[regions->count - 1])) {
+    /* extend non-null region */
+    regions->size[regions->count - 1] += size;
+  }
+  else {
+    /* create new region */
+    regions->data[regions->count] = data;
+    regions->size[regions->count] = size;
+    ++regions->count;
+  }
+
+  regions->total_size += size;
+
+  if (verbose_message_callback) {
+    char message[128];
+    snprintf(message, sizeof(message), "Registered 0x%04X bytes of %s at $%06X (%s)", (unsigned)size,
+             rc_memory_type_str(type), (unsigned)(regions->total_size - size), description);
+    verbose_message_callback(message);
+  }
+}
+
+static void rc_libretro_memory_init_without_regions(rc_libretro_memory_regions_t* regions) {
+  /* no regions specified, assume system RAM followed by save RAM */
+  char description[64];
+  void* data;
+  size_t size;
+
+  snprintf(description, sizeof(description), "offset 0x%06x", 0);
+
+  size = retro_get_memory_size(RETRO_MEMORY_SYSTEM_RAM);
+  if (size) {
+    data = retro_get_memory_data(RETRO_MEMORY_SYSTEM_RAM);
+    rc_libretro_memory_register_region(regions, RC_MEMORY_TYPE_SYSTEM_RAM, (unsigned char*)data, size, description);
+  }
+
+  size = retro_get_memory_size(RETRO_MEMORY_SAVE_RAM);
+  if (size) {
+    data = retro_get_memory_data(RETRO_MEMORY_SAVE_RAM);
+    rc_libretro_memory_register_region(regions, RC_MEMORY_TYPE_SAVE_RAM, (unsigned char*)data, size, description);
+  }
+}
+
+static const struct retro_memory_descriptor* rc_libretro_memory_get_descriptor(const struct retro_memory_map* mmap, unsigned real_address, size_t* offset)
+{
+  const struct retro_memory_descriptor* desc = mmap->descriptors;
+  const struct retro_memory_descriptor* end = desc + mmap->num_descriptors;
+
+  for (; desc < end; desc++) {
+    if (desc->select == 0) {
+      /* if select is 0, attempt to explcitly match the address */
+      if (real_address >= desc->start && real_address < desc->start + desc->len) {
+        *offset = real_address - desc->start;
+        return desc;
+      }
+    }
+    else {
+      /* otherwise, attempt to match the address by matching the select bits */
+      /* address is in the block if (addr & select) == (start & select) */
+      if (((desc->start ^ real_address) & desc->select) == 0) {
+        /* calculate the offset within the descriptor, removing any disconnected bits */
+        *offset = (real_address & ~desc->disconnect) - desc->start;
+
+        /* sanity check - make sure the descriptor is large enough to hold the target address */
+        if (*offset < desc->len)
+          return desc;
+      }
+    }
+  }
+
+  *offset = 0;
+  return NULL;
+}
+
+static void rc_libretro_memory_init_from_memory_map(rc_libretro_memory_regions_t* regions, const struct retro_memory_map* mmap,
+                                                    const rc_memory_regions_t* console_regions) {
+  char description[64];
+  unsigned i;
+  unsigned char* region_start;
+  unsigned char* desc_start;
+  size_t desc_size;
+  size_t offset;
+
+  for (i = 0; i < console_regions->num_regions; ++i) {
+    const rc_memory_region_t* console_region = &console_regions->region[i];
+    size_t console_region_size = console_region->end_address - console_region->start_address + 1;
+    unsigned real_address = console_region->real_address;
+
+    while (console_region_size > 0) {
+      const struct retro_memory_descriptor* desc = rc_libretro_memory_get_descriptor(mmap, real_address, &offset);
+      if (!desc) {
+        if (verbose_message_callback && console_region->type != RC_MEMORY_TYPE_UNUSED) {
+          snprintf(description, sizeof(description), "Could not map region starting at $%06X",
+                   real_address - console_region->real_address + console_region->start_address);
+          rc_libretro_verbose(description);
+        }
+
+        rc_libretro_memory_register_region(regions, console_region->type, NULL, console_region_size, "null filler");
+        break;
+      }
+
+      snprintf(description, sizeof(description), "descriptor %u, offset 0x%06X",
+               (unsigned)(desc - mmap->descriptors) + 1, (int)offset);
+
+      if (desc->ptr) {
+        desc_start = (uint8_t*)desc->ptr + desc->offset;
+        region_start = desc_start + offset;
+      }
+      else {
+        region_start = NULL;
+      }
+
+      desc_size = desc->len - offset;
+
+      if (console_region_size > desc_size) {
+        if (desc_size == 0) {
+          if (verbose_message_callback && console_region->type != RC_MEMORY_TYPE_UNUSED) {
+            snprintf(description, sizeof(description), "Could not map region starting at $%06X",
+                     real_address - console_region->real_address + console_region->start_address);
+            rc_libretro_verbose(description);
+          }
+
+          rc_libretro_memory_register_region(regions, console_region->type, NULL, console_region_size, "null filler");
+          console_region_size = 0;
+        }
+        else {
+          rc_libretro_memory_register_region(regions, console_region->type, region_start, desc_size, description);
+          console_region_size -= desc_size;
+          real_address += desc_size;
+        }
+      }
+      else {
+        rc_libretro_memory_register_region(regions, console_region->type, region_start, console_region_size, description);
+        console_region_size = 0;
+      }
+    }
+  }
+}
+
+static unsigned rc_libretro_memory_console_region_to_ram_type(int region_type) {
+  switch (region_type)
+  {
+    case RC_MEMORY_TYPE_SAVE_RAM:
+      return RETRO_MEMORY_SAVE_RAM;
+    case RC_MEMORY_TYPE_VIDEO_RAM:
+      return RETRO_MEMORY_VIDEO_RAM;
+    default:
+      break;
+  }
+
+  return RETRO_MEMORY_SYSTEM_RAM;
+}
+
+static void rc_libretro_memory_init_from_unmapped_memory(rc_libretro_memory_regions_t* regions, const rc_memory_regions_t* console_regions) {
+  char description[64];
+  unsigned i, j;
+  void* data;
+  size_t size;
+  size_t offset;
+
+  for (i = 0; i < console_regions->num_regions; ++i) {
+    const rc_memory_region_t* console_region = &console_regions->region[i];
+    const size_t console_region_size = console_region->end_address - console_region->start_address + 1;
+    const unsigned type = rc_libretro_memory_console_region_to_ram_type(console_region->type);
+    unsigned base_address = 0;
+
+    for (j = 0; j <= i; ++j) {
+      const rc_memory_region_t* console_region2 = &console_regions->region[j];
+      if (rc_libretro_memory_console_region_to_ram_type(console_region2->type) == type) {
+        base_address = console_region2->start_address;
+        break;
+      }
+    }
+    offset = console_region->start_address - base_address;
+
+    size = retro_get_memory_size(type);
+    data = (size) ? retro_get_memory_data(type) : NULL;
+
+    if (offset < size) {
+      size -= offset;
+
+      if (data) {
+        snprintf(description, sizeof(description), "offset 0x%06X", (int)offset);
+        data = (unsigned char*)data + offset;
+      }
+      else {
+        snprintf(description, sizeof(description), "null filler");
+      }
+    }
+    else {
+      if (verbose_message_callback && console_region->type != RC_MEMORY_TYPE_UNUSED) {
+        snprintf(description, sizeof(description), "Could not map region starting at $%06X", console_region->start_address);
+        rc_libretro_verbose(description);
+      }
+
+      data = NULL;
+      size = 0;
+    }
+
+    if (console_region_size > size) {
+      /* want more than what is available, take what we can and null fill the rest */
+      rc_libretro_memory_register_region(regions, console_region->type, (unsigned char*)data, size, description);
+      rc_libretro_memory_register_region(regions, console_region->type, NULL, console_region_size - size, "null filler");
+    }
+    else {
+      /* only take as much as we need */
+      rc_libretro_memory_register_region(regions, console_region->type, (unsigned char*)data, console_region_size, description);
+    }
+  }
+}
+
+int rc_libretro_memory_init(rc_libretro_memory_regions_t* regions, const struct retro_memory_map* mmap, int console_id) {
+  const rc_memory_regions_t* console_regions = rc_console_memory_regions(console_id);
+  rc_libretro_memory_regions_t new_regions;
+  int has_valid_region = 0;
+  unsigned i;
+
+  if (!regions)
+    return 0;
+
+  memset(&new_regions, 0, sizeof(new_regions));
+
+  if (console_regions == NULL || console_regions->num_regions == 0)
+    rc_libretro_memory_init_without_regions(&new_regions);
+  else if (mmap && mmap->num_descriptors != 0)
+    rc_libretro_memory_init_from_memory_map(&new_regions, mmap, console_regions);
+  else
+    rc_libretro_memory_init_from_unmapped_memory(&new_regions, console_regions);
+
+  /* determine if any valid regions were found */
+  for (i = 0; i < new_regions.count; i++) {
+    if (new_regions.data[i]) {
+      has_valid_region = 1;
+      break;
+    }
+  }
+
+  memcpy(regions, &new_regions, sizeof(*regions));
+  return has_valid_region;
+}
+
+void rc_libretro_memory_destroy(rc_libretro_memory_regions_t* regions) {
+  memset(regions, 0, sizeof(*regions));
+}

--- a/src/rcheevos/rc_libretro.h
+++ b/src/rcheevos/rc_libretro.h
@@ -1,0 +1,51 @@
+#ifndef RC_LIBRETRO_H
+#define RC_LIBRETRO_H
+
+/* this file comes from the libretro repository, which is not an explicit submodule.
+ * the integration must set up paths appropriately to find it. */
+#include <libretro.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*****************************************************************************\
+| Disallowed Settings                                                         |
+\*****************************************************************************/
+
+typedef struct rc_disallowed_setting_t
+{
+  const char* setting;
+  const char* value;
+} rc_disallowed_setting_t;
+
+const rc_disallowed_setting_t* rc_libretro_get_disallowed_settings(const char* library_name);
+int rc_libretro_is_setting_allowed(const rc_disallowed_setting_t* disallowed_settings, const char* setting, const char* value);
+
+/*****************************************************************************\
+| Memory Mapping                                                              |
+\*****************************************************************************/
+
+/* specifies a function to call for verbose logging */
+typedef void (*rc_libretro_message_callback)(const char*);
+void rc_libretro_init_verbose_message_callback(rc_libretro_message_callback callback);
+
+#define RC_LIBRETRO_MAX_MEMORY_REGIONS 32
+typedef struct rc_libretro_memory_regions_t
+{
+  unsigned char* data[RC_LIBRETRO_MAX_MEMORY_REGIONS];
+  size_t size[RC_LIBRETRO_MAX_MEMORY_REGIONS];
+  size_t total_size;
+  unsigned count;
+} rc_libretro_memory_regions_t;
+
+int rc_libretro_memory_init(rc_libretro_memory_regions_t* regions, const struct retro_memory_map* mmap, int console_id);
+void rc_libretro_memory_destroy(rc_libretro_memory_regions_t* regions);
+
+unsigned char* rc_libretro_memory_find(const rc_libretro_memory_regions_t* regions, unsigned address);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RC_LIBRETRO_H */

--- a/src/rcheevos/rc_libretro.h
+++ b/src/rcheevos/rc_libretro.h
@@ -39,7 +39,16 @@ typedef struct rc_libretro_memory_regions_t
   unsigned count;
 } rc_libretro_memory_regions_t;
 
-int rc_libretro_memory_init(rc_libretro_memory_regions_t* regions, const struct retro_memory_map* mmap, int console_id);
+typedef struct rc_libretro_core_memory_info_t
+{
+  unsigned char* data;
+  size_t size;
+} rc_libretro_core_memory_info_t;
+
+typedef void (*rc_libretro_get_core_memory_info_func)(unsigned id, rc_libretro_core_memory_info_t* info);
+
+int rc_libretro_memory_init(rc_libretro_memory_regions_t* regions, const struct retro_memory_map* mmap,
+                            rc_libretro_get_core_memory_info_func get_core_memory_info, int console_id);
 void rc_libretro_memory_destroy(rc_libretro_memory_regions_t* regions);
 
 unsigned char* rc_libretro_memory_find(const rc_libretro_memory_regions_t* regions, unsigned address);

--- a/test/Makefile
+++ b/test/Makefile
@@ -83,7 +83,7 @@ OBJ=$(RC_SRC)/alloc.o \
 
 # compile flags
 CFLAGS=-Wall -Wno-long-long
-INCLUDES=-I../include -I$(RC_SRC)
+INCLUDES=-I../include -I$(RC_SRC) -I.
 
 ifeq ($(ARCH), x86)
     CFLAGS += -m32

--- a/test/Makefile
+++ b/test/Makefile
@@ -45,6 +45,7 @@ OBJ=$(RC_SRC)/alloc.o \
     $(RC_SRC)/lboard.o \
     $(RC_SRC)/memref.o \
     $(RC_SRC)/operand.o \
+    $(RC_SRC)/rc_libretro.o \
     $(RC_SRC)/richpresence.o \
     $(RC_SRC)/runtime.o \
     $(RC_SRC)/runtime_progress.o \
@@ -64,6 +65,7 @@ OBJ=$(RC_SRC)/alloc.o \
     rcheevos/test_lboard.o \
     rcheevos/test_memref.o \
     rcheevos/test_operand.o \
+    rcheevos/test_rc_libretro.o \
     rcheevos/test_richpresence.o \
     rcheevos/test_runtime.o \
     rcheevos/test_runtime_progress.o \

--- a/test/libretro.h
+++ b/test/libretro.h
@@ -1,0 +1,209 @@
+/**
+ * Provides copies of structures and constants from
+ * https://github.com/libretro/RetroArch/blob/master/libretro-common/include/libretro.h
+ * for unit testing without pulling in the entire libretro project.
+ */
+
+#ifndef LIBRETRO_H__
+#define LIBRETRO_H__
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <limits.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Regular save RAM. This RAM is usually found on a game cartridge,
+ * backed up by a battery.
+ * If save game data is too complex for a single memory buffer,
+ * the SAVE_DIRECTORY (preferably) or SYSTEM_DIRECTORY environment
+ * callback can be used. */
+#define RETRO_MEMORY_SAVE_RAM    0
+
+/* Some games have a built-in clock to keep track of time.
+ * This memory is usually just a couple of bytes to keep track of time.
+ */
+#define RETRO_MEMORY_RTC         1
+
+/* System ram lets a frontend peek into a game systems main RAM. */
+#define RETRO_MEMORY_SYSTEM_RAM  2
+
+/* Video ram lets a frontend peek into a game systems video RAM (VRAM). */
+#define RETRO_MEMORY_VIDEO_RAM   3
+
+
+#define RETRO_MEMDESC_CONST      (1 << 0)   /* The frontend will never change this memory area once retro_load_game has returned. */
+#define RETRO_MEMDESC_BIGENDIAN  (1 << 1)   /* The memory area contains big endian data. Default is little endian. */
+#define RETRO_MEMDESC_SYSTEM_RAM (1 << 2)   /* The memory area is system RAM.  This is main RAM of the gaming system. */
+#define RETRO_MEMDESC_SAVE_RAM   (1 << 3)   /* The memory area is save RAM. This RAM is usually found on a game cartridge, backed up by a battery. */
+#define RETRO_MEMDESC_VIDEO_RAM  (1 << 4)   /* The memory area is video RAM (VRAM) */
+#define RETRO_MEMDESC_ALIGN_2    (1 << 16)  /* All memory access in this area is aligned to their own size, or 2, whichever is smaller. */
+#define RETRO_MEMDESC_ALIGN_4    (2 << 16)
+#define RETRO_MEMDESC_ALIGN_8    (3 << 16)
+#define RETRO_MEMDESC_MINSIZE_2  (1 << 24)  /* All memory in this region is accessed at least 2 bytes at the time. */
+#define RETRO_MEMDESC_MINSIZE_4  (2 << 24)
+#define RETRO_MEMDESC_MINSIZE_8  (3 << 24)
+struct retro_memory_descriptor
+{
+   uint64_t flags;
+
+   /* Pointer to the start of the relevant ROM or RAM chip.
+    * It's strongly recommended to use 'offset' if possible, rather than
+    * doing math on the pointer.
+    *
+    * If the same byte is mapped my multiple descriptors, their descriptors
+    * must have the same pointer.
+    * If 'start' does not point to the first byte in the pointer, put the
+    * difference in 'offset' instead.
+    *
+    * May be NULL if there's nothing usable here (e.g. hardware registers and
+    * open bus). No flags should be set if the pointer is NULL.
+    * It's recommended to minimize the number of descriptors if possible,
+    * but not mandatory. */
+   void *ptr;
+   size_t offset;
+
+   /* This is the location in the emulated address space
+    * where the mapping starts. */
+   size_t start;
+
+   /* Which bits must be same as in 'start' for this mapping to apply.
+    * The first memory descriptor to claim a certain byte is the one
+    * that applies.
+    * A bit which is set in 'start' must also be set in this.
+    * Can be zero, in which case each byte is assumed mapped exactly once.
+    * In this case, 'len' must be a power of two. */
+   size_t select;
+
+   /* If this is nonzero, the set bits are assumed not connected to the
+    * memory chip's address pins. */
+   size_t disconnect;
+
+   /* This one tells the size of the current memory area.
+    * If, after start+disconnect are applied, the address is higher than
+    * this, the highest bit of the address is cleared.
+    *
+    * If the address is still too high, the next highest bit is cleared.
+    * Can be zero, in which case it's assumed to be infinite (as limited
+    * by 'select' and 'disconnect'). */
+   size_t len;
+
+   /* To go from emulated address to physical address, the following
+    * order applies:
+    * Subtract 'start', pick off 'disconnect', apply 'len', add 'offset'. */
+
+   /* The address space name must consist of only a-zA-Z0-9_-,
+    * should be as short as feasible (maximum length is 8 plus the NUL),
+    * and may not be any other address space plus one or more 0-9A-F
+    * at the end.
+    * However, multiple memory descriptors for the same address space is
+    * allowed, and the address space name can be empty. NULL is treated
+    * as empty.
+    *
+    * Address space names are case sensitive, but avoid lowercase if possible.
+    * The same pointer may exist in multiple address spaces.
+    *
+    * Examples:
+    * blank+blank - valid (multiple things may be mapped in the same namespace)
+    * 'Sp'+'Sp' - valid (multiple things may be mapped in the same namespace)
+    * 'A'+'B' - valid (neither is a prefix of each other)
+    * 'S'+blank - valid ('S' is not in 0-9A-F)
+    * 'a'+blank - valid ('a' is not in 0-9A-F)
+    * 'a'+'A' - valid (neither is a prefix of each other)
+    * 'AR'+blank - valid ('R' is not in 0-9A-F)
+    * 'ARB'+blank - valid (the B can't be part of the address either, because
+    *                      there is no namespace 'AR')
+    * blank+'B' - not valid, because it's ambigous which address space B1234
+    *             would refer to.
+    * The length can't be used for that purpose; the frontend may want
+    * to append arbitrary data to an address, without a separator. */
+   const char *addrspace;
+
+   /* TODO: When finalizing this one, add a description field, which should be
+    * "WRAM" or something roughly equally long. */
+
+   /* TODO: When finalizing this one, replace 'select' with 'limit', which tells
+    * which bits can vary and still refer to the same address (limit = ~select).
+    * TODO: limit? range? vary? something else? */
+
+   /* TODO: When finalizing this one, if 'len' is above what 'select' (or
+    * 'limit') allows, it's bankswitched. Bankswitched data must have both 'len'
+    * and 'select' != 0, and the mappings don't tell how the system switches the
+    * banks. */
+
+   /* TODO: When finalizing this one, fix the 'len' bit removal order.
+    * For len=0x1800, pointer 0x1C00 should go to 0x1400, not 0x0C00.
+    * Algorithm: Take bits highest to lowest, but if it goes above len, clear
+    * the most recent addition and continue on the next bit.
+    * TODO: Can the above be optimized? Is "remove the lowest bit set in both
+    * pointer and 'len'" equivalent? */
+
+   /* TODO: Some emulators (MAME?) emulate big endian systems by only accessing
+    * the emulated memory in 32-bit chunks, native endian. But that's nothing
+    * compared to Darek Mihocka <http://www.emulators.com/docs/nx07_vm101.htm>
+    * (section Emulation 103 - Nearly Free Byte Reversal) - he flips the ENTIRE
+    * RAM backwards! I'll want to represent both of those, via some flags.
+    *
+    * I suspect MAME either didn't think of that idea, or don't want the #ifdef.
+    * Not sure which, nor do I really care. */
+
+   /* TODO: Some of those flags are unused and/or don't really make sense. Clean
+    * them up. */
+};
+
+/* The frontend may use the largest value of 'start'+'select' in a
+ * certain namespace to infer the size of the address space.
+ *
+ * If the address space is larger than that, a mapping with .ptr=NULL
+ * should be at the end of the array, with .select set to all ones for
+ * as long as the address space is big.
+ *
+ * Sample descriptors (minus .ptr, and RETRO_MEMFLAG_ on the flags):
+ * SNES WRAM:
+ * .start=0x7E0000, .len=0x20000
+ * (Note that this must be mapped before the ROM in most cases; some of the
+ * ROM mappers
+ * try to claim $7E0000, or at least $7E8000.)
+ * SNES SPC700 RAM:
+ * .addrspace="S", .len=0x10000
+ * SNES WRAM mirrors:
+ * .flags=MIRROR, .start=0x000000, .select=0xC0E000, .len=0x2000
+ * .flags=MIRROR, .start=0x800000, .select=0xC0E000, .len=0x2000
+ * SNES WRAM mirrors, alternate equivalent descriptor:
+ * .flags=MIRROR, .select=0x40E000, .disconnect=~0x1FFF
+ * (Various similar constructions can be created by combining parts of
+ * the above two.)
+ * SNES LoROM (512KB, mirrored a couple of times):
+ * .flags=CONST, .start=0x008000, .select=0x408000, .disconnect=0x8000, .len=512*1024
+ * .flags=CONST, .start=0x400000, .select=0x400000, .disconnect=0x8000, .len=512*1024
+ * SNES HiROM (4MB):
+ * .flags=CONST,                 .start=0x400000, .select=0x400000, .len=4*1024*1024
+ * .flags=CONST, .offset=0x8000, .start=0x008000, .select=0x408000, .len=4*1024*1024
+ * SNES ExHiROM (8MB):
+ * .flags=CONST, .offset=0,                  .start=0xC00000, .select=0xC00000, .len=4*1024*1024
+ * .flags=CONST, .offset=4*1024*1024,        .start=0x400000, .select=0xC00000, .len=4*1024*1024
+ * .flags=CONST, .offset=0x8000,             .start=0x808000, .select=0xC08000, .len=4*1024*1024
+ * .flags=CONST, .offset=4*1024*1024+0x8000, .start=0x008000, .select=0xC08000, .len=4*1024*1024
+ * Clarify the size of the address space:
+ * .ptr=NULL, .select=0xFFFFFF
+ * .len can be implied by .select in many of them, but was included for clarity.
+ */
+
+struct retro_memory_map
+{
+   const struct retro_memory_descriptor *descriptors;
+   unsigned num_descriptors;
+};
+
+/* Gets region of memory. */
+void *retro_get_memory_data(unsigned id);
+size_t retro_get_memory_size(unsigned id);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/test/libretro.h
+++ b/test/libretro.h
@@ -198,10 +198,6 @@ struct retro_memory_map
    unsigned num_descriptors;
 };
 
-/* Gets region of memory. */
-void *retro_get_memory_data(unsigned id);
-size_t retro_get_memory_size(unsigned id);
-
 #ifdef __cplusplus
 }
 #endif

--- a/test/rcheevos-test.vcxproj
+++ b/test/rcheevos-test.vcxproj
@@ -75,7 +75,7 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(ProjectDir)..\include;$(ProjectDir)..\src\rcheevos;$(ProjectDir)lua\src</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)..\include;$(ProjectDir)..\src\rcheevos;$(ProjectDir)lua\src</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
@@ -88,7 +88,7 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(ProjectDir)..\include;$(ProjectDir)..\src\rcheevos;$(ProjectDir)lua\src</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)..\include;$(ProjectDir)..\src\rcheevos;$(ProjectDir)lua\src</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
@@ -100,7 +100,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(ProjectDir)..\include;$(ProjectDir)..\src\rcheevos;$(ProjectDir)lua\src</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)..\include;$(ProjectDir)..\src\rcheevos;$(ProjectDir)lua\src</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
@@ -117,7 +117,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(ProjectDir)..\include;$(ProjectDir)..\src\rcheevos;$(ProjectDir)lua\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)..\include;$(ProjectDir)..\src\rcheevos;$(ProjectDir)lua\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
@@ -138,6 +138,7 @@
     <ClCompile Include="..\src\rcheevos\lboard.c" />
     <ClCompile Include="..\src\rcheevos\memref.c" />
     <ClCompile Include="..\src\rcheevos\operand.c" />
+    <ClCompile Include="..\src\rcheevos\rc_libretro.c" />
     <ClCompile Include="..\src\rcheevos\richpresence.c" />
     <ClCompile Include="..\src\rcheevos\runtime.c" />
     <ClCompile Include="..\src\rcheevos\runtime_progress.c" />
@@ -190,6 +191,7 @@
     <ClCompile Include="rcheevos\test_lboard.c" />
     <ClCompile Include="rcheevos\test_memref.c" />
     <ClCompile Include="rcheevos\test_operand.c" />
+    <ClCompile Include="rcheevos\test_rc_libretro.c" />
     <ClCompile Include="rcheevos\test_richpresence.c" />
     <ClCompile Include="rcheevos\test_runtime.c" />
     <ClCompile Include="rcheevos\test_runtime_progress.c" />
@@ -212,7 +214,9 @@
     <ClInclude Include="..\src\rcheevos\rc_internal.h" />
     <ClInclude Include="..\include\rc_error.h" />
     <ClInclude Include="..\src\rapi\rc_api_common.h" />
+    <ClInclude Include="..\src\rcheevos\rc_libretro.h" />
     <ClInclude Include="..\src\rhash\md5.h" />
+    <ClInclude Include="libretro.h" />
     <ClInclude Include="rcheevos\mock_memory.h" />
     <ClInclude Include="rhash\data.h" />
     <ClInclude Include="rhash\mock_filereader.h" />

--- a/test/rcheevos-test.vcxproj.filters
+++ b/test/rcheevos-test.vcxproj.filters
@@ -261,6 +261,12 @@
     <ClCompile Include="rapi\test_rc_api_common.c">
       <Filter>tests\rapi</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\rcheevos\rc_libretro.c">
+      <Filter>src\rcheevos</Filter>
+    </ClCompile>
+    <ClCompile Include="rcheevos\test_rc_libretro.c">
+      <Filter>tests\rcheevos</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\include\rcheevos.h">
@@ -310,6 +316,12 @@
     </ClInclude>
     <ClInclude Include="..\include\rc_api_runtime.h">
       <Filter>src\rapi</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\rcheevos\rc_libretro.h">
+      <Filter>src\rcheevos</Filter>
+    </ClInclude>
+    <ClInclude Include="libretro.h">
+      <Filter>tests\rcheevos</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/test/rcheevos/test_rc_libretro.c
+++ b/test/rcheevos/test_rc_libretro.c
@@ -145,7 +145,7 @@ static void test_memory_init_from_unmapped_memory_no_save_ram() {
 
 static void test_memory_init_from_unmapped_memory_merge_neighbors() {
   rc_libretro_memory_regions_t regions;
-  unsigned char buffer1[16];
+  unsigned char* buffer1 = malloc(0x10000); /* have to malloc to prevent array-bounds compiler warnings */
   retro_memory_data[RETRO_MEMORY_SYSTEM_RAM] = buffer1;
   retro_memory_size[RETRO_MEMORY_SYSTEM_RAM] = 0x10000;
   retro_memory_data[RETRO_MEMORY_SAVE_RAM] = NULL;
@@ -159,6 +159,8 @@ static void test_memory_init_from_unmapped_memory_merge_neighbors() {
   ASSERT_PTR_EQUALS(rc_libretro_memory_find(&regions, 0x0102), &buffer1[0x0102]);
   ASSERT_PTR_EQUALS(rc_libretro_memory_find(&regions, 0xFFFF), &buffer1[0xFFFF]);
   ASSERT_PTR_NULL(rc_libretro_memory_find(&regions, 0x10000));
+
+  free(buffer1);
 }
 
 static void test_memory_init_from_unmapped_memory_no_ram() {
@@ -251,7 +253,7 @@ static void test_memory_init_from_memory_map_no_save_ram() {
 
 static void test_memory_init_from_memory_map_merge_neighbors() {
   rc_libretro_memory_regions_t regions;
-  unsigned char buffer1[8];
+  unsigned char* buffer1 = malloc(0x10000); /* have to malloc to prevent array-bounds compiler warnings */
   const struct retro_memory_descriptor mmap_desc[] = {
 	{ RETRO_MEMDESC_SYSTEM_RAM, &buffer1[0x0000], 0, 0x0000U, 0, 0, 0xFC00, "RAM" },
 	{ RETRO_MEMDESC_SYSTEM_RAM, &buffer1[0xFC00], 0, 0xFC00U, 0, 0, 0x0400, "Hardware controllers" }
@@ -266,6 +268,8 @@ static void test_memory_init_from_memory_map_merge_neighbors() {
   ASSERT_PTR_EQUALS(rc_libretro_memory_find(&regions, 0x0102), &buffer1[0x0102]);
   ASSERT_PTR_EQUALS(rc_libretro_memory_find(&regions, 0xFFFF), &buffer1[0xFFFF]);
   ASSERT_PTR_NULL(rc_libretro_memory_find(&regions, 0x10000));
+
+  free(buffer1);
 }
 
 static void test_memory_init_from_memory_map_no_ram() {

--- a/test/rcheevos/test_rc_libretro.c
+++ b/test/rcheevos/test_rc_libretro.c
@@ -1,0 +1,451 @@
+#include "rc_libretro.h"
+
+#include "rc_consoles.h"
+
+#include "../test_framework.h"
+
+static void* retro_memory_data[4] = { NULL, NULL, NULL, NULL };
+static size_t retro_memory_size[4] = { 0, 0, 0, 0 };
+
+void* retro_get_memory_data(unsigned id) {
+  return retro_memory_data[id];
+}
+
+size_t retro_get_memory_size(unsigned id) {
+  return retro_memory_size[id];
+}
+
+static void test_allowed_setting(const char* library_name, const char* setting, const char* value) {
+  const rc_disallowed_setting_t* settings = rc_libretro_get_disallowed_settings(library_name);
+  if (!settings)
+	return;
+
+  ASSERT_TRUE(rc_libretro_is_setting_allowed(settings, setting, value));
+}
+
+static void test_disallowed_setting(const char* library_name, const char* setting, const char* value) {
+  const rc_disallowed_setting_t* settings = rc_libretro_get_disallowed_settings(library_name);
+  ASSERT_PTR_NOT_NULL(settings);
+  ASSERT_FALSE(rc_libretro_is_setting_allowed(settings, setting, value));
+}
+
+static void test_memory_init_without_regions() {
+  rc_libretro_memory_regions_t regions;
+  unsigned char buffer1[16], buffer2[8];
+  retro_memory_data[RETRO_MEMORY_SYSTEM_RAM] = buffer1;
+  retro_memory_size[RETRO_MEMORY_SYSTEM_RAM] = sizeof(buffer1);
+  retro_memory_data[RETRO_MEMORY_SAVE_RAM] = buffer2;
+  retro_memory_size[RETRO_MEMORY_SAVE_RAM] = sizeof(buffer2);
+
+  ASSERT_TRUE(rc_libretro_memory_init(&regions, NULL, RC_CONSOLE_HUBS));
+
+  ASSERT_NUM_EQUALS(regions.count, 2);
+  ASSERT_NUM_EQUALS(regions.total_size, sizeof(buffer1) + sizeof(buffer2));
+  ASSERT_PTR_EQUALS(rc_libretro_memory_find(&regions, 2), &buffer1[2]);
+  ASSERT_PTR_EQUALS(rc_libretro_memory_find(&regions, sizeof(buffer1) + 2), &buffer2[2]);
+  ASSERT_PTR_NULL(rc_libretro_memory_find(&regions, sizeof(buffer1) + sizeof(buffer2) + 2));
+}
+
+static void test_memory_init_without_regions_system_ram_only() {
+  rc_libretro_memory_regions_t regions;
+  unsigned char buffer1[16];
+  retro_memory_data[RETRO_MEMORY_SYSTEM_RAM] = buffer1;
+  retro_memory_size[RETRO_MEMORY_SYSTEM_RAM] = sizeof(buffer1);
+  retro_memory_data[RETRO_MEMORY_SAVE_RAM] = NULL;
+  retro_memory_size[RETRO_MEMORY_SAVE_RAM] = 0;
+
+  ASSERT_TRUE(rc_libretro_memory_init(&regions, NULL, RC_CONSOLE_HUBS));
+
+  ASSERT_NUM_EQUALS(regions.count, 1);
+  ASSERT_NUM_EQUALS(regions.total_size, sizeof(buffer1));
+  ASSERT_PTR_EQUALS(rc_libretro_memory_find(&regions, 2), &buffer1[2]);
+  ASSERT_PTR_NULL(rc_libretro_memory_find(&regions, sizeof(buffer1) + 2));
+}
+
+static void test_memory_init_without_regions_save_ram_only() {
+  rc_libretro_memory_regions_t regions;
+  unsigned char buffer2[8];
+  retro_memory_data[RETRO_MEMORY_SYSTEM_RAM] = NULL;
+  retro_memory_size[RETRO_MEMORY_SYSTEM_RAM] = 0;
+  retro_memory_data[RETRO_MEMORY_SAVE_RAM] = buffer2;
+  retro_memory_size[RETRO_MEMORY_SAVE_RAM] = sizeof(buffer2);
+
+  ASSERT_TRUE(rc_libretro_memory_init(&regions, NULL, RC_CONSOLE_HUBS));
+
+  ASSERT_NUM_EQUALS(regions.count, 1);
+  ASSERT_NUM_EQUALS(regions.total_size, sizeof(buffer2));
+  ASSERT_PTR_EQUALS(rc_libretro_memory_find(&regions, 2), &buffer2[2]);
+  ASSERT_PTR_NULL(rc_libretro_memory_find(&regions, sizeof(buffer2) + 2));
+}
+
+static void test_memory_init_without_regions_no_ram() {
+  rc_libretro_memory_regions_t regions;
+  retro_memory_data[RETRO_MEMORY_SYSTEM_RAM] = NULL;
+  retro_memory_size[RETRO_MEMORY_SYSTEM_RAM] = 0;
+  retro_memory_data[RETRO_MEMORY_SAVE_RAM] = NULL;
+  retro_memory_size[RETRO_MEMORY_SAVE_RAM] = 0;
+
+  ASSERT_FALSE(rc_libretro_memory_init(&regions, NULL, RC_CONSOLE_HUBS));
+
+  ASSERT_NUM_EQUALS(regions.count, 0);
+  ASSERT_NUM_EQUALS(regions.total_size, 0);
+  ASSERT_PTR_NULL(rc_libretro_memory_find(&regions, 2));
+}
+
+static void test_memory_init_from_unmapped_memory() {
+  rc_libretro_memory_regions_t regions;
+  unsigned char buffer1[8], buffer2[8];
+  retro_memory_data[RETRO_MEMORY_SYSTEM_RAM] = buffer1;
+  retro_memory_size[RETRO_MEMORY_SYSTEM_RAM] = 0x10000;
+  retro_memory_data[RETRO_MEMORY_SAVE_RAM] = buffer2;
+  retro_memory_size[RETRO_MEMORY_SAVE_RAM] = 0x10000;
+
+  ASSERT_TRUE(rc_libretro_memory_init(&regions, NULL, RC_CONSOLE_MEGA_DRIVE));
+
+  ASSERT_NUM_EQUALS(regions.count, 2);
+  ASSERT_NUM_EQUALS(regions.total_size, 0x20000);
+  ASSERT_PTR_EQUALS(rc_libretro_memory_find(&regions, 0x00002), &buffer1[2]);
+  ASSERT_PTR_EQUALS(rc_libretro_memory_find(&regions, 0x10002), &buffer2[2]);
+  ASSERT_PTR_NULL(rc_libretro_memory_find(&regions, 0x20002));
+}
+
+static void test_memory_init_from_unmapped_memory_null_filler() {
+  rc_libretro_memory_regions_t regions;
+  unsigned char buffer1[16], buffer2[8];
+  retro_memory_data[RETRO_MEMORY_SYSTEM_RAM] = buffer1;
+  retro_memory_size[RETRO_MEMORY_SYSTEM_RAM] = sizeof(buffer1);
+  retro_memory_data[RETRO_MEMORY_SAVE_RAM] = buffer2;
+  retro_memory_size[RETRO_MEMORY_SAVE_RAM] = sizeof(buffer2);
+
+  ASSERT_TRUE(rc_libretro_memory_init(&regions, NULL, RC_CONSOLE_MEGA_DRIVE));
+
+  ASSERT_NUM_EQUALS(regions.count, 4); /* two valid regions and two null fillers */
+  ASSERT_NUM_EQUALS(regions.total_size, 0x20000);
+  ASSERT_PTR_EQUALS(rc_libretro_memory_find(&regions, 0x00002), &buffer1[2]);
+  ASSERT_PTR_NULL(rc_libretro_memory_find(&regions, 0x00012));
+  ASSERT_PTR_EQUALS(rc_libretro_memory_find(&regions, 0x10002), &buffer2[2]);
+  ASSERT_PTR_NULL(rc_libretro_memory_find(&regions, 0x1000A));
+  ASSERT_PTR_NULL(rc_libretro_memory_find(&regions, 0x20002));
+}
+
+static void test_memory_init_from_unmapped_memory_no_save_ram() {
+  rc_libretro_memory_regions_t regions;
+  unsigned char buffer1[16];
+  retro_memory_data[RETRO_MEMORY_SYSTEM_RAM] = buffer1;
+  retro_memory_size[RETRO_MEMORY_SYSTEM_RAM] = 0x10000;
+  retro_memory_data[RETRO_MEMORY_SAVE_RAM] = NULL;
+  retro_memory_size[RETRO_MEMORY_SAVE_RAM] = 0;
+
+  ASSERT_TRUE(rc_libretro_memory_init(&regions, NULL, RC_CONSOLE_MEGA_DRIVE));
+
+  ASSERT_NUM_EQUALS(regions.count, 2);
+  ASSERT_NUM_EQUALS(regions.total_size, 0x20000);
+  ASSERT_PTR_EQUALS(rc_libretro_memory_find(&regions, 0x00002), &buffer1[2]);
+  ASSERT_PTR_NULL(rc_libretro_memory_find(&regions, 0x10002));
+  ASSERT_PTR_NULL(rc_libretro_memory_find(&regions, 0x20002));
+}
+
+static void test_memory_init_from_unmapped_memory_merge_neighbors() {
+  rc_libretro_memory_regions_t regions;
+  unsigned char buffer1[16];
+  retro_memory_data[RETRO_MEMORY_SYSTEM_RAM] = buffer1;
+  retro_memory_size[RETRO_MEMORY_SYSTEM_RAM] = 0x10000;
+  retro_memory_data[RETRO_MEMORY_SAVE_RAM] = NULL;
+  retro_memory_size[RETRO_MEMORY_SAVE_RAM] = 0;
+
+  ASSERT_TRUE(rc_libretro_memory_init(&regions, NULL, RC_CONSOLE_ATARI_LYNX));
+
+  ASSERT_NUM_EQUALS(regions.count, 1); /* all regions are adjacent, so should be merged */
+  ASSERT_NUM_EQUALS(regions.total_size, 0x10000);
+  ASSERT_PTR_EQUALS(rc_libretro_memory_find(&regions, 0x0002), &buffer1[0x0002]);
+  ASSERT_PTR_EQUALS(rc_libretro_memory_find(&regions, 0x0102), &buffer1[0x0102]);
+  ASSERT_PTR_EQUALS(rc_libretro_memory_find(&regions, 0xFFFF), &buffer1[0xFFFF]);
+  ASSERT_PTR_NULL(rc_libretro_memory_find(&regions, 0x10000));
+}
+
+static void test_memory_init_from_unmapped_memory_no_ram() {
+  rc_libretro_memory_regions_t regions;
+  retro_memory_data[RETRO_MEMORY_SYSTEM_RAM] = NULL;
+  retro_memory_size[RETRO_MEMORY_SYSTEM_RAM] = 0;
+  retro_memory_data[RETRO_MEMORY_SAVE_RAM] = NULL;
+  retro_memory_size[RETRO_MEMORY_SAVE_RAM] = 0;
+
+  /* init returns false */
+  ASSERT_FALSE(rc_libretro_memory_init(&regions, NULL, RC_CONSOLE_MEGA_DRIVE));
+
+  /* but one null-filled region is still generated */
+  ASSERT_NUM_EQUALS(regions.count, 1);
+  ASSERT_NUM_EQUALS(regions.total_size, 0x20000);
+  ASSERT_PTR_NULL(rc_libretro_memory_find(&regions, 0x00002));
+  ASSERT_PTR_NULL(rc_libretro_memory_find(&regions, 0x10002));
+  ASSERT_PTR_NULL(rc_libretro_memory_find(&regions, 0x20002));
+}
+
+static void test_memory_init_from_unmapped_memory_save_ram_first() {
+  rc_libretro_memory_regions_t regions;
+  unsigned char buffer1[8], buffer2[8];
+  retro_memory_data[RETRO_MEMORY_SYSTEM_RAM] = buffer1;
+  retro_memory_size[RETRO_MEMORY_SYSTEM_RAM] = 0x40000;
+  retro_memory_data[RETRO_MEMORY_SAVE_RAM] = buffer2;
+  retro_memory_size[RETRO_MEMORY_SAVE_RAM] = 0x8000;
+
+  ASSERT_TRUE(rc_libretro_memory_init(&regions, NULL, RC_CONSOLE_GAMEBOY_ADVANCE));
+
+  ASSERT_NUM_EQUALS(regions.count, 2);
+  ASSERT_NUM_EQUALS(regions.total_size, 0x48000);
+  ASSERT_PTR_EQUALS(rc_libretro_memory_find(&regions, 0x00002), &buffer2[2]);
+  ASSERT_PTR_EQUALS(rc_libretro_memory_find(&regions, 0x08002), &buffer1[2]);
+  ASSERT_PTR_NULL(rc_libretro_memory_find(&regions, 0x48002));
+}
+
+static void test_memory_init_from_memory_map() {
+  rc_libretro_memory_regions_t regions;
+  unsigned char buffer1[8], buffer2[8];
+  const struct retro_memory_descriptor mmap_desc[] = {
+	{ RETRO_MEMDESC_SYSTEM_RAM, &buffer1[0], 0, 0xFF0000U, 0, 0, 0x10000, "RAM" },
+	{ RETRO_MEMDESC_SAVE_RAM,   &buffer2[0], 0, 0x000000U, 0, 0, 0x10000, "SRAM" }
+  };
+  const struct retro_memory_map mmap = { mmap_desc, sizeof(mmap_desc) / sizeof(mmap_desc[0]) };
+
+  ASSERT_TRUE(rc_libretro_memory_init(&regions, &mmap, RC_CONSOLE_MEGA_DRIVE));
+
+  ASSERT_NUM_EQUALS(regions.count, 2);
+  ASSERT_NUM_EQUALS(regions.total_size, 0x20000);
+  ASSERT_PTR_EQUALS(rc_libretro_memory_find(&regions, 0x00002), &buffer1[2]);
+  ASSERT_PTR_EQUALS(rc_libretro_memory_find(&regions, 0x10002), &buffer2[2]);
+  ASSERT_PTR_NULL(rc_libretro_memory_find(&regions, 0x20002));
+}
+
+static void test_memory_init_from_memory_map_null_filler() {
+  rc_libretro_memory_regions_t regions;
+  unsigned char buffer1[8], buffer2[8];
+  const struct retro_memory_descriptor mmap_desc[] = {
+	{ RETRO_MEMDESC_SYSTEM_RAM, &buffer1[0], 0, 0xFF0000U, 0, 0, 0x10000, "RAM" },
+	{ RETRO_MEMDESC_SAVE_RAM,   &buffer2[0], 0, 0x000000U, 0, 0, 0x10000, "SRAM" }
+  };
+  const struct retro_memory_map mmap = { mmap_desc, sizeof(mmap_desc) / sizeof(mmap_desc[0]) };
+
+  ASSERT_TRUE(rc_libretro_memory_init(&regions, &mmap, RC_CONSOLE_MEGA_DRIVE));
+
+  ASSERT_NUM_EQUALS(regions.count, 2);
+  ASSERT_NUM_EQUALS(regions.total_size, 0x20000);
+  ASSERT_PTR_EQUALS(rc_libretro_memory_find(&regions, 0x00002), &buffer1[2]);
+  ASSERT_PTR_EQUALS(rc_libretro_memory_find(&regions, 0x10002), &buffer2[2]);
+  ASSERT_PTR_NULL(rc_libretro_memory_find(&regions, 0x20002));
+}
+
+static void test_memory_init_from_memory_map_no_save_ram() {
+  rc_libretro_memory_regions_t regions;
+  unsigned char buffer1[8];
+  const struct retro_memory_descriptor mmap_desc[] = {
+	{ RETRO_MEMDESC_SYSTEM_RAM, &buffer1[0], 0, 0xFF0000U, 0, 0, 0x10000, "RAM" }
+  };
+  const struct retro_memory_map mmap = { mmap_desc, sizeof(mmap_desc) / sizeof(mmap_desc[0]) };
+
+  ASSERT_TRUE(rc_libretro_memory_init(&regions, &mmap, RC_CONSOLE_MEGA_DRIVE));
+
+  ASSERT_NUM_EQUALS(regions.count, 2);
+  ASSERT_NUM_EQUALS(regions.total_size, 0x20000);
+  ASSERT_PTR_EQUALS(rc_libretro_memory_find(&regions, 0x00002), &buffer1[2]);
+  ASSERT_PTR_NULL(rc_libretro_memory_find(&regions, 0x10002));
+  ASSERT_PTR_NULL(rc_libretro_memory_find(&regions, 0x20002));
+}
+
+static void test_memory_init_from_memory_map_merge_neighbors() {
+  rc_libretro_memory_regions_t regions;
+  unsigned char buffer1[8];
+  const struct retro_memory_descriptor mmap_desc[] = {
+	{ RETRO_MEMDESC_SYSTEM_RAM, &buffer1[0x0000], 0, 0x0000U, 0, 0, 0xFC00, "RAM" },
+	{ RETRO_MEMDESC_SYSTEM_RAM, &buffer1[0xFC00], 0, 0xFC00U, 0, 0, 0x0400, "Hardware controllers" }
+  };
+  const struct retro_memory_map mmap = { mmap_desc, sizeof(mmap_desc) / sizeof(mmap_desc[0]) };
+
+  ASSERT_TRUE(rc_libretro_memory_init(&regions, &mmap, RC_CONSOLE_ATARI_LYNX));
+
+  ASSERT_NUM_EQUALS(regions.count, 1); /* all regions are adjacent, so should be merged */
+  ASSERT_NUM_EQUALS(regions.total_size, 0x10000);
+  ASSERT_PTR_EQUALS(rc_libretro_memory_find(&regions, 0x0002), &buffer1[0x0002]);
+  ASSERT_PTR_EQUALS(rc_libretro_memory_find(&regions, 0x0102), &buffer1[0x0102]);
+  ASSERT_PTR_EQUALS(rc_libretro_memory_find(&regions, 0xFFFF), &buffer1[0xFFFF]);
+  ASSERT_PTR_NULL(rc_libretro_memory_find(&regions, 0x10000));
+}
+
+static void test_memory_init_from_memory_map_no_ram() {
+  rc_libretro_memory_regions_t regions;
+  const struct retro_memory_descriptor mmap_desc[] = {
+	{ RETRO_MEMDESC_SYSTEM_RAM, NULL, 0, 0xFF0000U, 0, 0, 0x10000, "RAM" },
+	{ RETRO_MEMDESC_SAVE_RAM,   NULL, 0, 0x000000U, 0, 0, 0x10000, "SRAM" }
+  };
+  const struct retro_memory_map mmap = { mmap_desc, sizeof(mmap_desc) / sizeof(mmap_desc[0]) };
+
+  /* init returns false */
+  ASSERT_FALSE(rc_libretro_memory_init(&regions, &mmap, RC_CONSOLE_MEGA_DRIVE));
+
+  /* but one null-filled region is still generated */
+  ASSERT_NUM_EQUALS(regions.count, 1);
+  ASSERT_NUM_EQUALS(regions.total_size, 0x20000);
+  ASSERT_PTR_NULL(rc_libretro_memory_find(&regions, 0x00002));
+  ASSERT_PTR_NULL(rc_libretro_memory_find(&regions, 0x10002));
+  ASSERT_PTR_NULL(rc_libretro_memory_find(&regions, 0x20002));
+}
+
+static void test_memory_init_from_memory_map_splice() {
+  rc_libretro_memory_regions_t regions;
+  unsigned char buffer1[8], buffer2[8], buffer3[8];
+  const struct retro_memory_descriptor mmap_desc[] = {
+	{ RETRO_MEMDESC_SYSTEM_RAM, &buffer1[0], 0, 0xFF0000U, 0, 0, 0x08000, "RAM1" },
+	{ RETRO_MEMDESC_SYSTEM_RAM, &buffer2[0], 0, 0xFF8000U, 0, 0, 0x08000, "RAM2" },
+	{ RETRO_MEMDESC_SAVE_RAM,   &buffer3[0], 0, 0x000000U, 0, 0, 0x10000, "SRAM" }
+  };
+  const struct retro_memory_map mmap = { mmap_desc, sizeof(mmap_desc) / sizeof(mmap_desc[0]) };
+
+  ASSERT_TRUE(rc_libretro_memory_init(&regions, &mmap, RC_CONSOLE_MEGA_DRIVE));
+
+  ASSERT_NUM_EQUALS(regions.count, 3);
+  ASSERT_NUM_EQUALS(regions.total_size, 0x20000);
+  ASSERT_PTR_EQUALS(rc_libretro_memory_find(&regions, 0x00002), &buffer1[2]);
+  ASSERT_PTR_EQUALS(rc_libretro_memory_find(&regions, 0x08002), &buffer2[2]);
+  ASSERT_PTR_EQUALS(rc_libretro_memory_find(&regions, 0x10002), &buffer3[2]);
+  ASSERT_PTR_NULL(rc_libretro_memory_find(&regions, 0x20002));
+}
+
+static void test_memory_init_from_memory_map_mirrored() {
+  rc_libretro_memory_regions_t regions;
+  unsigned char buffer1[8], buffer2[8];
+  const struct retro_memory_descriptor mmap_desc[] = {
+	{ RETRO_MEMDESC_SYSTEM_RAM, &buffer1[0], 0, 0xFF0000U, 0xFF0000U, 0x00C000U, 0x04000, "RAM" },
+	{ RETRO_MEMDESC_SAVE_RAM,   &buffer2[0], 0, 0x000000U, 0x000000U, 0x000000U, 0x10000, "SRAM" }
+  };
+  const struct retro_memory_map mmap = { mmap_desc, sizeof(mmap_desc) / sizeof(mmap_desc[0]) };
+
+  ASSERT_TRUE(rc_libretro_memory_init(&regions, &mmap, RC_CONSOLE_MEGA_DRIVE));
+
+  /* select of 0xFF0000 should mirror the 0x4000 bytes at 0xFF0000 into 0xFF4000, 0xFF8000, and 0xFFC000 */
+  ASSERT_NUM_EQUALS(regions.count, 5);
+  ASSERT_NUM_EQUALS(regions.total_size, 0x20000);
+  ASSERT_PTR_EQUALS(rc_libretro_memory_find(&regions, 0x00002), &buffer1[2]);
+  ASSERT_PTR_EQUALS(rc_libretro_memory_find(&regions, 0x04002), &buffer1[2]);
+  ASSERT_PTR_EQUALS(rc_libretro_memory_find(&regions, 0x08002), &buffer1[2]);
+  ASSERT_PTR_EQUALS(rc_libretro_memory_find(&regions, 0x0C002), &buffer1[2]);
+  ASSERT_PTR_EQUALS(rc_libretro_memory_find(&regions, 0x10002), &buffer2[2]);
+  ASSERT_PTR_NULL(rc_libretro_memory_find(&regions, 0x20002));
+}
+
+static void test_memory_init_from_memory_map_out_of_order() {
+  rc_libretro_memory_regions_t regions;
+  unsigned char buffer1[8], buffer2[8];
+  const struct retro_memory_descriptor mmap_desc[] = {
+	{ RETRO_MEMDESC_SAVE_RAM,   &buffer2[0], 0, 0x000000U, 0, 0, 0x10000, "SRAM" },
+	{ RETRO_MEMDESC_SYSTEM_RAM, &buffer1[0], 0, 0xFF0000U, 0, 0, 0x10000, "RAM" }
+  };
+  const struct retro_memory_map mmap = { mmap_desc, sizeof(mmap_desc) / sizeof(mmap_desc[0]) };
+
+  ASSERT_TRUE(rc_libretro_memory_init(&regions, &mmap, RC_CONSOLE_MEGA_DRIVE));
+
+  ASSERT_NUM_EQUALS(regions.count, 2);
+  ASSERT_NUM_EQUALS(regions.total_size, 0x20000);
+  ASSERT_PTR_EQUALS(rc_libretro_memory_find(&regions, 0x00002), &buffer1[2]);
+  ASSERT_PTR_EQUALS(rc_libretro_memory_find(&regions, 0x10002), &buffer2[2]);
+  ASSERT_PTR_NULL(rc_libretro_memory_find(&regions, 0x20002));
+}
+
+
+void test_rc_libretro(void) {
+  TEST_SUITE_BEGIN();
+
+  /* rc_libretro_disallowed_settings */
+  TEST_PARAMS3(test_allowed_setting,    "bsnes-mercury", "bsnes_region", "Auto");
+  TEST_PARAMS3(test_allowed_setting,    "bsnes-mercury", "bsnes_region", "NTSC");
+  TEST_PARAMS3(test_disallowed_setting, "bsnes-mercury", "bsnes_region", "PAL");
+
+  TEST_PARAMS3(test_allowed_setting,    "dolphin-emu", "dolphin_cheats_enabled", "disabled");
+  TEST_PARAMS3(test_disallowed_setting, "dolphin-emu", "dolphin_cheats_enabled", "enabled");
+
+  TEST_PARAMS3(test_allowed_setting,    "ecwolf", "ecwolf-invulnerability", "disabled");
+  TEST_PARAMS3(test_disallowed_setting, "ecwolf", "ecwolf-invulnerability", "enabled");
+
+  TEST_PARAMS3(test_allowed_setting,    "FCEUmm", "fceumm_region", "Auto");
+  TEST_PARAMS3(test_allowed_setting,    "FCEUmm", "fceumm_region", "NTSC");
+  TEST_PARAMS3(test_disallowed_setting, "FCEUmm", "fceumm_region", "PAL");
+  TEST_PARAMS3(test_disallowed_setting, "FCEUmm", "fceumm_region", "pal"); /* case insensitive */
+  TEST_PARAMS3(test_disallowed_setting, "FCEUmm", "fceumm_region", "Dendy");
+  TEST_PARAMS3(test_allowed_setting,    "FCEUmm", "fceumm_palette", "default"); /* setting we don't care about */
+
+  TEST_PARAMS3(test_allowed_setting,    "FinalBurn Neo", "fbneo-allow-patched-romsets", "disabled");
+  TEST_PARAMS3(test_disallowed_setting, "FinalBurn Neo", "fbneo-allow-patched-romsets", "enabled");
+  TEST_PARAMS3(test_allowed_setting,    "FinalBurn Neo", "fbneo-cheat-mvsc-P1_Char_1_Easy_Hyper_Combo", "disabled"); /* wildcard key match */
+  TEST_PARAMS3(test_disallowed_setting, "FinalBurn Neo", "fbneo-cheat-mvsc-P1_Char_1_Easy_Hyper_Combo", "enabled");
+  TEST_PARAMS3(test_allowed_setting,    "FinalBurn Neo", "fbneo-cheat-mvsc-P1_Char_1_Easy_Hyper_Combo", "0 - Disabled"); /* multi-not value match */
+  TEST_PARAMS3(test_disallowed_setting, "FinalBurn Neo", "fbneo-cheat-mvsc-P1_Char_1_Easy_Hyper_Combo", "1 - Enabled");
+
+  TEST_PARAMS3(test_allowed_setting,    "Genesis Plus GX", "genesis_plus_gx_lock_on", "disabled");
+  TEST_PARAMS3(test_disallowed_setting, "Genesis Plus GX", "genesis_plus_gx_lock_on", "action replay (pro)");
+  TEST_PARAMS3(test_disallowed_setting, "Genesis Plus GX", "genesis_plus_gx_lock_on", "game genie");
+  TEST_PARAMS3(test_allowed_setting,    "Genesis Plus GX", "genesis_plus_gx_lock_on", "sonic & knuckles");
+  TEST_PARAMS3(test_allowed_setting,    "Genesis Plus GX", "genesis_plus_gx_region_detect", "Auto");
+  TEST_PARAMS3(test_allowed_setting,    "Genesis Plus GX", "genesis_plus_gx_region_detect", "NTSC-U");
+  TEST_PARAMS3(test_disallowed_setting, "Genesis Plus GX", "genesis_plus_gx_region_detect", "PAL");
+  TEST_PARAMS3(test_allowed_setting,    "Genesis Plus GX", "genesis_plus_gx_region_detect", "NTSC-J");
+
+  TEST_PARAMS3(test_allowed_setting,    "Genesis Plus GX Wide", "genesis_plus_gx_wide_lock_on", "disabled");
+  TEST_PARAMS3(test_disallowed_setting, "Genesis Plus GX Wide", "genesis_plus_gx_wide_lock_on", "action replay (pro)");
+  TEST_PARAMS3(test_disallowed_setting, "Genesis Plus GX Wide", "genesis_plus_gx_wide_lock_on", "game genie");
+  TEST_PARAMS3(test_allowed_setting,    "Genesis Plus GX Wide", "genesis_plus_gx_wide_lock_on", "sonic & knuckles");
+  TEST_PARAMS3(test_allowed_setting,    "Genesis Plus GX Wide", "genesis_plus_gx_wide_region_detect", "Auto");
+  TEST_PARAMS3(test_allowed_setting,    "Genesis Plus GX Wide", "genesis_plus_gx_wide_region_detect", "NTSC-U");
+  TEST_PARAMS3(test_disallowed_setting, "Genesis Plus GX Wide", "genesis_plus_gx_wide_region_detect", "PAL");
+  TEST_PARAMS3(test_allowed_setting,    "Genesis Plus GX Wide", "genesis_plus_gx_wide_region_detect", "NTSC-J");
+
+  TEST_PARAMS3(test_allowed_setting,    "Mesen", "mesen_region", "Auto");
+  TEST_PARAMS3(test_allowed_setting,    "Mesen", "mesen_region", "NTSC");
+  TEST_PARAMS3(test_disallowed_setting, "Mesen", "mesen_region", "PAL");
+  TEST_PARAMS3(test_disallowed_setting, "Mesen", "mesen_region", "Dendy");
+
+  TEST_PARAMS3(test_allowed_setting,    "Mesen-S", "mesen-s_region", "Auto");
+  TEST_PARAMS3(test_allowed_setting,    "Mesen-S", "mesen-s_region", "NTSC");
+  TEST_PARAMS3(test_disallowed_setting, "Mesen-S", "mesen-s_region", "PAL");
+
+  TEST_PARAMS3(test_allowed_setting,    "PPSSPP", "ppsspp_cheats", "disabled");
+  TEST_PARAMS3(test_disallowed_setting, "PPSSPP", "ppsspp_cheats", "enabled");
+
+  TEST_PARAMS3(test_allowed_setting,    "PCSX-ReARMed", "pcsx_rearmed_region", "Auto");
+  TEST_PARAMS3(test_allowed_setting,    "PCSX-ReARMed", "pcsx_rearmed_region", "NTSC");
+  TEST_PARAMS3(test_disallowed_setting, "PCSX-ReARMed", "pcsx_rearmed_region", "PAL");
+  
+  TEST_PARAMS3(test_allowed_setting,    "PicoDrive", "picodrive_region", "Auto");
+  TEST_PARAMS3(test_allowed_setting,    "PicoDrive", "picodrive_region", "US");
+  TEST_PARAMS3(test_allowed_setting,    "PicoDrive", "picodrive_region", "Japan NTSC");
+  TEST_PARAMS3(test_disallowed_setting, "PicoDrive", "picodrive_region", "Europe");
+  TEST_PARAMS3(test_disallowed_setting, "PicoDrive", "picodrive_region", "Japan PAL");
+  
+  TEST_PARAMS3(test_allowed_setting,    "Snes9x", "snes9x_region", "Auto");
+  TEST_PARAMS3(test_allowed_setting,    "Snes9x", "snes9x_region", "NTSC");
+  TEST_PARAMS3(test_disallowed_setting, "Snes9x", "snes9x_region", "PAL");
+  
+  TEST_PARAMS3(test_allowed_setting,    "Virtual Jaguar", "virtualjaguar_pal", "disabled");
+  TEST_PARAMS3(test_disallowed_setting, "Virtual Jaguar", "virtualjaguar_pal", "enabled");
+
+  /* rc_libretro_memory_init */
+  TEST(test_memory_init_without_regions);
+  TEST(test_memory_init_without_regions_system_ram_only);
+  TEST(test_memory_init_without_regions_save_ram_only);
+  TEST(test_memory_init_without_regions_no_ram);
+
+  TEST(test_memory_init_from_unmapped_memory);
+  TEST(test_memory_init_from_unmapped_memory_null_filler);
+  TEST(test_memory_init_from_unmapped_memory_no_save_ram);
+  TEST(test_memory_init_from_unmapped_memory_merge_neighbors);
+  TEST(test_memory_init_from_unmapped_memory_no_ram);
+  TEST(test_memory_init_from_unmapped_memory_save_ram_first);
+
+  TEST(test_memory_init_from_memory_map);
+  TEST(test_memory_init_from_memory_map_null_filler);
+  TEST(test_memory_init_from_memory_map_no_save_ram);
+  TEST(test_memory_init_from_memory_map_merge_neighbors);
+  TEST(test_memory_init_from_memory_map_no_ram);
+  TEST(test_memory_init_from_memory_map_splice);
+  TEST(test_memory_init_from_memory_map_mirrored);
+  TEST(test_memory_init_from_memory_map_out_of_order);
+
+  TEST_SUITE_END();
+}

--- a/test/test.c
+++ b/test/test.c
@@ -56,6 +56,7 @@ extern void test_runtime();
 extern void test_runtime_progress();
 
 extern void test_consoleinfo();
+extern void test_rc_libretro();
 
 extern void test_url();
 
@@ -84,6 +85,7 @@ int main(void) {
   test_runtime_progress();
 
   test_consoleinfo();
+  test_rc_libretro();
 
   test_lua();
 


### PR DESCRIPTION
Will eliminate some duplicated code. Also adds unit tests.