### PR TITLE
improve error messages for malformed leaderboards

### DIFF
--- a/src/rcheevos/lboard.c
+++ b/src/rcheevos/lboard.c
@@ -29,10 +29,6 @@ void rc_parse_lboard_internal(rc_lboard_t* self, const char* memaddr, rc_parse_s
       memaddr += 4;
       rc_parse_trigger_internal(&self->start, &memaddr, parse);
       self->start.memrefs = 0;
-
-      if (parse->offset < 0) {
-        return;
-      }
     }
     else if ((memaddr[0] == 'c' || memaddr[0] == 'C') &&
              (memaddr[1] == 'a' || memaddr[1] == 'A') &&
@@ -46,10 +42,6 @@ void rc_parse_lboard_internal(rc_lboard_t* self, const char* memaddr, rc_parse_s
       memaddr += 4;
       rc_parse_trigger_internal(&self->cancel, &memaddr, parse);
       self->cancel.memrefs = 0;
-
-      if (parse->offset < 0) {
-        return;
-      }
     }
     else if ((memaddr[0] == 's' || memaddr[0] == 'S') &&
              (memaddr[1] == 'u' || memaddr[1] == 'U') &&
@@ -63,10 +55,6 @@ void rc_parse_lboard_internal(rc_lboard_t* self, const char* memaddr, rc_parse_s
       memaddr += 4;
       rc_parse_trigger_internal(&self->submit, &memaddr, parse);
       self->submit.memrefs = 0;
-
-      if (parse->offset < 0) {
-        return;
-      }
     }
     else if ((memaddr[0] == 'v' || memaddr[0] == 'V') &&
              (memaddr[1] == 'a' || memaddr[1] == 'A') &&
@@ -80,10 +68,6 @@ void rc_parse_lboard_internal(rc_lboard_t* self, const char* memaddr, rc_parse_s
       memaddr += 4;
       rc_parse_value_internal(&self->value, &memaddr, parse);
       self->value.memrefs = 0;
-
-      if (parse->offset < 0) {
-        return;
-      }
     }
     else if ((memaddr[0] == 'p' || memaddr[0] == 'P') &&
              (memaddr[1] == 'r' || memaddr[1] == 'R') &&
@@ -99,18 +83,20 @@ void rc_parse_lboard_internal(rc_lboard_t* self, const char* memaddr, rc_parse_s
       self->progress = RC_ALLOC(rc_value_t, parse);
       rc_parse_value_internal(self->progress, &memaddr, parse);
       self->progress->memrefs = 0;
-
-      if (parse->offset < 0) {
-        return;
-      }
     }
-    else {
+
+    /* encountered an error parsing one of the parts */
+    if (parse->offset < 0)
+      return;
+
+    /* end of string, or end of quoted string - stop processing */
+    if (memaddr[0] == '\0' || memaddr[0] == '\"')
+      break;
+
+    /* expect two colons between fields */
+    if (memaddr[0] != ':' || memaddr[1] != ':') {
       parse->offset = RC_INVALID_LBOARD_FIELD;
       return;
-    }
-
-    if (memaddr[0] != ':' || memaddr[1] != ':') {
-      break;
     }
 
     memaddr += 2;

--- a/src/rcheevos/value.c
+++ b/src/rcheevos/value.c
@@ -92,7 +92,12 @@ void rc_parse_legacy_value(rc_value_t* self, const char** memaddr, rc_parse_stat
 
     buffer_ptr = buffer;
     cond = rc_parse_condition(&buffer_ptr, parse, 0);
-    if (parse->offset < 0) {
+    if (parse->offset < 0)
+      return;
+
+    if (*buffer_ptr) {
+      /* whatever we copied as a single condition was not fully consumed */
+      parse->offset = RC_INVALID_COMPARISON;
       return;
     }
 

--- a/test/rcheevos/test_lboard.c
+++ b/test/rcheevos/test_lboard.c
@@ -540,9 +540,17 @@ static void test_unparsable_strings() {
   TEST_PARAMS2(test_unparsable_lboard, "STA:0xH00=0::CAN:0xH00=2::SUB:0xH00=3::VAL:M:0xH02SM:0xH03", RC_INVALID_VALUE_FLAG);
   TEST_PARAMS2(test_unparsable_lboard, "STA:0xH00=A::CAN:0xH00=2::SUB:0xH00=3::VAL:0xH02", RC_INVALID_MEMORY_OPERAND);
 
-  /* "STA:0xH00=1" is valid, but that leaves the read pointer pointing at the "A", which is not "::", so the code
-   * thinks it's completely done with the input. As the CAN logic was never parsed, RC_MISSING_CANCEL is returned. */
-  TEST_PARAMS2(test_unparsable_lboard, "STA:0xH00=1A::CAN:0xH00=2::SUB:0xH00=3::VAL:0xH02", RC_MISSING_CANCEL);
+  /* "STA:0xH00=1" is valid, but that leaves the read pointer pointing at the "A", which is not "::", so a generic
+   * invalid field error is returned. */
+  TEST_PARAMS2(test_unparsable_lboard, "STA:0xH00=1A::CAN:0xH00=2::SUB:0xH00=3::VAL:0xH02", RC_INVALID_LBOARD_FIELD);
+
+  /* Missing '_' causes "0xH00=10" to be valid, but that leaves the read pointer pointing at the "x", which is not 
+   * "::", so a generic invalid field error is returned. */
+  TEST_PARAMS2(test_unparsable_lboard, "STA:0xH00=10xH01=1::CAN:0xH00=2::SUB:0xH00=3::VAL:0xH02", RC_INVALID_LBOARD_FIELD);
+
+  /* Garbage following value field (legacy format conversion will return invalid comparison) */
+  TEST_PARAMS2(test_unparsable_lboard, "STA:0xH00=1::CAN:0xH00=2::SUB:0xH00=3::VAL:0xH02=1=2", RC_INVALID_COMPARISON);
+  TEST_PARAMS2(test_unparsable_lboard, "STA:0xH00=1::CAN:0xH00=2::SUB:0xH00=3::VAL:M:0xH02=1=2", RC_INVALID_LBOARD_FIELD);
 }
 
 void test_lboard(void) {


### PR DESCRIPTION
When a start/submit/cancel condition looks mostly correct, it leaves the parser in an invalid state moving to the next field and the error that gets generated is that the next field could not be found.

For example, if the start condition were "0xH1234=1A", it would say "Missing cancel condition" because the "0xH1234=1" would parse successfully, but the "A" is unexpected, so it never finds the cancel condition, even though a cancel condition likely exists.

I've modified the logic so this generates an "Invalid field in leaderboard" error, which doesn't help identify which field has the error, but should be less confusing.