### PR TITLE
replace strtod with locale-independent custom parser

### DIFF
--- a/src/rcheevos/value.c
+++ b/src/rcheevos/value.c
@@ -72,17 +72,14 @@ void rc_parse_legacy_value(rc_value_t* self, const char** memaddr, rc_parse_stat
           *ptr++ = '*';
 
           buffer_ptr = *memaddr + 1;
-          if (*buffer_ptr == '-') {
-            /* negative value automatically needs prefix, 'f' handles both float and digits, so use it */
+          if (*buffer_ptr == '-' || *buffer_ptr == '+')
+            ++buffer_ptr; /* ignore sign */
+
+          /* if it looks like a floating point number, add the 'f' prefix */
+          while (isdigit(*(unsigned char*)buffer_ptr))
+            ++buffer_ptr;
+          if (*buffer_ptr == '.')
             *ptr++ = 'f';
-          }
-          else {
-            /* if it looks like a floating point number, add the 'f' prefix */
-            while (isdigit(*(unsigned char*)buffer_ptr))
-              ++buffer_ptr;
-            if (*buffer_ptr == '.')
-              *ptr++ = 'f';
-          }
           break;
 
         default:

--- a/test/rcheevos/test_operand.c
+++ b/test/rcheevos/test_operand.c
@@ -301,9 +301,12 @@ static void test_parse_float_values() {
   TEST_PARAMS3(test_parse_operand_fp, "f+0.5", RC_OPERAND_FP, 0.5);
   TEST_PARAMS3(test_parse_operand_fp, "f-0.5", RC_OPERAND_FP, -0.5);
   TEST_PARAMS3(test_parse_operand_fp, "f1.0", RC_OPERAND_CONST, 1.0);
+  TEST_PARAMS3(test_parse_operand_fp, "f1.000000", RC_OPERAND_CONST, 1.0);
+  TEST_PARAMS3(test_parse_operand_fp, "f1.000001", RC_OPERAND_FP, 1.000001);
   TEST_PARAMS3(test_parse_operand_fp, "f1", RC_OPERAND_CONST, 1.0);
   TEST_PARAMS3(test_parse_operand_fp, "f0.666666", RC_OPERAND_FP, 0.666666);
   TEST_PARAMS3(test_parse_operand_fp, "f0.001", RC_OPERAND_FP, 0.001);
+  TEST_PARAMS3(test_parse_operand_fp, "f0.100", RC_OPERAND_FP, 0.1);
   TEST_PARAMS3(test_parse_operand_fp, "f.12345", RC_OPERAND_FP, 0.12345);
 
   /* prefix, no value */

--- a/test/rcheevos/test_value.c
+++ b/test/rcheevos/test_value.c
@@ -173,6 +173,8 @@ void test_value(void) {
   TEST_PARAMS2(test_evaluate_value, "0xH001_V-20", 0x12 - 20);
   TEST_PARAMS2(test_evaluate_value, "0xH0001_H10", 0x12 + 0x10);
   TEST_PARAMS2(test_evaluate_value, "0xh0000*-1_99_0xh0001*-100_5900", 4199);
+  TEST_PARAMS2(test_evaluate_value, "v5900_0xh0000*-1.0_0xh0001*-100.0", 4100);
+  TEST_PARAMS2(test_evaluate_value, "v5900_0xh0000*v-1_0xh0001*v-100", 4100);
 
   TEST_PARAMS2(test_evaluate_value, "0xH01*4", 0x12 * 4); /* multiply by constant */
   TEST_PARAMS2(test_evaluate_value, "0xH01*0.5", 0x12 / 2); /* multiply by fraction */


### PR DESCRIPTION
`strtod` parses floats using the current locale. If that locale uses commas for the decimal separator, the floating point value may not be parsed correctly. This replaces the `strtod` call with two integer parses and creates a floating point number from the two parts.

Eliminating the call to `strtod` should also fix an issue that appears to be the inability to handle negative numbers reported [here](https://discord.com/channels/310192285306454017/859938399468388362/860289329221599243).