### PR TITLE
add measured_as_percent flag to rc_trigger_t

### DIFF
--- a/include/rc_runtime.h
+++ b/include/rc_runtime.h
@@ -7,6 +7,8 @@ extern "C" {
 
 #include "rc_error.h"
 
+#include <stdint.h>
+
 /*****************************************************************************\
 | Forward Declarations (defined in rc_runtime_types.h)                        |
 \*****************************************************************************/
@@ -94,6 +96,7 @@ int rc_runtime_activate_achievement(rc_runtime_t* runtime, unsigned id, const ch
 void rc_runtime_deactivate_achievement(rc_runtime_t* runtime, unsigned id);
 rc_trigger_t* rc_runtime_get_achievement(const rc_runtime_t* runtime, unsigned id);
 int rc_runtime_get_achievement_measured(const rc_runtime_t* runtime, unsigned id, unsigned* measured_value, unsigned* measured_target);
+int rc_runtime_format_achievement_measured(const rc_runtime_t* runtime, unsigned id, char *buffer, size_t buffer_size);
 
 int rc_runtime_activate_lboard(rc_runtime_t* runtime, unsigned id, const char* memaddr, lua_State* L, int funcs_idx);
 void rc_runtime_deactivate_lboard(rc_runtime_t* runtime, unsigned id);

--- a/include/rc_runtime.h
+++ b/include/rc_runtime.h
@@ -7,7 +7,7 @@ extern "C" {
 
 #include "rc_error.h"
 
-#include <stdint.h>
+#include <stddef.h>
 
 /*****************************************************************************\
 | Forward Declarations (defined in rc_runtime_types.h)                        |

--- a/include/rc_runtime_types.h
+++ b/include/rc_runtime_types.h
@@ -255,6 +255,9 @@ struct rc_trigger_t {
 
   /* True if at least one condition has a non-zero required hit count */
   char has_required_hits;
+
+  /* True if the measured value should be displayed as a percentage */
+  char measured_as_percent;
 };
 
 int rc_trigger_size(const char* memaddr);

--- a/src/rcheevos/alloc.c
+++ b/src/rcheevos/alloc.c
@@ -144,6 +144,7 @@ void rc_init_parse_state(rc_parse_state_t* parse, void* buffer, lua_State* L, in
   parse->measured_target = 0;
   parse->lines_read = 0;
   parse->has_required_hits = 0;
+  parse->measured_as_percent = 0;
 }
 
 void rc_destroy_parse_state(rc_parse_state_t* parse)

--- a/src/rcheevos/condition.c
+++ b/src/rcheevos/condition.c
@@ -86,6 +86,11 @@ rc_condition_t* rc_parse_condition(const char** memaddr, rc_parse_state_t* parse
       case 'i': case 'I': self->type = RC_CONDITION_ADD_ADDRESS; can_modify = 1; break;
       case 't': case 'T': self->type = RC_CONDITION_TRIGGER; break;
       case 'z': case 'Z': self->type = RC_CONDITION_RESET_NEXT_IF; break;
+      case 'g': case 'G':
+          parse->measured_as_percent = 1;
+          self->type = RC_CONDITION_MEASURED;
+          break;
+      /* e f h j k l s u v w x y */
       default: parse->offset = RC_INVALID_CONDITION_TYPE; return 0;
     }
 

--- a/src/rcheevos/rc_internal.h
+++ b/src/rcheevos/rc_internal.h
@@ -99,6 +99,7 @@ typedef struct {
   int lines_read;
 
   char has_required_hits;
+  char measured_as_percent;
 }
 rc_parse_state_t;
 

--- a/src/rcheevos/runtime.c
+++ b/src/rcheevos/runtime.c
@@ -1,5 +1,6 @@
 #include "rc_runtime.h"
 #include "rc_internal.h"
+#include "rc_compat.h"
 
 #include "../rhash/md5.h"
 
@@ -239,6 +240,33 @@ int rc_runtime_get_achievement_measured(const rc_runtime_t* runtime, unsigned id
   }
 
   return 1;
+}
+
+int rc_runtime_format_achievement_measured(const rc_runtime_t* runtime, unsigned id, char* buffer, size_t buffer_size)
+{
+  const rc_trigger_t* trigger = rc_runtime_get_achievement(runtime, id);
+  unsigned value;
+  if (!buffer || !buffer_size)
+    return 0;
+
+  if (!trigger || /* no trigger */
+      trigger->measured_target == 0 || /* not measured */
+      !rc_trigger_state_active(trigger->state)) { /* don't report measured value for inactive triggers */
+    *buffer = '\0';
+    return 0;
+  }
+
+  /* cap the value at the target so we can count past the target: "107 >= 100" */
+  value = trigger->measured_value;
+  if (value > trigger->measured_target)
+    value = trigger->measured_target;
+
+  if (trigger->measured_as_percent) {
+    unsigned percent = (unsigned)(((unsigned long long)value * 100) / trigger->measured_target);
+    return snprintf(buffer, buffer_size, "%u%%", percent);
+  }
+
+  return snprintf(buffer, buffer_size, "%u/%u", value, trigger->measured_target);
 }
 
 static void rc_runtime_deactivate_lboard_by_index(rc_runtime_t* self, unsigned index) {

--- a/src/rcheevos/trigger.c
+++ b/src/rcheevos/trigger.c
@@ -13,6 +13,7 @@ void rc_parse_trigger_internal(rc_trigger_t* self, const char** memaddr, rc_pars
   /* reset in case multiple triggers are parsed by the same parse_state */
   parse->measured_target = 0;
   parse->has_required_hits = 0;
+  parse->measured_as_percent = 0;
 
   if (*aux == 's' || *aux == 'S') {
     self->requirement = 0;
@@ -43,6 +44,7 @@ void rc_parse_trigger_internal(rc_trigger_t* self, const char** memaddr, rc_pars
 
   self->measured_value = 0;
   self->measured_target = parse->measured_target;
+  self->measured_as_percent = parse->measured_as_percent;
   self->state = RC_TRIGGER_STATE_WAITING;
   self->has_hits = 0;
   self->has_required_hits = parse->has_required_hits;

--- a/test/rcheevos/test_condition.c
+++ b/test/rcheevos/test_condition.c
@@ -205,6 +205,7 @@ void test_condition(void) {
   TEST_PARAMS5(test_parse_condition, "C:0xH1234=8", RC_CONDITION_ADD_HITS, RC_OPERAND_ADDRESS, RC_OPERATOR_EQ, 0);
   TEST_PARAMS5(test_parse_condition, "D:0xH1234=8", RC_CONDITION_SUB_HITS, RC_OPERAND_ADDRESS, RC_OPERATOR_EQ, 0);
   TEST_PARAMS5(test_parse_condition, "M:0xH1234=8", RC_CONDITION_MEASURED, RC_OPERAND_ADDRESS, RC_OPERATOR_EQ, 0);
+  TEST_PARAMS5(test_parse_condition, "G:0xH1234=8", RC_CONDITION_MEASURED, RC_OPERAND_ADDRESS, RC_OPERATOR_EQ, 0);
   TEST_PARAMS5(test_parse_condition, "Q:0xH1234=8", RC_CONDITION_MEASURED_IF, RC_OPERAND_ADDRESS, RC_OPERATOR_EQ, 0);
   TEST_PARAMS5(test_parse_condition, "I:0xH1234=8", RC_CONDITION_ADD_ADDRESS, RC_OPERAND_ADDRESS, RC_OPERATOR_NONE, 0);
   TEST_PARAMS5(test_parse_condition, "T:0xH1234=8", RC_CONDITION_TRIGGER, RC_OPERAND_ADDRESS, RC_OPERATOR_EQ, 0);
@@ -252,6 +253,7 @@ void test_condition(void) {
   TEST_PARAMS2(test_parse_condition_error, "P:0x1234", RC_INVALID_OPERATOR);
   TEST_PARAMS2(test_parse_condition_error, "R:0x1234", RC_INVALID_OPERATOR);
   TEST_PARAMS2(test_parse_condition_error, "M:0x1234", RC_INVALID_OPERATOR);
+  TEST_PARAMS2(test_parse_condition_error, "G:0x1234", RC_INVALID_OPERATOR);
   TEST_PARAMS2(test_parse_condition_error, "Y:0x1234", RC_INVALID_CONDITION_TYPE);
   TEST_PARAMS2(test_parse_condition_error, "0x1234=1.2", RC_INVALID_REQUIRED_HITS);
   TEST_PARAMS2(test_parse_condition_error, "0.1234==0", RC_INVALID_OPERATOR); /* period is assumed to be operator */

--- a/test/rcheevos/test_runtime.c
+++ b/test/rcheevos/test_runtime.c
@@ -190,6 +190,7 @@ static void test_deactivate_achievements(void)
 static void test_achievement_measured(void)
 {
   unsigned char ram[] = { 0, 10, 10 };
+  char buffer[32];
   memory_t memory;
   rc_runtime_t runtime;
   unsigned value, target;
@@ -199,38 +200,162 @@ static void test_achievement_measured(void)
 
   rc_runtime_init(&runtime);
 
-  assert_activate_achievement(&runtime, 1, "0xH0001=10");
-  assert_activate_achievement(&runtime, 2, "M:0xH0002>=10");
+  /* use equality so we can test values greater than the target */
+  assert_activate_achievement(&runtime, 1, "0xH0002==10");
+  assert_activate_achievement(&runtime, 2, "M:0xH0002==10");
+  assert_activate_achievement(&runtime, 3, "G:0xH0002==10");
 
-  /* both achievements are true, should remain in waiting state */
+  /* achievements are true, should remain in waiting state with no measured value */
   assert_do_frame(&runtime, &memory);
   ASSERT_TRUE(rc_runtime_get_achievement_measured(&runtime, 1, &value, &target));
   ASSERT_NUM_EQUALS(value, 0);
   ASSERT_NUM_EQUALS(target, 0);
+  ASSERT_FALSE(rc_runtime_format_achievement_measured(&runtime, 1, buffer, sizeof(buffer)));
+  ASSERT_STR_EQUALS(buffer, "");
   ASSERT_TRUE(rc_runtime_get_achievement_measured(&runtime, 2, &value, &target));
   ASSERT_NUM_EQUALS(value, 0);
   ASSERT_NUM_EQUALS(target, 10);
-  ASSERT_FALSE(rc_runtime_get_achievement_measured(&runtime, 3, &value, &target));
+  ASSERT_TRUE(rc_runtime_format_achievement_measured(&runtime, 2, buffer, sizeof(buffer)));
+  ASSERT_STR_EQUALS(buffer, "0/10");
+  ASSERT_TRUE(rc_runtime_get_achievement_measured(&runtime, 3, &value, &target));
+  ASSERT_NUM_EQUALS(value, 0);
+  ASSERT_NUM_EQUALS(target, 10);
+  ASSERT_TRUE(rc_runtime_format_achievement_measured(&runtime, 3, buffer, sizeof(buffer)));
+  ASSERT_STR_EQUALS(buffer, "0%");
+  ASSERT_FALSE(rc_runtime_get_achievement_measured(&runtime, 4, &value, &target));
+  ASSERT_FALSE(rc_runtime_format_achievement_measured(&runtime, 4, buffer, sizeof(buffer)));
+  ASSERT_STR_EQUALS(buffer, "");
 
-  /* both achievements are false, should activate */
-  ram[1] = ram[2] = 9;
+  /* achievements are false, should activate */
+  ram[2] = 9;
   assert_do_frame(&runtime, &memory);
   ASSERT_TRUE(rc_runtime_get_achievement_measured(&runtime, 1, &value, &target));
   ASSERT_NUM_EQUALS(value, 0);
   ASSERT_NUM_EQUALS(target, 0);
+  ASSERT_FALSE(rc_runtime_format_achievement_measured(&runtime, 1, buffer, sizeof(buffer)));
+  ASSERT_STR_EQUALS(buffer, "");
   ASSERT_TRUE(rc_runtime_get_achievement_measured(&runtime, 2, &value, &target));
   ASSERT_NUM_EQUALS(value, 9);
   ASSERT_NUM_EQUALS(target, 10);
+  ASSERT_TRUE(rc_runtime_format_achievement_measured(&runtime, 2, buffer, sizeof(buffer)));
+  ASSERT_STR_EQUALS(buffer, "9/10");
+  ASSERT_TRUE(rc_runtime_get_achievement_measured(&runtime, 3, &value, &target));
+  ASSERT_NUM_EQUALS(value, 9);
+  ASSERT_NUM_EQUALS(target, 10);
+  ASSERT_TRUE(rc_runtime_format_achievement_measured(&runtime, 3, buffer, sizeof(buffer)));
+  ASSERT_STR_EQUALS(buffer, "90%");
 
-  /* second achievement is true, should trigger - triggered achievement is not measurable */
+  /* value greater than target (i.e. "6 >= 5" should report maximum "5/5" or "100%" */
+  ram[2] = 12;
+  assert_do_frame(&runtime, &memory);
+  ASSERT_TRUE(rc_runtime_get_achievement_measured(&runtime, 1, &value, &target));
+  ASSERT_NUM_EQUALS(value, 0);
+  ASSERT_NUM_EQUALS(target, 0);
+  ASSERT_FALSE(rc_runtime_format_achievement_measured(&runtime, 1, buffer, sizeof(buffer)));
+  ASSERT_STR_EQUALS(buffer, "");
+  ASSERT_TRUE(rc_runtime_get_achievement_measured(&runtime, 2, &value, &target));
+  ASSERT_NUM_EQUALS(value, 12);
+  ASSERT_NUM_EQUALS(target, 10);
+  ASSERT_TRUE(rc_runtime_format_achievement_measured(&runtime, 2, buffer, sizeof(buffer)));
+  ASSERT_STR_EQUALS(buffer, "10/10");
+  ASSERT_TRUE(rc_runtime_get_achievement_measured(&runtime, 3, &value, &target));
+  ASSERT_NUM_EQUALS(value, 12);
+  ASSERT_NUM_EQUALS(target, 10);
+  ASSERT_TRUE(rc_runtime_format_achievement_measured(&runtime, 3, buffer, sizeof(buffer)));
+  ASSERT_STR_EQUALS(buffer, "100%");
+
+  /* achievements are true, should trigger - triggered achievement is not measurable */
   ram[2] = 10;
   assert_do_frame(&runtime, &memory);
   ASSERT_TRUE(rc_runtime_get_achievement_measured(&runtime, 1, &value, &target));
   ASSERT_NUM_EQUALS(value, 0);
   ASSERT_NUM_EQUALS(target, 0);
+  ASSERT_FALSE(rc_runtime_format_achievement_measured(&runtime, 1, buffer, sizeof(buffer)));
+  ASSERT_STR_EQUALS(buffer, "");
   ASSERT_TRUE(rc_runtime_get_achievement_measured(&runtime, 2, &value, &target));
   ASSERT_NUM_EQUALS(value, 0);
   ASSERT_NUM_EQUALS(target, 0);
+  ASSERT_FALSE(rc_runtime_format_achievement_measured(&runtime, 2, buffer, sizeof(buffer)));
+  ASSERT_STR_EQUALS(buffer, "");
+  ASSERT_TRUE(rc_runtime_get_achievement_measured(&runtime, 3, &value, &target));
+  ASSERT_NUM_EQUALS(value, 0);
+  ASSERT_NUM_EQUALS(target, 0);
+  ASSERT_FALSE(rc_runtime_format_achievement_measured(&runtime, 3, buffer, sizeof(buffer)));
+  ASSERT_STR_EQUALS(buffer, "");
+
+  rc_runtime_destroy(&runtime);
+}
+
+static void test_achievement_measured_maxint(void)
+{
+  unsigned char ram[] = { 0xFF, 0xFF, 0xFF, 0xFF };
+  char buffer[32];
+  memory_t memory;
+  rc_runtime_t runtime;
+  unsigned value, target;
+
+  memory.ram = ram;
+  memory.size = sizeof(ram);
+
+  rc_runtime_init(&runtime);
+
+  assert_activate_achievement(&runtime, 2, "M:0xX0000==hFFFFFFFF");
+  assert_activate_achievement(&runtime, 3, "G:0xX0000==hFFFFFFFF");
+
+  /* achievements are true, should remain in waiting state */
+  assert_do_frame(&runtime, &memory);
+  ASSERT_TRUE(rc_runtime_get_achievement_measured(&runtime, 2, &value, &target));
+  ASSERT_NUM_EQUALS(value, 0);
+  ASSERT_NUM_EQUALS(target, 0xFFFFFFFF);
+  ASSERT_TRUE(rc_runtime_format_achievement_measured(&runtime, 2, buffer, sizeof(buffer)));
+  ASSERT_STR_EQUALS(buffer, "0/4294967295");
+  ASSERT_TRUE(rc_runtime_get_achievement_measured(&runtime, 3, &value, &target));
+  ASSERT_NUM_EQUALS(value, 0);
+  ASSERT_NUM_EQUALS(target, 0xFFFFFFFF);
+  ASSERT_TRUE(rc_runtime_format_achievement_measured(&runtime, 3, buffer, sizeof(buffer)));
+  ASSERT_STR_EQUALS(buffer, "0%");
+
+  /* achievements are false (value fits in 31-bits), should activate */
+  ram[1] = ram[3] = 0x7F;
+  assert_do_frame(&runtime, &memory);
+  ASSERT_TRUE(rc_runtime_get_achievement_measured(&runtime, 2, &value, &target));
+  ASSERT_NUM_EQUALS(value, 0x7FFF7FFF);
+  ASSERT_NUM_EQUALS(target, 0xFFFFFFFF);
+  ASSERT_TRUE(rc_runtime_format_achievement_measured(&runtime, 2, buffer, sizeof(buffer)));
+  ASSERT_STR_EQUALS(buffer, "2147450879/4294967295");
+  ASSERT_TRUE(rc_runtime_get_achievement_measured(&runtime, 3, &value, &target));
+  ASSERT_NUM_EQUALS(value, 0x7FFF7FFF);
+  ASSERT_NUM_EQUALS(target, 0xFFFFFFFF);
+  ASSERT_TRUE(rc_runtime_format_achievement_measured(&runtime, 3, buffer, sizeof(buffer)));
+  ASSERT_STR_EQUALS(buffer, "49%");
+
+  /* achievements are false (value requires 32-bits) */
+  ram[1] = ram[3] = 0xFE;
+  assert_do_frame(&runtime, &memory);
+  ASSERT_TRUE(rc_runtime_get_achievement_measured(&runtime, 2, &value, &target));
+  ASSERT_NUM_EQUALS(value, 0xFEFFFEFF);
+  ASSERT_NUM_EQUALS(target, 0xFFFFFFFF);
+  ASSERT_TRUE(rc_runtime_format_achievement_measured(&runtime, 2, buffer, sizeof(buffer)));
+  ASSERT_STR_EQUALS(buffer, "4278189823/4294967295");
+  ASSERT_TRUE(rc_runtime_get_achievement_measured(&runtime, 3, &value, &target));
+  ASSERT_NUM_EQUALS(value, 0xFEFFFEFF);
+  ASSERT_NUM_EQUALS(target, 0xFFFFFFFF);
+  ASSERT_TRUE(rc_runtime_format_achievement_measured(&runtime, 3, buffer, sizeof(buffer)));
+  ASSERT_STR_EQUALS(buffer, "99%");
+
+  /* achievements are true, should trigger - triggered achievement is not measurable */
+  ram[1] = ram[3] = 0xFF;
+  assert_do_frame(&runtime, &memory);
+  ASSERT_TRUE(rc_runtime_get_achievement_measured(&runtime, 2, &value, &target));
+  ASSERT_NUM_EQUALS(value, 0);
+  ASSERT_NUM_EQUALS(target, 0);
+  ASSERT_FALSE(rc_runtime_format_achievement_measured(&runtime, 2, buffer, sizeof(buffer)));
+  ASSERT_STR_EQUALS(buffer, "");
+  ASSERT_TRUE(rc_runtime_get_achievement_measured(&runtime, 3, &value, &target));
+  ASSERT_NUM_EQUALS(value, 0);
+  ASSERT_NUM_EQUALS(target, 0);
+  ASSERT_FALSE(rc_runtime_format_achievement_measured(&runtime, 3, buffer, sizeof(buffer)));
+  ASSERT_STR_EQUALS(buffer, "");
 
   rc_runtime_destroy(&runtime);
 }
@@ -1273,6 +1398,7 @@ void test_runtime(void) {
   TEST(test_two_achievements_activate_and_trigger);
   TEST(test_deactivate_achievements);
   TEST(test_achievement_measured);
+  TEST(test_achievement_measured_maxint);
 
   TEST(test_shared_memref);
   TEST(test_replace_active_trigger);

--- a/test/rcheevos/test_trigger.c
+++ b/test/rcheevos/test_trigger.c
@@ -419,6 +419,45 @@ static void test_measured() {
 
   /* measured(repeated(3, byte(2) == 52)) */
   assert_parse_trigger(&trigger, buffer, "M:0xH0002=52(3)");
+  ASSERT_NUM_EQUALS(trigger->measured_as_percent, 0);
+
+  /* condition is true - hit count should be incremented */
+  assert_evaluate_trigger(trigger, &memory, 0);
+  assert_hit_count(trigger, 0, 0, 1U);
+  ASSERT_NUM_EQUALS(trigger->measured_value, 1U);
+  ASSERT_NUM_EQUALS(trigger->measured_target, 3U);
+
+  /* condition is true - hit count should be incremented */
+  assert_evaluate_trigger(trigger, &memory, 0);
+  assert_hit_count(trigger, 0, 0, 2U);
+  ASSERT_NUM_EQUALS(trigger->measured_value, 2U);
+  ASSERT_NUM_EQUALS(trigger->measured_target, 3U);
+
+  /* condition is true - hit count should be incremented to reach target */
+  assert_evaluate_trigger(trigger, &memory, 1);
+  assert_hit_count(trigger, 0, 0, 3U);
+  ASSERT_NUM_EQUALS(trigger->measured_value, 3U);
+  ASSERT_NUM_EQUALS(trigger->measured_target, 3U);
+
+  /* condition is true - target previously met */
+  assert_evaluate_trigger(trigger, &memory, 1);
+  assert_hit_count(trigger, 0, 0, 3U);
+  ASSERT_NUM_EQUALS(trigger->measured_value, 3U);
+  ASSERT_NUM_EQUALS(trigger->measured_target, 3U);
+}
+
+static void test_measured_as_percent() {
+  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  memory_t memory;
+  rc_trigger_t* trigger;
+  char buffer[256];
+
+  memory.ram = ram;
+  memory.size = sizeof(ram);
+
+  /* measured(repeated(3, byte(2) == 52)) */
+  assert_parse_trigger(&trigger, buffer, "G:0xH0002=52(3)");
+  ASSERT_NUM_EQUALS(trigger->measured_as_percent, 1);
 
   /* condition is true - hit count should be incremented */
   assert_evaluate_trigger(trigger, &memory, 0);
@@ -1759,6 +1798,7 @@ void test_trigger(void) {
 
   /* measured */
   TEST(test_measured);
+  TEST(test_measured_as_percent);
   TEST(test_measured_comparison);
   TEST(test_measured_addhits);
   TEST(test_measured_indirect);


### PR DESCRIPTION
This allows an achievement definition to hint at whether the measured progress should be displayed as a percentage (current behavior) or a raw value (i.e `35/80`). It's still up to the client to honor this hint.

This feature has been delayed for quite some time due to concerns over how best to implement it. The cleanest solution would be to add a flag to the achievement itself indicating how the progress data should be displayed, but that would require API changes. Another possibility would be to allow the user to toggle the display, but the decision really should be up to the developer. The final suggestion was to add a new flag to differentiate between MeasuredRaw and MeasuredPct.

The fact that an achievement has progress data is currently derived from the presence of a Measured condition within the achievement, so the solution that I've chosen to implement was to add a second Measured flag to the syntax (`G`) that tells the achievement that a percentage should be displayed. However, this is not an actual unique flag that can be assigned to a condition. Instead, when it's seen, it's mapped to `M`, and a flag is set on the `rc_trigger_t` indicating a percentage display is preferred. `M` will not set this flag, so all existing achievements will automatically switch over to showing raw values once this feature is rolled out. We believe this to be desirable after discussing in discord, as there are very few achievements where a the raw value does not reflect the target described by the achievement description.

Because both `M` and `G` map to `RC_CONDITION_MEASURED`, there will not be a new flag in the achievement editor. Instead, a checkbox will be added which will inform the serializer whether to generate an `M` or `G` for the Measured conditions in the achievement. This will maintain the appearance that the property is associated to the achievement and not the individual conditions.