### PR TITLE
eliminate query parameters from POST requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,29 @@
 # v10.0.0
 
-* renamed `rhash.h` to eliminate conflict with system headers, renamed `rconsoles.h` and `rurl.h` for consistency
+* add rapi sublibrary for communicating with server (eliminates need for client-side JSON parsing; client must still
+  provide HTTP functionality). rurl is now deprecated
+* renamed 'rhash.h' to 'rc_hash.h' to eliminate conflict with system headers, renamed 'rconsoles.h' and 'rurl.h' for 
+  consistency
+* split non-runtime functions out of 'rcheevos.h' as they're not needed by most clients
 * allow ranges in rich presence lookups
+* add rc_richpresence_size_lines function to fetch line associated to error when processing rich presence script
+* add rc_runtime_invalidate_address function to disable achievements when an unknown address is queried
 * add RC_CONDITION_RESET_NEXT_IF
 * add RC_CONDITION_SUB_HITS
-* support MAXOF($) for leaderboard values using trigger syntax
+* support MAXOF operator ($) for leaderboard values using trigger syntax
 * allow RC_CONDITION_PAUSE_IF and RC_CONDITION_RESET_IF in leaderboard value expression
 * changed track parameter of rc_hash_cdreader_open_track_handler to support three virtual tracks:
   RC_HASH_CDTRACK_FIRST_DATA, RC_HASH_CDTRACK_LAST and RC_HASH_CDTRACK_LARGEST.
+* changed offset parameter of rc_hash_filereader_seek_handler and return value of rc_hash_filereader_tell_handler
+  from size_t to int64_t to support files larger than 2GB when compiling in 32-bit mode.
 * reset to default cd reader if NULL is passed to rc_hash_init_custom_cdreader
-* add hash support for RC_CONSOLE_DREAMCAST
-* ignore headers for RC_CONSOLE_PC_ENGINE
-* look for unique identifier in RC_CONSOLE_SEGA_CD and RC_CONSOLE_SATURN discs
+* add hash support for RC_CONSOLE_DREAMCAST, RC_CONSOLE_PLAYSTATION_2, RC_CONSOLE_SUPERVISION, and RC_CONSOLE_TIC80
+* ignore headers when generating hashs for RC_CONSOLE_PC_ENGINE and RC_CONSOLE_ATARI_7800
+* require unique identifier when hashing RC_CONSOLE_SEGA_CD and RC_CONSOLE_SATURN discs
+* add expansion memory to RC_CONSOLE_SG1000 memory map
 * rename RC_CONSOLE_MAGNAVOX_ODYSSEY -> RC_CONSOLE_MAGNAVOX_ODYSSEY2
 * rename RC_CONSOLE_AMIGA_ST -> RC_CONSOLE_ATARI_ST
+* add RC_CONSOLE_SUPERVISION, RC_CONSOLE_SHARPX1, RC_CONSOLE_TIC80, RC_CONSOLE_THOMSONTO8
 * fix error identifying largest track when track has multiple bins
 * fix memory corruption error when cue track has more than 6 INDEXs
 * several improvements to data storage for conditions (rc_memref_t and rc_memref_value_t structures have been modified)

--- a/include/rc_api_runtime.h
+++ b/include/rc_api_runtime.h
@@ -78,7 +78,7 @@ rc_api_fetch_game_data_request_t;
 
 /* A leaderboard definition */
 typedef struct rc_api_leaderboard_definition_t {
-  /* The unique identified of the leaderboard */
+  /* The unique identifier of the leaderboard */
   unsigned id;
   /* The format to pass to rc_format_value to format the leaderboard value */
   int format;

--- a/src/rapi/rc_api_common.h
+++ b/src/rapi/rc_api_common.h
@@ -59,7 +59,8 @@ void rc_url_builder_append_num_param(rc_api_url_builder_t* builder, const char* 
 void rc_url_builder_append_unum_param(rc_api_url_builder_t* builder, const char* param, unsigned value);
 void rc_url_builder_append_str_param(rc_api_url_builder_t* builder, const char* param, const char* value);
 
-void rc_api_url_build_dorequest(rc_api_url_builder_t* builder, rc_api_buffer_t* buffer, const char* api, const char* username);
+void rc_api_url_build_dorequest_url(rc_api_request_t* request);
+int rc_api_url_build_dorequest(rc_api_url_builder_t* builder, const char* api, const char* username, const char* api_token);
 void rc_api_generate_checksum(char checksum[33], const char* data);
 
 #ifdef __cplusplus

--- a/test/rapi/test_rc_api_common.c
+++ b/test/rapi/test_rc_api_common.c
@@ -352,52 +352,36 @@ static void test_json_get_unum_array_trailing_comma() {
   assert_json_parse_response(&response, &field, "{\"Test\":[1,2,3,]}", RC_INVALID_JSON);
 }
 
-static void test_url_build_dorequest_default_host() {
-  rc_api_url_builder_t builder;
-  rc_api_buffer_t buffer;
-  const char* url;
+static void test_url_build_dorequest_url_default_host() {
+  rc_api_request_t request;
+  rc_api_url_build_dorequest_url(&request);
+  ASSERT_STR_EQUALS(request.url, "https://retroachievements.org/dorequest.php");
 
-  rc_buf_init(&buffer);
-  rc_api_url_build_dorequest(&builder, &buffer, "login", "Username");
-  url = rc_url_builder_finalize(&builder);
-
-  ASSERT_STR_EQUALS(url, "https://retroachievements.org/dorequest.php?r=login&u=Username");
-
-  rc_buf_destroy(&buffer);
+  rc_api_destroy_request(&request);
 }
 
-static void test_url_build_dorequest_custom_host() {
-  rc_api_url_builder_t builder;
-  rc_api_buffer_t buffer;
-  const char* url;
+static void test_url_build_dorequest_url_custom_host() {
+  rc_api_request_t request;
 
   rc_api_set_host("http://localhost");
+  rc_api_url_build_dorequest_url(&request);
 
-  rc_buf_init(&buffer);
-  rc_api_url_build_dorequest(&builder, &buffer, "test", "Guy");
-  url = rc_url_builder_finalize(&builder);
+  ASSERT_STR_EQUALS(request.url, "http://localhost/dorequest.php");
 
-  ASSERT_STR_EQUALS(url, "http://localhost/dorequest.php?r=test&u=Guy");
-
+  rc_api_destroy_request(&request);
   rc_api_set_host(NULL);
-  rc_buf_destroy(&buffer);
 }
 
-static void test_url_build_dorequest_custom_host_no_protocol() {
-  rc_api_url_builder_t builder;
-  rc_api_buffer_t buffer;
-  const char* url;
+static void test_url_build_dorequest_url_custom_host_no_protocol() {
+  rc_api_request_t request;
 
   rc_api_set_host("my.host");
+  rc_api_url_build_dorequest_url(&request);
 
-  rc_buf_init(&buffer);
-  rc_api_url_build_dorequest(&builder, &buffer, "photo", "Dude");
-  url = rc_url_builder_finalize(&builder);
+  ASSERT_STR_EQUALS(request.url, "http://my.host/dorequest.php");
 
-  ASSERT_STR_EQUALS(url, "http://my.host/dorequest.php?r=photo&u=Dude");
-
+  rc_api_destroy_request(&request);
   rc_api_set_host(NULL);
-  rc_buf_destroy(&buffer);
 }
 
 static void test_url_builder_append_encoded_str(const char* input, const char* expected) {
@@ -618,10 +602,10 @@ void test_rapi_common(void) {
   TEST_PARAMS3(test_json_get_unum_array, "[A,B,C]", 3, RC_MISSING_VALUE);
   TEST(test_json_get_unum_array_trailing_comma);
 
-  /* rc_api_url_build_dorequest / rc_api_set_host */
-  TEST(test_url_build_dorequest_default_host);
-  TEST(test_url_build_dorequest_custom_host);
-  TEST(test_url_build_dorequest_custom_host_no_protocol);
+  /* rc_api_url_build_dorequest_url / rc_api_set_host */
+  TEST(test_url_build_dorequest_url_default_host);
+  TEST(test_url_build_dorequest_url_custom_host);
+  TEST(test_url_build_dorequest_url_custom_host_no_protocol);
 
   /* rc_api_url_builder_append_encoded_str */
   TEST_PARAMS2(test_url_builder_append_encoded_str, "", "");

--- a/test/rapi/test_rc_api_runtime.c
+++ b/test/rapi/test_rc_api_runtime.c
@@ -16,8 +16,8 @@ static void test_init_resolve_hash_request() {
   resolve_hash_request.game_hash = "ABCDEF0123456789";
 
   ASSERT_NUM_EQUALS(rc_api_init_resolve_hash_request(&request, &resolve_hash_request), RC_OK);
-  ASSERT_STR_EQUALS(request.url, DOREQUEST_URL "?r=gameid&u=Username&m=ABCDEF0123456789");
-  ASSERT_STR_EQUALS(request.post_data, "t=API_TOKEN");
+  ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
+  ASSERT_STR_EQUALS(request.post_data, "r=gameid&u=Username&t=API_TOKEN&m=ABCDEF0123456789");
 
   rc_api_destroy_request(&request);
 }
@@ -87,8 +87,8 @@ static void test_init_fetch_game_data_request() {
   fetch_game_data_request.game_id = 1234;
 
   ASSERT_NUM_EQUALS(rc_api_init_fetch_game_data_request(&request, &fetch_game_data_request), RC_OK);
-  ASSERT_STR_EQUALS(request.url, DOREQUEST_URL "?r=patch&u=Username&g=1234");
-  ASSERT_STR_EQUALS(request.post_data, "t=API_TOKEN");
+  ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
+  ASSERT_STR_EQUALS(request.post_data, "r=patch&u=Username&t=API_TOKEN&g=1234");
 
   rc_api_destroy_request(&request);
 }
@@ -324,8 +324,8 @@ static void test_init_ping_request() {
   ping_request.game_id = 1234;
 
   ASSERT_NUM_EQUALS(rc_api_init_ping_request(&request, &ping_request), RC_OK);
-  ASSERT_STR_EQUALS(request.url, DOREQUEST_URL "?r=ping&u=Username&g=1234");
-  ASSERT_STR_EQUALS(request.post_data, "t=API_TOKEN");
+  ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
+  ASSERT_STR_EQUALS(request.post_data, "r=ping&u=Username&t=API_TOKEN&g=1234");
 
   rc_api_destroy_request(&request);
 }
@@ -354,8 +354,8 @@ static void test_init_ping_request_rich_presence() {
   ping_request.rich_presence = "Level 1, 70% complete";
 
   ASSERT_NUM_EQUALS(rc_api_init_ping_request(&request, &ping_request), RC_OK);
-  ASSERT_STR_EQUALS(request.url, DOREQUEST_URL "?r=ping&u=Username&g=1234");
-  ASSERT_STR_EQUALS(request.post_data, "t=API_TOKEN&m=Level+1%2c+70%25+complete");
+  ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
+  ASSERT_STR_EQUALS(request.post_data, "r=ping&u=Username&t=API_TOKEN&g=1234&m=Level+1%2c+70%25+complete");
 
   rc_api_destroy_request(&request);
 }
@@ -371,8 +371,8 @@ static void test_init_ping_request_rich_presence_unicode() {
   ping_request.rich_presence = "\xf0\x9f\x9a\xb6:3, 1st Quest";
 
   ASSERT_NUM_EQUALS(rc_api_init_ping_request(&request, &ping_request), RC_OK);
-  ASSERT_STR_EQUALS(request.url, DOREQUEST_URL "?r=ping&u=Username&g=1446");
-  ASSERT_STR_EQUALS(request.post_data, "t=API_TOKEN&m=%f0%9f%9a%b6%3a3%2c+1st+Quest");
+  ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
+  ASSERT_STR_EQUALS(request.post_data, "r=ping&u=Username&t=API_TOKEN&g=1446&m=%f0%9f%9a%b6%3a3%2c+1st+Quest");
 
   rc_api_destroy_request(&request);
 }
@@ -388,8 +388,8 @@ static void test_init_ping_request_rich_presence_empty() {
   ping_request.rich_presence = "";
 
   ASSERT_NUM_EQUALS(rc_api_init_ping_request(&request, &ping_request), RC_OK);
-  ASSERT_STR_EQUALS(request.url, DOREQUEST_URL "?r=ping&u=Username&g=1234");
-  ASSERT_STR_EQUALS(request.post_data, "t=API_TOKEN");
+  ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
+  ASSERT_STR_EQUALS(request.post_data, "r=ping&u=Username&t=API_TOKEN&g=1234");
 
   rc_api_destroy_request(&request);
 }
@@ -419,8 +419,8 @@ static void test_init_award_achievement_request_hardcore() {
   award_achievement_request.game_hash = "ABCDEF0123456789";
 
   ASSERT_NUM_EQUALS(rc_api_init_award_achievement_request(&request, &award_achievement_request), RC_OK);
-  ASSERT_STR_EQUALS(request.url, DOREQUEST_URL "?r=awardachievement&u=Username&a=1234&h=1&m=ABCDEF0123456789");
-  ASSERT_STR_EQUALS(request.post_data, "t=API_TOKEN&v=b8aefaad6f9659e2164bc60da0c3b64d");
+  ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
+  ASSERT_STR_EQUALS(request.post_data, "r=awardachievement&u=Username&t=API_TOKEN&a=1234&h=1&m=ABCDEF0123456789&v=b8aefaad6f9659e2164bc60da0c3b64d");
 
   rc_api_destroy_request(&request);
 }
@@ -437,8 +437,8 @@ static void test_init_award_achievement_request_non_hardcore() {
   award_achievement_request.game_hash = "ABABCBCBDEDEFFFF";
 
   ASSERT_NUM_EQUALS(rc_api_init_award_achievement_request(&request, &award_achievement_request), RC_OK);
-  ASSERT_STR_EQUALS(request.url, DOREQUEST_URL "?r=awardachievement&u=Username&a=1234&h=0&m=ABABCBCBDEDEFFFF");
-  ASSERT_STR_EQUALS(request.post_data, "t=API_TOKEN&v=ed81d6ecf825f8cbe3ae1edace098892");
+  ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
+  ASSERT_STR_EQUALS(request.post_data, "r=awardachievement&u=Username&t=API_TOKEN&a=1234&h=0&m=ABABCBCBDEDEFFFF&v=ed81d6ecf825f8cbe3ae1edace098892");
 
   rc_api_destroy_request(&request);
 }
@@ -454,8 +454,8 @@ static void test_init_award_achievement_request_no_hash() {
   award_achievement_request.hardcore = 1;
 
   ASSERT_NUM_EQUALS(rc_api_init_award_achievement_request(&request, &award_achievement_request), RC_OK);
-  ASSERT_STR_EQUALS(request.url, DOREQUEST_URL "?r=awardachievement&u=Username&a=5432&h=1");
-  ASSERT_STR_EQUALS(request.post_data, "t=API_TOKEN&v=31048257ab1788386e71ab0c222aa5c8");
+  ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
+  ASSERT_STR_EQUALS(request.post_data, "r=awardachievement&u=Username&t=API_TOKEN&a=5432&h=1&v=31048257ab1788386e71ab0c222aa5c8");
 
   rc_api_destroy_request(&request);
 }
@@ -592,8 +592,8 @@ static void test_init_submit_lboard_entry_request() {
   submit_lboard_entry_request.game_hash = "ABCDEF0123456789";
 
   ASSERT_NUM_EQUALS(rc_api_init_submit_lboard_entry_request(&request, &submit_lboard_entry_request), RC_OK);
-  ASSERT_STR_EQUALS(request.url, DOREQUEST_URL "?r=submitlbentry&u=Username&i=1234&s=10999&m=ABCDEF0123456789");
-  ASSERT_STR_EQUALS(request.post_data, "t=API_TOKEN&v=e13c9132ee651256f9d2ee8f06f75d76");
+  ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
+  ASSERT_STR_EQUALS(request.post_data, "r=submitlbentry&u=Username&t=API_TOKEN&i=1234&s=10999&m=ABCDEF0123456789&v=e13c9132ee651256f9d2ee8f06f75d76");
 
   rc_api_destroy_request(&request);
 }
@@ -610,8 +610,8 @@ static void test_init_submit_lboard_entry_request_zero_value() {
   submit_lboard_entry_request.game_hash = "ABCDEF0123456789";
 
   ASSERT_NUM_EQUALS(rc_api_init_submit_lboard_entry_request(&request, &submit_lboard_entry_request), RC_OK);
-  ASSERT_STR_EQUALS(request.url, DOREQUEST_URL "?r=submitlbentry&u=Username&i=1111&s=0&m=ABCDEF0123456789");
-  ASSERT_STR_EQUALS(request.post_data, "t=API_TOKEN&v=9c2ac665157d68b8a26e83bb71dd8aaf");
+  ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
+  ASSERT_STR_EQUALS(request.post_data, "r=submitlbentry&u=Username&t=API_TOKEN&i=1111&s=0&m=ABCDEF0123456789&v=9c2ac665157d68b8a26e83bb71dd8aaf");
 
   rc_api_destroy_request(&request);
 }
@@ -628,8 +628,8 @@ static void test_init_submit_lboard_entry_request_negative_value() {
   submit_lboard_entry_request.game_hash = "ABCDEF0123456789";
 
   ASSERT_NUM_EQUALS(rc_api_init_submit_lboard_entry_request(&request, &submit_lboard_entry_request), RC_OK);
-  ASSERT_STR_EQUALS(request.url, DOREQUEST_URL "?r=submitlbentry&u=Username&i=1111&s=-234781&m=ABCDEF0123456789");
-  ASSERT_STR_EQUALS(request.post_data, "t=API_TOKEN&v=fbe290266f2d121a7a37942e1e90f453");
+  ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
+  ASSERT_STR_EQUALS(request.post_data, "r=submitlbentry&u=Username&t=API_TOKEN&i=1111&s=-234781&m=ABCDEF0123456789&v=fbe290266f2d121a7a37942e1e90f453");
 
   rc_api_destroy_request(&request);
 }

--- a/test/rapi/test_rc_api_user.c
+++ b/test/rapi/test_rc_api_user.c
@@ -16,8 +16,8 @@ static void test_init_start_session_request()
   start_session_request.game_id = 1234;
 
   ASSERT_NUM_EQUALS(rc_api_init_start_session_request(&request, &start_session_request), RC_OK);
-  ASSERT_STR_EQUALS(request.url, DOREQUEST_URL "?r=postactivity&u=Username&a=3&m=1234");
-  ASSERT_STR_EQUALS(request.post_data, "t=API_TOKEN");
+  ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
+  ASSERT_STR_EQUALS(request.post_data,  "r=postactivity&u=Username&t=API_TOKEN&a=3&m=1234");
 
   rc_api_destroy_request(&request);
 }
@@ -60,32 +60,30 @@ static void test_init_login_request_password()
   login_request.password = "Pa$$w0rd!";
 
   ASSERT_NUM_EQUALS(rc_api_init_login_request(&request, &login_request), RC_OK);
-  ASSERT_STR_EQUALS(request.url, DOREQUEST_URL "?r=login&u=Username");
-  ASSERT_STR_EQUALS(request.post_data, "p=Pa%24%24w0rd%21");
+  ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
+  ASSERT_STR_EQUALS(request.post_data, "r=login&u=Username&p=Pa%24%24w0rd%21");
 
   rc_api_destroy_request(&request);
 }
 
 static void test_init_login_request_password_long()
 {
-  char buffer[1024], *ptr;
+  char buffer[1024], *ptr, *password_start;
   rc_api_login_request_t login_request;
   rc_api_request_t request;
   int i;
 
   /* this generates a password that's 830 characters long */
-  buffer[0] = 'p';
-  buffer[1] = '=';
-  ptr = &buffer[2];
+  ptr = password_start = buffer + snprintf(buffer, sizeof(buffer), "r=login&u=ThisUsernameIsAlsoReallyLongAtRoughlyFiftyCharacters&p=");
   for (i = 0; i < 30; i++)
 	ptr += snprintf(ptr, sizeof(buffer) - (ptr - buffer), "%dABCDEFGHIJKLMNOPQRSTUVWXYZ", i);
 
   memset(&login_request, 0, sizeof(login_request));
   login_request.username = "ThisUsernameIsAlsoReallyLongAtRoughlyFiftyCharacters";
-  login_request.password = &buffer[2];
+  login_request.password = password_start;
 
   ASSERT_NUM_EQUALS(rc_api_init_login_request(&request, &login_request), RC_OK);
-  ASSERT_STR_EQUALS(request.url, DOREQUEST_URL "?r=login&u=ThisUsernameIsAlsoReallyLongAtRoughlyFiftyCharacters");
+  ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
   ASSERT_STR_EQUALS(request.post_data, buffer);
 
   rc_api_destroy_request(&request);
@@ -101,8 +99,8 @@ static void test_init_login_request_token()
   login_request.api_token = "ABCDEFGHIJKLMNOP";
 
   ASSERT_NUM_EQUALS(rc_api_init_login_request(&request, &login_request), RC_OK);
-  ASSERT_STR_EQUALS(request.url, DOREQUEST_URL "?r=login&u=Username");
-  ASSERT_STR_EQUALS(request.post_data, "t=ABCDEFGHIJKLMNOP");
+  ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
+  ASSERT_STR_EQUALS(request.post_data, "r=login&u=Username&t=ABCDEFGHIJKLMNOP");
 
   rc_api_destroy_request(&request);
 }
@@ -118,8 +116,8 @@ static void test_init_login_request_password_and_token()
   login_request.api_token = "ABCDEFGHIJKLMNOP";
 
   ASSERT_NUM_EQUALS(rc_api_init_login_request(&request, &login_request), RC_OK);
-  ASSERT_STR_EQUALS(request.url, DOREQUEST_URL "?r=login&u=Username");
-  ASSERT_STR_EQUALS(request.post_data, "p=Pa%24%24w0rd%21");
+  ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
+  ASSERT_STR_EQUALS(request.post_data, "r=login&u=Username&p=Pa%24%24w0rd%21");
 
   rc_api_destroy_request(&request);
 }
@@ -148,8 +146,8 @@ static void test_init_login_request_alternate_host()
 
   rc_api_set_host("localhost");
   ASSERT_NUM_EQUALS(rc_api_init_login_request(&request, &login_request), RC_OK);
-  ASSERT_STR_EQUALS(request.url, "http://localhost/dorequest.php?r=login&u=Username");
-  ASSERT_STR_EQUALS(request.post_data, "p=Pa%24%24w0rd%21");
+  ASSERT_STR_EQUALS(request.url, "http://localhost/dorequest.php");
+  ASSERT_STR_EQUALS(request.post_data, "r=login&u=Username&p=Pa%24%24w0rd%21");
 
   rc_api_set_host(NULL);
   rc_api_destroy_request(&request);
@@ -347,8 +345,8 @@ static void test_init_fetch_user_unlocks_request_non_hardcore()
   fetch_user_unlocks_request.hardcore = 0;
 
   ASSERT_NUM_EQUALS(rc_api_init_fetch_user_unlocks_request(&request, &fetch_user_unlocks_request), RC_OK);
-  ASSERT_STR_EQUALS(request.url, DOREQUEST_URL "?r=unlocks&u=Username&g=1234&h=0");
-  ASSERT_STR_EQUALS(request.post_data, "t=API_TOKEN");
+  ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
+  ASSERT_STR_EQUALS(request.post_data, "r=unlocks&u=Username&t=API_TOKEN&g=1234&h=0");
 
   rc_api_destroy_request(&request);
 }
@@ -365,8 +363,8 @@ static void test_init_fetch_user_unlocks_request_hardcore()
   fetch_user_unlocks_request.hardcore = 1;
 
   ASSERT_NUM_EQUALS(rc_api_init_fetch_user_unlocks_request(&request, &fetch_user_unlocks_request), RC_OK);
-  ASSERT_STR_EQUALS(request.url, DOREQUEST_URL "?r=unlocks&u=Username&g=2345&h=1");
-  ASSERT_STR_EQUALS(request.post_data, "t=API_TOKEN");
+  ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
+  ASSERT_STR_EQUALS(request.post_data, "r=unlocks&u=Username&t=API_TOKEN&g=2345&h=1");
 
   rc_api_destroy_request(&request);
 }


### PR DESCRIPTION
extension of #120 

Our server guy suggested that using both URL parameters and POST data in a single request is not a good practice. This moves all of the URL parameters into the POST data.