### PR TITLE
address return-local-addr warnings

### DIFF
--- a/src/rcheevos/lboard.c
+++ b/src/rcheevos/lboard.c
@@ -153,6 +153,10 @@ int rc_lboard_size(const char* memaddr) {
 rc_lboard_t* rc_parse_lboard(void* buffer, const char* memaddr, lua_State* L, int funcs_ndx) {
   rc_lboard_t* self;
   rc_parse_state_t parse;
+
+  if (!buffer || !memaddr)
+    return 0;
+
   rc_init_parse_state(&parse, buffer, L, funcs_ndx);
 
   self = RC_ALLOC(rc_lboard_t, &parse);
@@ -161,7 +165,7 @@ rc_lboard_t* rc_parse_lboard(void* buffer, const char* memaddr, lua_State* L, in
   rc_parse_lboard_internal(self, memaddr, &parse);
 
   rc_destroy_parse_state(&parse);
-  return parse.offset >= 0 ? self : 0;
+  return (parse.offset >= 0) ? self : 0;
 }
 
 int rc_evaluate_lboard(rc_lboard_t* self, int* value, rc_peek_t peek, void* peek_ud, lua_State* L) {

--- a/src/rcheevos/richpresence.c
+++ b/src/rcheevos/richpresence.c
@@ -591,6 +591,10 @@ int rc_richpresence_size(const char* script) {
 rc_richpresence_t* rc_parse_richpresence(void* buffer, const char* script, lua_State* L, int funcs_ndx) {
   rc_richpresence_t* self;
   rc_parse_state_t parse;
+
+  if (!buffer || !script)
+    return NULL;
+
   rc_init_parse_state(&parse, buffer, L, funcs_ndx);
 
   self = RC_ALLOC(rc_richpresence_t, &parse);
@@ -600,7 +604,7 @@ rc_richpresence_t* rc_parse_richpresence(void* buffer, const char* script, lua_S
   rc_parse_richpresence_internal(self, script, &parse);
 
   rc_destroy_parse_state(&parse);
-  return parse.offset >= 0 ? self : 0;
+  return (parse.offset >= 0) ? self : NULL;
 }
 
 void rc_update_richpresence(rc_richpresence_t* richpresence, rc_peek_t peek, void* peek_ud, lua_State* L) {

--- a/src/rcheevos/trigger.c
+++ b/src/rcheevos/trigger.c
@@ -65,6 +65,10 @@ int rc_trigger_size(const char* memaddr) {
 rc_trigger_t* rc_parse_trigger(void* buffer, const char* memaddr, lua_State* L, int funcs_ndx) {
   rc_trigger_t* self;
   rc_parse_state_t parse;
+
+  if (!buffer || !memaddr)
+    return NULL;
+
   rc_init_parse_state(&parse, buffer, L, funcs_ndx);
 
   self = RC_ALLOC(rc_trigger_t, &parse);
@@ -73,7 +77,7 @@ rc_trigger_t* rc_parse_trigger(void* buffer, const char* memaddr, lua_State* L, 
   rc_parse_trigger_internal(self, &memaddr, &parse);
 
   rc_destroy_parse_state(&parse);
-  return parse.offset >= 0 ? self : 0;
+  return (parse.offset >= 0) ? self : NULL;
 }
 
 static void rc_reset_trigger_hitcounts(rc_trigger_t* self) {

--- a/src/rcheevos/value.c
+++ b/src/rcheevos/value.c
@@ -171,6 +171,10 @@ int rc_value_size(const char* memaddr) {
 rc_value_t* rc_parse_value(void* buffer, const char* memaddr, lua_State* L, int funcs_ndx) {
   rc_value_t* self;
   rc_parse_state_t parse;
+
+  if (!buffer || !memaddr)
+    return NULL;
+
   rc_init_parse_state(&parse, buffer, L, funcs_ndx);
 
   self = RC_ALLOC(rc_value_t, &parse);
@@ -179,7 +183,7 @@ rc_value_t* rc_parse_value(void* buffer, const char* memaddr, lua_State* L, int 
   rc_parse_value_internal(self, &memaddr, &parse);
 
   rc_destroy_parse_state(&parse);
-  return parse.offset >= 0 ? self : 0;
+  return (parse.offset >= 0) ? self : NULL;
 }
 
 int rc_evaluate_value(rc_value_t* self, rc_peek_t peek, void* ud, lua_State* L) {


### PR DESCRIPTION
Addresses some warnings caught by the RetroArch CI (https://github.com/libretro/RetroArch/pull/12256)