### PR TITLE
prevent array subscript error for some ctype implementations

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -44,6 +44,9 @@ jobs:
       uses: actions/checkout@v2
     - name: Install dependencies
       run: sudo apt-get install gcc-multilib # bits/libc-header-start.h
+    - name: Check ctype calls
+      run: make ARCH=x64 BUILD=retroarch TARGET=check_ctype
+      working-directory: test
     - name: Build
       run: make ARCH=x64 BUILD=retroarch TARGET=tests
       working-directory: test

--- a/src/rapi/rc_api_common.c
+++ b/src/rapi/rc_api_common.c
@@ -101,7 +101,7 @@ static int rc_json_parse_array(const char** json_ptr, rc_json_field_t* field) {
   if (*json != ']') {
     do
     {
-      while (isspace(*json))
+      while (isspace((unsigned char)*json))
         ++json;
 
       result = rc_json_parse_field(&json, &unused_field);

--- a/src/rapi/rc_api_common.c
+++ b/src/rapi/rc_api_common.c
@@ -75,12 +75,12 @@ static int rc_json_parse_field(const char** json_ptr, rc_json_field_t* field) {
       break;
 
     default: /* non-quoted text [true,false,null] */
-      if (!isalpha(**json_ptr))
+      if (!isalpha((unsigned char)**json_ptr))
         return RC_INVALID_JSON;
 
       do {
         ++(*json_ptr);
-      } while (isalnum(**json_ptr));
+      } while (isalnum((unsigned char)**json_ptr));
       break;
   }
 
@@ -101,7 +101,7 @@ static int rc_json_parse_array(const char** json_ptr, rc_json_field_t* field) {
   if (*json != ']') {
     do
     {
-      while (isspace(*json))
+      while (isspace((unsigned char)*json))
         ++json;
 
       result = rc_json_parse_field(&json, &unused_field);
@@ -110,7 +110,7 @@ static int rc_json_parse_array(const char** json_ptr, rc_json_field_t* field) {
 
       ++field->array_size;
 
-      while (isspace(*json))
+      while (isspace((unsigned char)*json))
         ++json;
 
       if (*json != ',')
@@ -130,7 +130,7 @@ static int rc_json_parse_array(const char** json_ptr, rc_json_field_t* field) {
 static int rc_json_get_next_field(rc_json_object_field_iterator_t* iterator) {
   const char* json = iterator->json;
 
-  while (isspace(*json))
+  while (isspace((unsigned char)*json))
     ++json;
 
   if (*json != '"')
@@ -145,7 +145,7 @@ static int rc_json_get_next_field(rc_json_object_field_iterator_t* iterator) {
   iterator->name_len = json - iterator->field.name;
   ++json;
 
-  while (isspace(*json))
+  while (isspace((unsigned char)*json))
     ++json;
 
   if (*json != ':')
@@ -153,13 +153,13 @@ static int rc_json_get_next_field(rc_json_object_field_iterator_t* iterator) {
 
   ++json;
 
-  while (isspace(*json))
+  while (isspace((unsigned char)*json))
     ++json;
 
   if (rc_json_parse_field(&json, &iterator->field) < 0)
     return RC_INVALID_JSON;
 
-  while (isspace(*json))
+  while (isspace((unsigned char)*json))
     ++json;
 
   iterator->json = json;
@@ -307,12 +307,12 @@ static int rc_json_get_array_entry_value(rc_json_field_t* field, rc_json_field_t
   if (!iterator->array_size)
     return 0;
 
-  while (isspace(*iterator->value_start))
+  while (isspace((unsigned char)*iterator->value_start))
     ++iterator->value_start;
 
   rc_json_parse_field(&iterator->value_start, field);
 
-  while (isspace(*iterator->value_start))
+  while (isspace((unsigned char)*iterator->value_start))
     ++iterator->value_start;
 
   ++iterator->value_start; /* skip , or ] */
@@ -368,12 +368,12 @@ int rc_json_get_array_entry_object(rc_json_field_t* fields, size_t field_count, 
   if (!iterator->array_size)
     return 0;
 
-  while (isspace(*iterator->value_start))
+  while (isspace((unsigned char)*iterator->value_start))
     ++iterator->value_start;
 
   rc_json_parse_object(&iterator->value_start, fields, field_count, NULL);
 
-  while (isspace(*iterator->value_start))
+  while (isspace((unsigned char)*iterator->value_start))
     ++iterator->value_start;
 
   ++iterator->value_start; /* skip , or ] */

--- a/src/rapi/rc_api_common.c
+++ b/src/rapi/rc_api_common.c
@@ -101,7 +101,7 @@ static int rc_json_parse_array(const char** json_ptr, rc_json_field_t* field) {
   if (*json != ']') {
     do
     {
-      while (isspace((unsigned char)*json))
+      while (isspace(*json))
         ++json;
 
       result = rc_json_parse_field(&json, &unused_field);

--- a/src/rcheevos/compat.c
+++ b/src/rcheevos/compat.c
@@ -55,6 +55,7 @@ int rc_snprintf(char* buffer, size_t size, const char* format, ...)
 
    va_start(args, format);
    /* assume buffer is large enough and ignore size */
+   (void)size;
    result = vsprintf(buffer, format, args);
    va_end(args);
 

--- a/src/rcheevos/condset.c
+++ b/src/rcheevos/condset.c
@@ -140,7 +140,7 @@ rc_condset_t* rc_parse_condset(const char** memaddr, rc_parse_state_t* parse, in
   return self;
 }
 
-static void rc_condset_update_indirect_memrefs(rc_condset_t* self, rc_condition_t* condition, int processing_pause, rc_eval_state_t* eval_state) {
+static void rc_condset_update_indirect_memrefs(rc_condition_t* condition, int processing_pause, rc_eval_state_t* eval_state) {
   for (; condition != 0; condition = condition->next) {
     if (condition->pause != processing_pause)
       continue;
@@ -311,10 +311,10 @@ static int rc_test_condset_internal(rc_condset_t* self, int processing_pause, rc
            * if the set has any indirect memrefs, manually update them now so the deltas are correct */
           if (self->has_indirect_memrefs) {
             /* first, update any indirect memrefs in the remaining part of the pause subset  */
-            rc_condset_update_indirect_memrefs(self, condition->next, 1, eval_state);
+            rc_condset_update_indirect_memrefs(condition->next, 1, eval_state);
 
             /* then, update all indirect memrefs in the non-pause subset */
-            rc_condset_update_indirect_memrefs(self, self->conditions, 0, eval_state);
+            rc_condset_update_indirect_memrefs(self->conditions, 0, eval_state);
           }
 
           return 1;

--- a/src/rcheevos/operand.c
+++ b/src/rcheevos/operand.c
@@ -29,7 +29,7 @@ static int rc_parse_operand_lua(rc_operand_t* self, const char** memaddr, rc_par
     return RC_INVALID_LUA_OPERAND;
   }
 
-  if (!isalpha(*aux)) {
+  if (!isalpha((unsigned char)*aux)) {
     return RC_INVALID_LUA_OPERAND;
   }
 
@@ -37,7 +37,7 @@ static int rc_parse_operand_lua(rc_operand_t* self, const char** memaddr, rc_par
   id = aux;
 #endif
 
-  while (isalnum(*aux) || *aux == '_') {
+  while (isalnum((unsigned char)*aux) || *aux == '_') {
     aux++;
   }
 

--- a/src/rcheevos/value.c
+++ b/src/rcheevos/value.c
@@ -76,7 +76,7 @@ void rc_parse_legacy_value(rc_value_t* self, const char** memaddr, rc_parse_stat
             ++buffer_ptr; /* ignore sign */
 
           /* if it looks like a floating point number, add the 'f' prefix */
-          while (isdigit(*(unsigned char*)buffer_ptr))
+          while (isdigit((unsigned char)*buffer_ptr))
             ++buffer_ptr;
           if (*buffer_ptr == '.')
             *ptr++ = 'f';

--- a/src/rhash/cdreader.c
+++ b/src/rhash/cdreader.c
@@ -324,7 +324,7 @@ static void* cdreader_open_cue_track(const char* path, uint32_t track)
         }
 
         /* calculate the true offset and update the counters for the next INDEX marker */
-        offset += sector_offset * previous_sector_size;
+        offset += (int64_t)sector_offset * previous_sector_size;
         previous_sector_size = sector_size;
         previous_index_sector_offset += sector_offset;
 
@@ -334,7 +334,7 @@ static void* cdreader_open_cue_track(const char* path, uint32_t track)
           {
             char message[128];
             char* scan = mode;
-            while (*scan && !isspace(*scan))
+            while (*scan && !isspace((unsigned char)*scan))
               ++scan;
             *scan = '\0';
 
@@ -589,43 +589,43 @@ static void* cdreader_open_gdi_track(const char* path, uint32_t track)
         ++ptr;
 
       /* line format: [trackid] [lba] [type] [sectorsize] [file] [?] */
-      while (isspace(*ptr))
+      while (isspace((unsigned char)*ptr))
         ++ptr;
 
       current_track = (uint32_t)atoi(ptr);
       if (track && current_track != track)
         continue;
 
-      while (isdigit(*ptr))
+      while (isdigit((unsigned char)*ptr))
         ++ptr;
       ++ptr;
 
-      while (isspace(*ptr))
+      while (isspace((unsigned char)*ptr))
         ++ptr;
 
       lba = atoi(ptr);
-      while (isdigit(*ptr))
+      while (isdigit((unsigned char)*ptr))
         ++ptr;
       ++ptr;
 
-      while (isspace(*ptr))
+      while (isspace((unsigned char)*ptr))
         ++ptr;
 
       track_type = atoi(ptr);
-      while (isdigit(*ptr))
+      while (isdigit((unsigned char)*ptr))
         ++ptr;
       ++ptr;
 
-      while (isspace(*ptr))
+      while (isspace((unsigned char)*ptr))
         ++ptr;
 
       ptr2 = sector_size;
-      while (isdigit(*ptr))
+      while (isdigit((unsigned char)*ptr))
         *ptr2++ = *ptr++;
       *ptr2 = '\0';
       ++ptr;
 
-      while (isspace(*ptr))
+      while (isspace((unsigned char)*ptr))
         ++ptr;
 
       ptr2 = file;

--- a/src/rhash/hash.c
+++ b/src/rhash/hash.c
@@ -58,7 +58,6 @@ static void filereader_seek(void* file_handle, int64_t offset, int origin)
 #elif defined(_LARGEFILE64_SOURCE)
   fseeko64((FILE*)file_handle, offset, origin);
 #else
-#pragma message("Using generic fseek may fail for large files")
   fseek((FILE*)file_handle, offset, origin);
 #endif
 }

--- a/src/rhash/hash.c
+++ b/src/rhash/hash.c
@@ -1240,7 +1240,7 @@ static int rc_hash_dreamcast(char hash[33], const char* path)
   /* the boot filename is 96 bytes into the meta information (https://mc.pp.se/dc/ip0000.bin.html) */
   /* remove whitespace from bootfile */
   i = 0;
-  while (!isspace(buffer[96 + i]) && i < 16)
+  while (!isspace((unsigned char)buffer[96 + i]) && i < 16)
     ++i;
 
   /* sometimes boot file isn't present on meta information.
@@ -1308,13 +1308,13 @@ static int rc_hash_find_playstation_executable(void* track_handle, const char* b
     if (strncmp(ptr, boot_key, boot_key_len) == 0)
     {
       ptr += boot_key_len;
-      while (isspace(*ptr))
+      while (isspace((unsigned char)*ptr))
         ++ptr;
 
       if (*ptr == '=')
       {
         ++ptr;
-        while (isspace(*ptr))
+        while (isspace((unsigned char)*ptr))
           ++ptr;
 
         if (strncmp(ptr, cdrom_prefix, cdrom_prefix_len) == 0)
@@ -1323,7 +1323,7 @@ static int rc_hash_find_playstation_executable(void* track_handle, const char* b
           ++ptr;
 
         start = ptr;
-        while (!isspace(*ptr) && *ptr != ';')
+        while (!isspace((unsigned char)*ptr) && *ptr != ';')
           ++ptr;
 
         size = (unsigned)(ptr - start);
@@ -1734,7 +1734,7 @@ static const char* rc_hash_get_first_item_from_playlist(const char* path)
     next = ptr;
 
     /* remove trailing whitespace - especially '\r' */
-    while (ptr > start && isspace(ptr[-1]))
+    while (ptr > start && isspace((unsigned char)ptr[-1]))
       --ptr;
 
     /* if we found a non-empty line, break out of the loop to process it */

--- a/test/Makefile
+++ b/test/Makefile
@@ -106,13 +106,14 @@ else
 endif
 
 # more strict validation for source files to eliminate warnings/errors in upstream consumers
-SRC_CFLAGS=-pedantic -Wsign-compare
+# 3DS build (retroarch) doesn't support signed char
+SRC_CFLAGS=-pedantic -Wsign-compare -fno-signed-char
 
 ifeq ($(BUILD), c89)
     CFLAGS += -std=c89
 else ifeq ($(BUILD), retroarch)
     # RetroArch builds with gcc8 and gnu99 which adds some extra warning validations
-    SRC_CFLAGS += -std=gnu99 -D_GNU_SOURCE -Wall -fno-signed-char
+    SRC_CFLAGS += -std=gnu99 -D_GNU_SOURCE -Wall
 else
     $(error unknown BUILD "$(BUILD)")
 endif
@@ -164,7 +165,21 @@ test: $(OBJ)
 	$(CC) $(LDFLAGS) -o $@$(EXE) $+ -lm
 	@echo ---------------------------------
 
-runtests: test
+check_ctype:
+	@if grep -rnI "isalpha([^(u]" ../src/*; \
+	then echo "*** Error: isalpha without unsigned char cast" && false; \
+	fi
+	@if grep -rnI "isalnum([^(u]" ../src/*; \
+	then echo "*** Error: isalnum without unsigned char cast" && false; \
+	fi
+	@if grep -rnI "isdigit([^(u]" ../src/*; \
+	then echo "*** Error: isdigit without unsigned char cast" && false; \
+	fi
+	@if grep -rnI "isspace([^(u]" ../src/*; \
+	then echo "*** Error: isspace without unsigned char cast" && false; \
+	fi
+
+runtests: check_ctype test
 	@./test$(EXE)
 
 valgrind: test

--- a/test/Makefile
+++ b/test/Makefile
@@ -161,7 +161,7 @@ $(LUA_SRC)/%.o: $(LUA_SRC)/%.c
 %.o: %.c
 	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@
 
-test: check_ctype $(OBJ)
+test: $(OBJ)
 	$(CC) $(LDFLAGS) -o $@$(EXE) $+ -lm
 	@echo ---------------------------------
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -161,7 +161,7 @@ $(LUA_SRC)/%.o: $(LUA_SRC)/%.c
 %.o: %.c
 	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@
 
-test: $(OBJ)
+test: check_ctype $(OBJ)
 	$(CC) $(LDFLAGS) -o $@$(EXE) $+ -lm
 	@echo ---------------------------------
 
@@ -179,7 +179,7 @@ check_ctype:
 	then echo "*** Error: isspace without unsigned char cast" && false; \
 	fi
 
-runtests: check_ctype test
+runtests: test
 	@./test$(EXE)
 
 valgrind: test


### PR DESCRIPTION
fixes warnings generated in RetroArch switch build:
```
In file included from deps/rcheevos/src/rcheevos/operand.c:4:
deps/rcheevos/src/rcheevos/operand.c: In function 'rc_parse_operand_lua':
deps/rcheevos/src/rcheevos/operand.c:32:16: warning: array subscript has type 'char' [-Wchar-subscripts]
   32 |   if (!isalpha(*aux)) {
      |                ^~~~
deps/rcheevos/src/rcheevos/operand.c:40:18: warning: array subscript has type 'char' [-Wchar-subscripts]
   40 |   while (isalnum(*aux) || *aux == '_') {
      |                  ^~~~
In file included from deps/rcheevos/src/rhash/hash.c:8:
deps/rcheevos/src/rhash/hash.c: In function 'rc_hash_find_playstation_executable':
deps/rcheevos/src/rhash/hash.c:1104:22: warning: array subscript has type 'char' [-Wchar-subscripts]
 1104 |       while (isspace(*ptr))
      |                      ^~~~
deps/rcheevos/src/rhash/hash.c:1110:24: warning: array subscript has type 'char' [-Wchar-subscripts]
 1110 |         while (isspace(*ptr))
      |                        ^~~~
deps/rcheevos/src/rhash/hash.c:1119:25: warning: array subscript has type 'char' [-Wchar-subscripts]
 1119 |         while (!isspace(*ptr) && *ptr != ';')
      |                         ^~~~
deps/rcheevos/src/rhash/hash.c: In function 'rc_hash_get_first_item_from_playlist':
deps/rcheevos/src/rhash/hash.c:1528:38: warning: array subscript has type 'char' [-Wchar-subscripts]
 1528 |     while (ptr > start && isspace(ptr[-1]))
      |                                   ~~~^~~~
In file included from deps/rcheevos/src/rapi/rc_api_common.c:9:
deps/rcheevos/src/rapi/rc_api_common.c: In function 'rc_json_parse_field':
deps/rcheevos/src/rapi/rc_api_common.c:78:20: warning: array subscript has type 'char' [-Wchar-subscripts]
   78 |       if (!isalpha(**json_ptr))
      |                    ^~~~~~~~~~
deps/rcheevos/src/rapi/rc_api_common.c:83:24: warning: array subscript has type 'char' [-Wchar-subscripts]
   83 |       } while (isalnum(**json_ptr));
      |                        ^~~~~~~~~~
deps/rcheevos/src/rapi/rc_api_common.c: In function 'rc_json_parse_array':
deps/rcheevos/src/rapi/rc_api_common.c:104:22: warning: array subscript has type 'char' [-Wchar-subscripts]
  104 |       while (isspace(*json))
      |                      ^~~~~
deps/rcheevos/src/rapi/rc_api_common.c:113:22: warning: array subscript has type 'char' [-Wchar-subscripts]
  113 |       while (isspace(*json))
      |                      ^~~~~
deps/rcheevos/src/rapi/rc_api_common.c: In function 'rc_json_parse_object':
deps/rcheevos/src/rapi/rc_api_common.c:152:20: warning: array subscript has type 'char' [-Wchar-subscripts]
  152 |     while (isspace(*json))
      |                    ^~~~~
deps/rcheevos/src/rapi/rc_api_common.c:167:20: warning: array subscript has type 'char' [-Wchar-subscripts]
  167 |     while (isspace(*json))
      |                    ^~~~~
deps/rcheevos/src/rapi/rc_api_common.c:175:20: warning: array subscript has type 'char' [-Wchar-subscripts]
  175 |     while (isspace(*json))
      |                    ^~~~~
deps/rcheevos/src/rapi/rc_api_common.c:189:20: warning: array subscript has type 'char' [-Wchar-subscripts]
  189 |     while (isspace(*json))
      |                    ^~~~~
deps/rcheevos/src/rapi/rc_api_common.c: In function 'rc_json_get_array_entry_value':
deps/rcheevos/src/rapi/rc_api_common.c:280:18: warning: array subscript has type 'char' [-Wchar-subscripts]
  280 |   while (isspace(*iterator->value_start))
      |                  ^~~~~~~~~~~~~~~~~~~~~~
deps/rcheevos/src/rapi/rc_api_common.c:285:18: warning: array subscript has type 'char' [-Wchar-subscripts]
  285 |   while (isspace(*iterator->value_start))
      |                  ^~~~~~~~~~~~~~~~~~~~~~
deps/rcheevos/src/rapi/rc_api_common.c: In function 'rc_json_get_array_entry_object':
deps/rcheevos/src/rapi/rc_api_common.c:341:18: warning: array subscript has type 'char' [-Wchar-subscripts]
  341 |   while (isspace(*iterator->value_start))
      |                  ^~~~~~~~~~~~~~~~~~~~~~
deps/rcheevos/src/rapi/rc_api_common.c:346:18: warning: array subscript has type 'char' [-Wchar-subscripts]
  346 |   while (isspace(*iterator->value_start))
      |                  ^~~~~~~~~~~~~~~~~~~~~~
```
If the `ctype.h` implementation of `isspace`, `isalpha`, etc is a macro around an array lookup, the compiler may complain when `char` is used as an array subscript as illustrated above. The solution is to explicitly cast the `char` to an `unsigned char` before calling the `isXXXXX` function.

This case is not handled by any of the existing github action builds as all of the provided `ctype.h` files provide a function instead of a macro for the affected functions, so a special Makefile command was added to cause the build to fail when these are detected by grep.