### PR TITLE
RESET is not a trigger state

### DIFF
--- a/test/rcheevos/test_value.c
+++ b/test/rcheevos/test_value.c
@@ -176,6 +176,7 @@ void test_value(void) {
 
   TEST_PARAMS2(test_evaluate_value, "0xH01*4", 0x12 * 4); /* multiply by constant */
   TEST_PARAMS2(test_evaluate_value, "0xH01*0.5", 0x12 / 2); /* multiply by fraction */
+  TEST_PARAMS2(test_evaluate_value, "0xH01/2", 0x12 / 2); /* divide by constant */
   TEST_PARAMS2(test_evaluate_value, "0xH01*0xH02", 0x12 * 0x34); /* multiply by second address */
   TEST_PARAMS2(test_evaluate_value, "0xH01*0xT02", 0); /* multiply by bit */
   TEST_PARAMS2(test_evaluate_value, "0xH01*~0xT02", 0x12); /* multiply by inverse bit */


### PR DESCRIPTION
The logic added for #134 to detect trigger state changes was seeing the RESET notification as a state change, and UNPRIMEing the trigger. This corrects for that. When `rc_evaluate_trigger` returns RESET, a RESET event is fired, then the current state is pulled out of the trigger for detecting a change in state.