### PR TITLE
Update console info for PC Engine

### DIFF
--- a/src/rcheevos/consoleinfo.c
+++ b/src/rcheevos/consoleinfo.c
@@ -136,7 +136,7 @@ const char* rc_console_name(int console_id)
       return "PC-FX";
 
     case RC_CONSOLE_PC_ENGINE:
-      return "PCEngine";
+      return "PC Engine";
 
     case RC_CONSOLE_PLAYSTATION:
       return "PlayStation";
@@ -447,13 +447,13 @@ static const rc_memory_regions_t rc_memory_regions_pc8800 = { _rc_memory_regions
 
 /* ===== PC Engine ===== */
 /* http://www.archaicpixels.com/Memory_Map */
-static const rc_memory_region_t _rc_memory_regions_pcengine[] = {
+static const rc_memory_region_t _rc_memory_regions_pc_engine[] = {
     { 0x000000U, 0x001FFFU, 0x1F0000U, RC_MEMORY_TYPE_SYSTEM_RAM, "System RAM" },
     { 0x002000U, 0x011FFFU, 0x100000U, RC_MEMORY_TYPE_SYSTEM_RAM, "CD RAM" },
     { 0x012000U, 0x041FFFU, 0x0D0000U, RC_MEMORY_TYPE_SYSTEM_RAM, "Super System Card RAM" },
     { 0x042000U, 0x0427FFU, 0x1EE000U, RC_MEMORY_TYPE_SAVE_RAM,   "CD Battery-backed RAM" }
 };
-static const rc_memory_regions_t rc_memory_regions_pcengine = { _rc_memory_regions_pcengine, 4 };
+static const rc_memory_regions_t rc_memory_regions_pc_engine = { _rc_memory_regions_pc_engine, 4 };
 
 /* ===== PC-FX ===== */
 /* http://daifukkat.su/pcfx/data/memmap.html */
@@ -679,7 +679,7 @@ const rc_memory_regions_t* rc_console_memory_regions(int console_id)
       return &rc_memory_regions_pc8800;
 
     case RC_CONSOLE_PC_ENGINE:
-      return &rc_memory_regions_pcengine;
+      return &rc_memory_regions_pc_engine;
 
     case RC_CONSOLE_PCFX:
       return &rc_memory_regions_pcfx;

--- a/test/rcheevos/test_consoleinfo.c
+++ b/test/rcheevos/test_consoleinfo.c
@@ -46,7 +46,7 @@ void test_consoleinfo(void) {
   TEST_PARAMS2(test_name,  5, "GameBoy Advance");
   TEST_PARAMS2(test_name,  6, "GameBoy Color");
   TEST_PARAMS2(test_name,  7, "Nintendo Entertainment System");
-  TEST_PARAMS2(test_name,  8, "PCEngine");
+  TEST_PARAMS2(test_name,  8, "PC Engine");
   TEST_PARAMS2(test_name,  9, "Sega CD");
   TEST_PARAMS2(test_name, 10, "Sega 32X");
   TEST_PARAMS2(test_name, 11, "Master System");


### PR DESCRIPTION
Just adding a space since I've never seen it stylized as "PCEngine" anywhere.