### PR TITLE
add address validation to validator

### DIFF
--- a/validator/Makefile
+++ b/validator/Makefile
@@ -6,6 +6,7 @@ LUA_SRC=../test/lua/src
 OBJ=$(RC_SRC)/trigger.o $(RC_SRC)/condset.o $(RC_SRC)/condition.o $(RC_SRC)/operand.o \
     $(RC_SRC)/value.o $(RC_SRC)/lboard.o $(RC_SRC)/richpresence.o $(RC_SRC)/runtime.o \
     $(RC_SRC)/alloc.o $(RC_SRC)/memref.o $(RC_SRC)/format.o $(RC_SRC)/compat.o  \
+    $(RC_SRC)/consoleinfo.o \
     $(RC_HASH_SRC)/md5.o \
     $(RC_API_SRC)/rc_api_common.o $(RC_API_SRC)/rc_api_runtime.o \
     $(LUA_SRC)/lapi.o $(LUA_SRC)/lcode.o $(LUA_SRC)/lctype.o $(LUA_SRC)/ldebug.o \

--- a/validator/validator.vcxproj
+++ b/validator/validator.vcxproj
@@ -132,6 +132,7 @@
     <ClCompile Include="..\src\rcheevos\compat.c" />
     <ClCompile Include="..\src\rcheevos\condition.c" />
     <ClCompile Include="..\src\rcheevos\condset.c" />
+    <ClCompile Include="..\src\rcheevos\consoleinfo.c" />
     <ClCompile Include="..\src\rcheevos\format.c" />
     <ClCompile Include="..\src\rcheevos\lboard.c" />
     <ClCompile Include="..\src\rcheevos\memref.c" />

--- a/validator/validator.vcxproj.filters
+++ b/validator/validator.vcxproj.filters
@@ -163,6 +163,9 @@
     <ClCompile Include="..\src\rapi\rc_api_common.c">
       <Filter>src\rapi</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\rcheevos\consoleinfo.c">
+      <Filter>src\rcheevos</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\include\rcheevos.h">


### PR DESCRIPTION
detects when an achievement/leaderboard/rich presence script references a memory address not supported by the game's memory map
```
achievement 55957: address 44E2 out of range (max 3FFF)
```