### PR TITLE
add rc_runtime_validate_addresses

### DIFF
--- a/include/rc_runtime.h
+++ b/include/rc_runtime.h
@@ -130,6 +130,9 @@ typedef void (*rc_runtime_event_handler_t)(const rc_runtime_event_t* runtime_eve
 
 void rc_runtime_do_frame(rc_runtime_t* runtime, rc_runtime_event_handler_t event_handler, rc_runtime_peek_t peek, void* ud, lua_State* L);
 void rc_runtime_reset(rc_runtime_t* runtime);
+
+typedef int (*rc_runtime_validate_address_t)(unsigned address);
+void rc_runtime_validate_addresses(rc_runtime_t* runtime, rc_runtime_event_handler_t event_handler, rc_runtime_validate_address_t validate_handler);
 void rc_runtime_invalidate_address(rc_runtime_t* runtime, unsigned address);
 
 int rc_runtime_progress_size(const rc_runtime_t* runtime, lua_State* L);

--- a/src/rcheevos/rc_libretro.c
+++ b/src/rcheevos/rc_libretro.c
@@ -360,8 +360,8 @@ static void rc_libretro_memory_init_from_memory_map(rc_libretro_memory_regions_t
         break;
       }
 
-      snprintf(description, sizeof(description), "descriptor %u, offset 0x%06X",
-               (unsigned)(desc - mmap->descriptors) + 1, (int)offset);
+      snprintf(description, sizeof(description), "descriptor %u, offset 0x%06X%s",
+               (unsigned)(desc - mmap->descriptors) + 1, (int)offset, desc->ptr ? "" : " [no pointer]");
 
       if (desc->ptr) {
         desc_start = (uint8_t*)desc->ptr + desc->offset;

--- a/src/rcheevos/runtime.c
+++ b/src/rcheevos/runtime.c
@@ -667,32 +667,8 @@ static int rc_trigger_contains_memref(const rc_trigger_t* trigger, const rc_memr
   return 0;
 }
 
-void rc_runtime_invalidate_address(rc_runtime_t* self, unsigned address) {
+static void rc_runtime_invalidate_memref(rc_runtime_t* self, rc_memref_t* memref) {
   unsigned i;
-  rc_memref_t* memref;
-  rc_memref_t** last_memref;
-
-  if (!self->memrefs)
-    return;
-
-  /* remove the invalid memref from the chain so we don't try to evaluate it in the future.
-   * it's still there, so anything referencing it will continue to fetch 0.
-   */
-  last_memref = &self->memrefs;
-  memref = *last_memref;
-  do {
-    if (memref->address == address && !memref->value.is_indirect) {
-      *last_memref = memref->next;
-      break;
-    }
-
-    last_memref = &memref->next;
-    memref = *last_memref;
-  } while (memref);
-
-  /* if the address is only used indirectly, don't disable anything dependent on it */
-  if (!memref)
-    return;
 
   /* disable any achievements dependent on the address */
   for (i = 0; i < self->trigger_count; ++i) {
@@ -722,6 +698,83 @@ void rc_runtime_invalidate_address(rc_runtime_t* self, unsigned address) {
 
         if (rc_value_contains_memref(&lboard->value, memref))
           self->lboards[i].invalid_memref = memref;
+      }
+    }
+  }
+}
+
+void rc_runtime_invalidate_address(rc_runtime_t* self, unsigned address) {
+  rc_memref_t** last_memref = &self->memrefs;
+  rc_memref_t* memref = self->memrefs;
+
+  while (memref) {
+    if (memref->address == address && !memref->value.is_indirect) {
+      /* remove the invalid memref from the chain so we don't try to evaluate it in the future.
+       * it's still there, so anything referencing it will continue to fetch 0.
+       */
+      *last_memref = memref->next;
+
+      rc_runtime_invalidate_memref(self, memref);
+      break;
+    }
+
+    last_memref = &memref->next;
+    memref = *last_memref;
+  }
+}
+
+void rc_runtime_validate_addresses(rc_runtime_t* self, rc_runtime_event_handler_t event_handler, 
+    rc_runtime_validate_address_t validate_handler) {
+  rc_memref_t** last_memref = &self->memrefs;
+  rc_memref_t* memref = self->memrefs;
+  int num_invalid = 0;
+
+  while (memref) {
+    if (!memref->value.is_indirect && !validate_handler(memref->address)) {
+      /* remove the invalid memref from the chain so we don't try to evaluate it in the future.
+       * it's still there, so anything referencing it will continue to fetch 0.
+       */
+      *last_memref = memref->next;
+
+      rc_runtime_invalidate_memref(self, memref);
+      ++num_invalid;
+    }
+    else {
+      last_memref = &memref->next;
+    }
+
+    memref = *last_memref;
+  }
+
+  if (num_invalid) {
+    rc_runtime_event_t runtime_event;
+    int i;
+
+    for (i = self->trigger_count - 1; i >= 0; --i) {
+      rc_trigger_t* trigger = self->triggers[i].trigger;
+      if (trigger && self->triggers[i].invalid_memref) {
+        runtime_event.type = RC_RUNTIME_EVENT_ACHIEVEMENT_DISABLED;
+        runtime_event.id = self->triggers[i].id;
+        runtime_event.value = self->triggers[i].invalid_memref->address;
+
+        trigger->state = RC_TRIGGER_STATE_DISABLED;
+        self->triggers[i].invalid_memref = NULL;
+
+        event_handler(&runtime_event);
+      }
+    }
+
+    for (i = self->lboard_count - 1; i >= 0; --i) {
+      rc_lboard_t* lboard = self->lboards[i].lboard;
+      if (lboard && self->lboards[i].invalid_memref) {
+        runtime_event.type = RC_RUNTIME_EVENT_LBOARD_DISABLED;
+        runtime_event.id = self->lboards[i].id;
+        runtime_event.value = self->lboards[i].invalid_memref->address;
+
+        lboard->state = RC_LBOARD_STATE_DISABLED;
+        self->lboards[i].invalid_memref = NULL;
+
+        event_handler(&runtime_event);
       }
     }
   }

--- a/src/rurl/url.c
+++ b/src/rurl/url.c
@@ -298,7 +298,7 @@ static int rc_url_append_unum(char* buffer, size_t buffer_size, size_t* buffer_o
   int written = rc_url_append_param_equals(buffer, buffer_size, *buffer_offset, param);
   if (written > 0) {
     char num[16];
-    int chars = sprintf(num, "%u", value);
+    int chars = snprintf(num, sizeof(num), "%u", value);
 
     if (chars + written < (int)buffer_size)
     {

--- a/test/rcheevos/test_runtime.c
+++ b/test/rcheevos/test_runtime.c
@@ -1135,12 +1135,7 @@ static int validate_address_handler(unsigned address)
 
 static void test_validate_addresses(void)
 {
-  unsigned char ram[] = { 0, 10, 10 };
-  memory_invalid_t memory;
   rc_runtime_t runtime;
-
-  memory.memory.ram = ram;
-  memory.memory.size = sizeof(ram);
 
   rc_runtime_init(&runtime);
   event_count = 0;


### PR DESCRIPTION
Provides a new function to quickly validate addresses used by all achievements in the runtime and immediately disable them. Can be passed the same callback as `rc_runtime_do_frame`, so the `RC_RUNTIME_EVENT_ACHIEVEMENT_DISABLED` event can be handled in a generic way.

The existing functionality of calling `rc_runtime_invalidate_address` on an invalid peek was not sufficient for identifying unsupported achievements in RetroArch, as the peek would not occur until after the runtime starts processing frames. It is desirable to disable them immediately so we can report the number of disabled achievements to the user.

The attempt to traverse the memref collection and call `rc_runtime_invalidate_address` was insufficient as no feedback was provided on which achievements were using the invalidated memrefs. The `RC_RUNTIME_EVENT_ACHIEVEMENT_DISABLED` event still did not occur until the first call to `rc_runtime_do_frame`. To address that, the current RetroArch traverses the memref collection to find invalid addresses, then traverses the achievement conditions to find triggers dependent on those memrefs and calls `rc_runtime_disable_achievement`. This puts a lot more knowledge about the runtime structures into RetroArch than is necessary, and ends up duplicating some code for traversing the achievement conditions.