### PR TITLE
don't generate PS2 hash for PSX disc

### DIFF
--- a/src/rhash/hash.c
+++ b/src/rhash/hash.c
@@ -1302,6 +1302,7 @@ static int rc_hash_find_playstation_executable(void* track_handle, const char* b
   size = (unsigned)rc_cd_read_sector(track_handle, sector, buffer, sizeof(buffer) - 1);
   buffer[size] = '\0';
 
+  sector = 0;
   for (ptr = (char*)buffer; *ptr; ++ptr)
   {
     if (strncmp(ptr, boot_key, boot_key_len) == 0)

--- a/test/rhash/test_hash.c
+++ b/test/rhash/test_hash.c
@@ -850,6 +850,38 @@ static void test_hash_ps2_iso()
   ASSERT_STR_EQUALS(hash_iterator, expected_md5);
 }
 
+static void test_hash_ps2_psx()
+{
+  size_t image_size;
+  uint8_t* image = generate_psx_bin("SLUS_007.45", 0x07D800, &image_size);
+  char hash_file[33], hash_iterator[33];
+  const char* expected_md5 = "db433fb038cde4fb15c144e8c7dea6e3";
+
+  mock_file(0, "game.bin", image, image_size);
+  mock_file(1, "game.cue", (uint8_t*)"game.bin", 8);
+
+  /* test file hash */
+  int result_file = rc_hash_generate_from_file(hash_file, RC_CONSOLE_PLAYSTATION_2, "game.cue");
+
+  /* test file identification from iterator */
+  int result_iterator;
+  struct rc_hash_iterator iterator;
+
+  rc_hash_initialize_iterator(&iterator, "game.cue", NULL, 0);
+  result_iterator = rc_hash_iterate(hash_iterator, &iterator);
+  ASSERT_NUM_EQUALS(result_iterator, 1);
+  ASSERT_STR_EQUALS(hash_iterator, expected_md5); /* PSX hash */
+  result_iterator = rc_hash_iterate(hash_iterator, &iterator);
+  rc_hash_destroy_iterator(&iterator);
+
+  /* cleanup */
+  free(image);
+
+  /* validation (should not generate PS2 hash for PSX file */
+  ASSERT_NUM_EQUALS(result_file, 0);
+  ASSERT_NUM_EQUALS(result_iterator, 0);
+}
+
 static void test_hash_sega_cd()
 {
   /* the first 512 bytes of sector 0 are a volume header and ROM header. 
@@ -1253,6 +1285,7 @@ void test_hash(void) {
 
   /* Playstation 2 */
   TEST(test_hash_ps2_iso);
+  TEST(test_hash_ps2_psx);
 
   /* Pokemon Mini */
   TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_POKEMON_MINI, "test.min", 524288, "68f0f13b598e0b66461bc578375c3888");


### PR DESCRIPTION
prevents checking an extra hash when the PSX hash doesn't match.