### PR TITLE
address compiler warnings

### DIFF
--- a/include/rc_hash.h
+++ b/include/rc_hash.h
@@ -16,7 +16,7 @@ extern "C" {
   /* generates a hash from a block of memory.
    * returns non-zero on success, or zero on failure.
    */
-  int rc_hash_generate_from_buffer(char hash[33], int console_id, uint8_t* buffer, size_t buffer_size);
+  int rc_hash_generate_from_buffer(char hash[33], int console_id, const uint8_t* buffer, size_t buffer_size);
 
   /* generates a hash from a file.
    * returns non-zero on success, or zero on failure.

--- a/src/rapi/rc_api_common.c
+++ b/src/rapi/rc_api_common.c
@@ -296,6 +296,7 @@ static int rc_json_missing_field(rc_api_response_t* response, const rc_json_fiel
 
 int rc_json_get_required_object(rc_json_field_t* fields, size_t field_count, rc_api_response_t* response, rc_json_field_t* field, const char* field_name) {
   const char* json = field->value_start;
+  (void)field_name;
 
   if (!json)
     return rc_json_missing_field(response, field);
@@ -357,6 +358,7 @@ int rc_json_get_required_array(unsigned* num_entries, rc_json_field_t* iterator,
     return rc_json_missing_field(response, field);
   }
 
+  (void)field_name;
   memcpy(iterator, field, sizeof(*iterator));
   ++iterator->value_start; /* skip [ */
 
@@ -388,7 +390,7 @@ static unsigned rc_json_decode_hex4(const char* input) {
   memcpy(hex, input, 4);
   hex[4] = '\0';
 
-  return strtol(hex, NULL, 16);
+  return (unsigned)strtol(hex, NULL, 16);
 }
 
 static int rc_json_ucs32_to_utf8(unsigned char* dst, unsigned ucs32_char) {

--- a/src/rapi/rc_api_common.c
+++ b/src/rapi/rc_api_common.c
@@ -296,7 +296,10 @@ static int rc_json_missing_field(rc_api_response_t* response, const rc_json_fiel
 
 int rc_json_get_required_object(rc_json_field_t* fields, size_t field_count, rc_api_response_t* response, rc_json_field_t* field, const char* field_name) {
   const char* json = field->value_start;
-  (void)field_name;
+#ifndef NDEBUG
+  if (strcmp(field->name, field_name) != 0)
+    return 0;
+#endif
 
   if (!json)
     return rc_json_missing_field(response, field);
@@ -353,12 +356,16 @@ int rc_json_get_required_unum_array(unsigned** entries, unsigned* num_entries, r
 }
 
 int rc_json_get_required_array(unsigned* num_entries, rc_json_field_t* iterator, rc_api_response_t* response, const rc_json_field_t* field, const char* field_name) {
+#ifndef NDEBUG
+  if (strcmp(field->name, field_name) != 0)
+    return 0;
+#endif
+
   if (!field->value_start || *field->value_start != '[') {
     *num_entries = 0;
     return rc_json_missing_field(response, field);
   }
 
-  (void)field_name;
   memcpy(iterator, field, sizeof(*iterator));
   ++iterator->value_start; /* skip [ */
 

--- a/src/rapi/rc_api_common.c
+++ b/src/rapi/rc_api_common.c
@@ -397,7 +397,7 @@ static unsigned rc_json_decode_hex4(const char* input) {
   memcpy(hex, input, 4);
   hex[4] = '\0';
 
-  return (unsigned)strtol(hex, NULL, 16);
+  return (unsigned)strtoul(hex, NULL, 16);
 }
 
 static int rc_json_ucs32_to_utf8(unsigned char* dst, unsigned ucs32_char) {

--- a/src/rapi/rc_api_common.c
+++ b/src/rapi/rc_api_common.c
@@ -1093,7 +1093,7 @@ int rc_api_init_fetch_image_request(rc_api_request_t* request, const rc_api_fetc
     case RC_IMAGE_TYPE_USER:
       rc_url_builder_append(&builder, "/UserPic/", 9);
       rc_url_builder_append(&builder, api_params->image_name, strlen(api_params->image_name));
-      rc_url_builder_append(&builder, ".png", 9);
+      rc_url_builder_append(&builder, ".png", 4);
       break;
 
     default:

--- a/src/rapi/rc_api_info.c
+++ b/src/rapi/rc_api_info.c
@@ -81,7 +81,7 @@ int rc_api_process_fetch_achievement_info_response(rc_api_fetch_achievement_info
   if (!rc_json_get_required_unum(&response->game_id, &response->response, &response_fields[2], "GameID"))
     return RC_MISSING_VALUE;
 
-  if (!rc_json_get_required_array(&response->num_recently_awarded, &iterator, &response->response, &response_fields[3], "RecentWinners"))
+  if (!rc_json_get_required_array(&response->num_recently_awarded, &iterator, &response->response, &response_fields[3], "RecentWinner"))
     return RC_MISSING_VALUE;
 
   if (response->num_recently_awarded) {
@@ -184,7 +184,7 @@ int rc_api_process_fetch_leaderboard_info_response(rc_api_fetch_leaderboard_info
   if (result != RC_OK)
     return result;
 
-  if (!rc_json_get_required_object(leaderboarddata_fields, sizeof(leaderboarddata_fields) / sizeof(leaderboarddata_fields[0]), &response->response, &fields[2], "Response"))
+  if (!rc_json_get_required_object(leaderboarddata_fields, sizeof(leaderboarddata_fields) / sizeof(leaderboarddata_fields[0]), &response->response, &fields[2], "LeaderboardData"))
     return RC_MISSING_VALUE;
 
   if (!rc_json_get_required_unum(&response->id, &response->response, &leaderboarddata_fields[0], "LBID"))

--- a/src/rapi/rc_api_runtime.c
+++ b/src/rapi/rc_api_runtime.c
@@ -129,7 +129,7 @@ int rc_api_process_fetch_game_data_response(rc_api_fetch_game_data_response_t* r
   if (result != RC_OK)
     return result;
 
-  if (!rc_json_get_required_object(patchdata_fields, sizeof(patchdata_fields) / sizeof(patchdata_fields[0]), &response->response, &fields[2], "Response"))
+  if (!rc_json_get_required_object(patchdata_fields, sizeof(patchdata_fields) / sizeof(patchdata_fields[0]), &response->response, &fields[2], "PatchData"))
     return RC_MISSING_VALUE;
 
   if (!rc_json_get_required_unum(&response->id, &response->response, &patchdata_fields[0], "ID"))

--- a/src/rcheevos/condition.c
+++ b/src/rcheevos/condition.c
@@ -95,7 +95,7 @@ rc_condition_t* rc_parse_condition(const char** memaddr, rc_parse_state_t* parse
     self->type = RC_CONDITION_STANDARD;
   }
 
-  result = rc_parse_operand(&self->operand1, &aux, 1, is_indirect, parse);
+  result = rc_parse_operand(&self->operand1, &aux, is_indirect, parse);
   if (result < 0) {
     parse->offset = result;
     return 0;
@@ -158,7 +158,7 @@ rc_condition_t* rc_parse_condition(const char** memaddr, rc_parse_state_t* parse
       break;
   }
 
-  result = rc_parse_operand(&self->operand2, &aux, 1, is_indirect, parse);
+  result = rc_parse_operand(&self->operand2, &aux, is_indirect, parse);
   if (result < 0) {
     parse->offset = result;
     return 0;

--- a/src/rcheevos/condset.c
+++ b/src/rcheevos/condset.c
@@ -18,7 +18,7 @@ static void rc_update_condition_pause(rc_condition_t* condition, int* in_pause) 
     case RC_CONDITION_OR_NEXT:
     case RC_CONDITION_ADD_ADDRESS:
     case RC_CONDITION_RESET_NEXT_IF:
-      condition->pause = *in_pause;
+      condition->pause = (char)*in_pause;
       break;
 
     default:
@@ -210,7 +210,7 @@ static int rc_test_condset_internal(rc_condset_t* self, int processing_pause, rc
     }
 
     /* STEP 2: evaluate the current condition */
-    condition->is_true = rc_test_condition(condition, eval_state);
+    condition->is_true = (char)rc_test_condition(condition, eval_state);
     eval_state->add_value = 0;
     eval_state->add_address = 0;
 
@@ -371,7 +371,7 @@ static int rc_test_condset_internal(rc_condset_t* self, int processing_pause, rc
   /* if not suppressed, update the measured value */
   if (measured_value > eval_state->measured_value && can_measure) {
     eval_state->measured_value = measured_value;
-    eval_state->measured_from_hits = measured_from_hits;
+    eval_state->measured_from_hits = (char)measured_from_hits;
   }
 
   return set_valid;
@@ -384,8 +384,9 @@ int rc_test_condset(rc_condset_t* self, rc_eval_state_t* eval_state) {
   }
 
   if (self->has_pause) {
-    if ((self->is_paused = rc_test_condset_internal(self, 1, eval_state))) {
-      /* one or more Pause conditions exists, if any of them are true, stop processing this group */
+    /* one or more Pause conditions exists, if any of them are true, stop processing this group */
+    self->is_paused = (char)rc_test_condset_internal(self, 1, eval_state);
+    if (self->is_paused) {
       eval_state->primed = 0;
       return 0;
     }

--- a/src/rcheevos/operand.c
+++ b/src/rcheevos/operand.c
@@ -103,7 +103,7 @@ static int rc_parse_operand_memory(rc_operand_t* self, const char** memaddr, rc_
     return ret;
 
   size = rc_memref_shared_size(self->size);
-  self->value.memref = rc_alloc_memref(parse, address, size, is_indirect);
+  self->value.memref = rc_alloc_memref(parse, address, size, (char)is_indirect);
   if (parse->offset < 0)
     return parse->offset;
 
@@ -111,7 +111,7 @@ static int rc_parse_operand_memory(rc_operand_t* self, const char** memaddr, rc_
   return RC_OK;
 }
 
-int rc_parse_operand(rc_operand_t* self, const char** memaddr, int is_trigger, int is_indirect, rc_parse_state_t* parse) {
+int rc_parse_operand(rc_operand_t* self, const char** memaddr, int is_indirect, rc_parse_state_t* parse) {
   const char* aux = *memaddr;
   char* end;
   int ret;

--- a/src/rcheevos/rc_internal.h
+++ b/src/rcheevos/rc_internal.h
@@ -131,7 +131,7 @@ rc_condition_t* rc_parse_condition(const char** memaddr, rc_parse_state_t* parse
 int rc_test_condition(rc_condition_t* self, rc_eval_state_t* eval_state);
 int rc_evaluate_condition_value(rc_condition_t* self, rc_eval_state_t* eval_state);
 
-int rc_parse_operand(rc_operand_t* self, const char** memaddr, int is_trigger, int is_indirect, rc_parse_state_t* parse);
+int rc_parse_operand(rc_operand_t* self, const char** memaddr, int is_indirect, rc_parse_state_t* parse);
 unsigned rc_evaluate_operand(rc_operand_t* self, rc_eval_state_t* eval_state);
 
 void rc_parse_value_internal(rc_value_t* self, const char** memaddr, rc_parse_state_t* parse);

--- a/src/rcheevos/richpresence.c
+++ b/src/rcheevos/richpresence.c
@@ -493,7 +493,7 @@ void rc_parse_richpresence_internal(rc_richpresence_t* self, const char* script,
         memcpy(format, line, chars);
         format[chars] = '\0';
 
-        lookup->format = rc_parse_format(format);
+        lookup->format = (unsigned short)rc_parse_format(format);
       } else {
         lookup->format = RC_FORMAT_VALUE;
       }

--- a/src/rcheevos/runtime_progress.c
+++ b/src/rcheevos/runtime_progress.c
@@ -247,7 +247,7 @@ static int rc_runtime_progress_read_condset(rc_runtime_progress_t* progress, rc_
   rc_condition_t* cond;
   unsigned flags;
 
-  condset->is_paused = rc_runtime_progress_read_uint(progress);
+  condset->is_paused = (char)rc_runtime_progress_read_uint(progress);
 
   cond = condset->conditions;
   while (cond) {
@@ -311,7 +311,7 @@ static int rc_runtime_progress_read_trigger(rc_runtime_progress_t* progress, rc_
   rc_condset_t* condset;
   int result;
 
-  trigger->state = rc_runtime_progress_read_uint(progress);
+  trigger->state = (char)rc_runtime_progress_read_uint(progress);
   trigger->measured_value = rc_runtime_progress_read_uint(progress);
 
   if (trigger->requirement) {

--- a/src/rhash/hash.c
+++ b/src/rhash/hash.c
@@ -1567,7 +1567,7 @@ int rc_hash_generate_from_buffer(char hash[33], int console_id, uint8_t* buffer,
   }
 }
 
-static int rc_hash_whole_file(char hash[33], int console_id, const char* path)
+static int rc_hash_whole_file(char hash[33], const char* path)
 {
   md5_state_t md5;
   uint8_t* buffer;
@@ -1828,7 +1828,7 @@ int rc_hash_generate_from_file(char hash[33], int console_id, const char* path)
     case RC_CONSOLE_VIRTUAL_BOY:
     case RC_CONSOLE_WONDERSWAN:
       /* generic whole-file hash - don't buffer */
-      return rc_hash_whole_file(hash, console_id, path);
+      return rc_hash_whole_file(hash, path);
 
     case RC_CONSOLE_MSX:
     case RC_CONSOLE_PC8800:
@@ -1836,7 +1836,7 @@ int rc_hash_generate_from_file(char hash[33], int console_id, const char* path)
       if (rc_path_compare_extension(path, "m3u"))
         return rc_hash_generate_from_playlist(hash, console_id, path);
 
-      return rc_hash_whole_file(hash, console_id, path);
+      return rc_hash_whole_file(hash, path);
 
     case RC_CONSOLE_ATARI_7800:
     case RC_CONSOLE_ATARI_LYNX:
@@ -1902,7 +1902,7 @@ int rc_hash_generate_from_file(char hash[33], int console_id, const char* path)
   }
 }
 
-static void rc_hash_iterator_append_console(struct rc_hash_iterator* iterator, int console_id)
+static void rc_hash_iterator_append_console(struct rc_hash_iterator* iterator, uint8_t console_id)
 {
   int i = 0;
   while (iterator->consoles[i] != 0)

--- a/src/rhash/hash.c
+++ b/src/rhash/hash.c
@@ -1359,7 +1359,6 @@ static int rc_hash_psx(char hash[33], const char* path)
   void* track_handle;
   uint32_t sector;
   unsigned size;
-  size_t num_read;
   int result = 0;
   md5_state_t md5;
 
@@ -1379,7 +1378,7 @@ static int rc_hash_psx(char hash[33], const char* path)
   {
     rc_hash_error("Could not locate primary executable");
   }
-  else if ((num_read = rc_cd_read_sector(track_handle, sector, buffer, sizeof(buffer))) < sizeof(buffer))
+  else if (rc_cd_read_sector(track_handle, sector, buffer, sizeof(buffer)) < sizeof(buffer))
   {
     rc_hash_error("Could not read primary executable");
   }
@@ -1424,7 +1423,6 @@ static int rc_hash_ps2(char hash[33], const char* path)
   void* track_handle;
   uint32_t sector;
   unsigned size;
-  size_t num_read;
   int result = 0;
   md5_state_t md5;
 
@@ -1437,7 +1435,7 @@ static int rc_hash_ps2(char hash[33], const char* path)
   {
     rc_hash_error("Could not locate primary executable");
   }
-  else if ((num_read = rc_cd_read_sector(track_handle, sector, buffer, sizeof(buffer))) < sizeof(buffer))
+  else if (rc_cd_read_sector(track_handle, sector, buffer, sizeof(buffer)) < sizeof(buffer))
   {
     rc_hash_error("Could not read primary executable");
   }

--- a/src/rhash/hash.c
+++ b/src/rhash/hash.c
@@ -361,7 +361,7 @@ static int rc_hash_finalize(md5_state_t* md5, char hash[33])
   return 1;
 }
 
-static int rc_hash_buffer(char hash[33], uint8_t* buffer, size_t buffer_size)
+static int rc_hash_buffer(char hash[33], const uint8_t* buffer, size_t buffer_size)
 {
   md5_state_t md5;
   md5_init(&md5);
@@ -558,7 +558,7 @@ static int rc_hash_3do(char hash[33], const char* path)
   return rc_hash_finalize(&md5, hash);
 }
 
-static int rc_hash_7800(char hash[33], uint8_t* buffer, size_t buffer_size)
+static int rc_hash_7800(char hash[33], const uint8_t* buffer, size_t buffer_size)
 {
   /* if the file contains a header, ignore it */
   if (memcmp(&buffer[1], "ATARI7800", 9) == 0)
@@ -645,7 +645,7 @@ static int rc_hash_arcade(char hash[33], const char* path)
   return rc_hash_buffer(hash, (uint8_t*)filename, filename_length);
 }
 
-static int rc_hash_lynx(char hash[33], uint8_t* buffer, size_t buffer_size)
+static int rc_hash_lynx(char hash[33], const uint8_t* buffer, size_t buffer_size)
 {
   /* if the file contains a header, ignore it */
   if (buffer[0] == 'L' && buffer[1] == 'Y' && buffer[2] == 'N' && buffer[3] == 'X' && buffer[4] == 0)
@@ -659,7 +659,7 @@ static int rc_hash_lynx(char hash[33], uint8_t* buffer, size_t buffer_size)
   return rc_hash_buffer(hash, buffer, buffer_size);
 }
 
-static int rc_hash_nes(char hash[33], uint8_t* buffer, size_t buffer_size)
+static int rc_hash_nes(char hash[33], const uint8_t* buffer, size_t buffer_size)
 {
   /* if the file contains a header, ignore it */
   if (buffer[0] == 'N' && buffer[1] == 'E' && buffer[2] == 'S' && buffer[3] == 0x1A)
@@ -708,7 +708,7 @@ static void rc_hash_n64_to_z64(uint8_t* buffer, const uint8_t* stop)
   }
 }
 
-static int rc_hash_n64(char hash[33], uint8_t* buffer, size_t buffer_size)
+static int rc_hash_n64(char hash[33], const uint8_t* buffer, size_t buffer_size)
 {
   uint8_t* swapbuffer;
   uint8_t* stop;
@@ -997,7 +997,7 @@ static int rc_hash_nintendo_ds(char hash[33], const char* path)
   return rc_hash_finalize(&md5, hash);
 }
 
-static int rc_hash_pce(char hash[33], uint8_t* buffer, size_t buffer_size)
+static int rc_hash_pce(char hash[33], const uint8_t* buffer, size_t buffer_size)
 {
   /* if the file contains a header, ignore it (expect ROM data to be multiple of 128KB) */
   uint32_t calc_size = ((uint32_t)buffer_size / 0x20000) * 0x20000;
@@ -1495,7 +1495,7 @@ static int rc_hash_sega_cd(char hash[33], const char* path)
   return rc_hash_buffer(hash, buffer, sizeof(buffer));
 }
 
-static int rc_hash_snes(char hash[33], uint8_t* buffer, size_t buffer_size)
+static int rc_hash_snes(char hash[33], const uint8_t* buffer, size_t buffer_size)
 {
   /* if the file contains a header, ignore it */
   uint32_t calc_size = ((uint32_t)buffer_size / 0x2000) * 0x2000;
@@ -1510,7 +1510,7 @@ static int rc_hash_snes(char hash[33], uint8_t* buffer, size_t buffer_size)
   return rc_hash_buffer(hash, buffer, buffer_size);
 }
 
-int rc_hash_generate_from_buffer(char hash[33], int console_id, uint8_t* buffer, size_t buffer_size)
+int rc_hash_generate_from_buffer(char hash[33], int console_id, const uint8_t* buffer, size_t buffer_size)
 {
   switch (console_id)
   {

--- a/test/rcheevos/test_condition.c
+++ b/test/rcheevos/test_condition.c
@@ -49,8 +49,8 @@ static void _assert_parse_condition(
     ASSERT_HELPER(_assert_parse_condition(memaddr, expected_type, expected_left_type, expected_left_size, expected_left_value, \
                                           expected_operator, expected_right_type, expected_right_size, expected_right_value, expected_required_hits), "assert_parse_condition")
 
-static void test_parse_condition(const char* memaddr, int expected_type, int expected_left_type,
-    int expected_operator, int expected_required_hits) {
+static void test_parse_condition(const char* memaddr, char expected_type, char expected_left_type,
+    char expected_operator, int expected_required_hits) {
   if (expected_operator == RC_OPERATOR_NONE) {
     assert_parse_condition(memaddr, expected_type,
       expected_left_type, RC_MEMSIZE_8_BITS, 0x1234U,
@@ -70,8 +70,8 @@ static void test_parse_condition(const char* memaddr, int expected_type, int exp
 }
 
 static void test_parse_operands(const char* memaddr,
-    int expected_left_type, int expected_left_size, unsigned expected_left_value,
-    int expected_right_type, int expected_right_size, unsigned expected_right_value) {
+    char expected_left_type, char expected_left_size, unsigned expected_left_value,
+    char expected_right_type, char expected_right_size, unsigned expected_right_value) {
   assert_parse_condition(memaddr, RC_CONDITION_STANDARD,
     expected_left_type, expected_left_size, expected_left_value,
     RC_OPERATOR_EQ,
@@ -80,7 +80,7 @@ static void test_parse_operands(const char* memaddr,
   );
 }
 
-static void test_parse_modifier(const char* memaddr, int expected_operator, int expected_operand, double expected_multiplier) {
+static void test_parse_modifier(const char* memaddr, char expected_operator, char expected_operand, double expected_multiplier) {
   assert_parse_condition(memaddr, RC_CONDITION_ADD_SOURCE,
     RC_OPERAND_ADDRESS, RC_MEMSIZE_8_BITS, 0x1234U,
     expected_operator,
@@ -89,7 +89,7 @@ static void test_parse_modifier(const char* memaddr, int expected_operator, int 
   );
 }
 
-static void test_parse_modifier_shorthand(const char* memaddr, int expected_type) {
+static void test_parse_modifier_shorthand(const char* memaddr, char expected_type) {
   assert_parse_condition(memaddr, expected_type,
     RC_OPERAND_ADDRESS, RC_MEMSIZE_8_BITS, 0x1234U,
     RC_OPERATOR_NONE,

--- a/test/rcheevos/test_operand.c
+++ b/test/rcheevos/test_operand.c
@@ -10,7 +10,7 @@ static void _assert_parse_operand(rc_operand_t* self, char* buffer, const char**
 
   rc_init_parse_state(&parse, buffer, 0, 0);
   rc_init_parse_state_memrefs(&parse, &memrefs);
-  ret = rc_parse_operand(self, memaddr, 1, 0, &parse);
+  ret = rc_parse_operand(self, memaddr, 0, &parse);
   rc_destroy_parse_state(&parse);
 
   ASSERT_NUM_GREATER_EQUALS(ret, 0);
@@ -67,7 +67,7 @@ static void test_parse_error_operand(const char* memaddr, int valid_chars, int e
 
   rc_init_parse_state(&parse, 0, 0, 0);
   rc_init_parse_state_memrefs(&parse, &memrefs);
-  ret = rc_parse_operand(&self, &memaddr, 1, 0, &parse);
+  ret = rc_parse_operand(&self, &memaddr, 0, &parse);
   rc_destroy_parse_state(&parse);
 
   ASSERT_NUM_EQUALS(expected_error, ret);
@@ -95,7 +95,7 @@ static void test_evaluate_operand(const char* memaddr, memory_t* memory, unsigne
 
   rc_init_parse_state(&parse, buffer, 0, 0);
   rc_init_parse_state_memrefs(&parse, &memrefs);
-  rc_parse_operand(&self, &memaddr, 1, 0, &parse);
+  rc_parse_operand(&self, &memaddr, 0, &parse);
   rc_destroy_parse_state(&parse);
 
   value = evaluate_operand(&self, memory, memrefs);
@@ -433,7 +433,7 @@ static void test_evaluate_delta_memory_reference() {
   memaddr = "d0xh1";
   rc_init_parse_state(&parse, buffer, 0, 0);
   rc_init_parse_state_memrefs(&parse, &memrefs);
-  rc_parse_operand(&op, &memaddr, 1, 0, &parse);
+  rc_parse_operand(&op, &memaddr, 0, &parse);
   rc_destroy_parse_state(&parse);
 
   ASSERT_UNUM_EQUALS(evaluate_operand(&op, &memory, memrefs), 0x00); /* first call gets uninitialized value */
@@ -471,7 +471,7 @@ void test_evaluate_prior_memory_reference() {
   memaddr = "p0xh1";
   rc_init_parse_state(&parse, buffer, 0, 0);
   rc_init_parse_state_memrefs(&parse, &memrefs);
-  rc_parse_operand(&op, &memaddr, 1, 0, &parse);
+  rc_parse_operand(&op, &memaddr, 0, &parse);
   rc_destroy_parse_state(&parse);
 
   /* RC_OPERAND_PRIOR only updates when the memory value changes */

--- a/test/rcheevos/test_runtime.c
+++ b/test/rcheevos/test_runtime.c
@@ -442,6 +442,8 @@ static void test_trigger_with_resetif() {
   ASSERT_NUM_EQUALS(runtime.triggers[0].trigger->state, RC_TRIGGER_STATE_PRIMED);
   ASSERT_NUM_EQUALS(event_count, 1);
   assert_event(RC_RUNTIME_EVENT_ACHIEVEMENT_PRIMED, 1, 0);
+
+  rc_runtime_destroy(&runtime);
 }
 
 static void test_trigger_with_resetnextif() {
@@ -494,6 +496,8 @@ static void test_trigger_with_resetnextif() {
   ASSERT_NUM_EQUALS(event_count, 2);
   assert_event(RC_RUNTIME_EVENT_ACHIEVEMENT_RESET, 1, 0);
   assert_event(RC_RUNTIME_EVENT_ACHIEVEMENT_UNPRIMED, 1, 0);
+
+  rc_runtime_destroy(&runtime);
 }
 
 static void test_reset_event(void)

--- a/test/rcheevos/test_runtime.c
+++ b/test/rcheevos/test_runtime.c
@@ -13,7 +13,7 @@ static void event_handler(const rc_runtime_event_t* e)
   memcpy(&events[event_count++], e, sizeof(rc_runtime_event_t));
 }
 
-static void _assert_event(char type, int id, int value)
+static void _assert_event(char type, unsigned id, int value)
 {
   int i;
 

--- a/test/rcheevos/test_runtime_progress.c
+++ b/test/rcheevos/test_runtime_progress.c
@@ -14,6 +14,7 @@ static void _assert_activate_achievement(rc_runtime_t* runtime, unsigned int id,
 
 static void event_handler(const rc_runtime_event_t* e)
 {
+    (void)e;
 }
 
 static void assert_do_frame(rc_runtime_t* runtime, memory_t* memory)

--- a/test/rhash/data.c
+++ b/test/rhash/data.c
@@ -81,7 +81,7 @@ static void fill_image(uint8_t* image, size_t size)
 
       default:
         count = 1;
-        value = (seed >> 8) ^ (seed >> 16);
+        value = ((seed >> 8) ^ (seed >> 16)) & 0xFF;
         break;
     }
 
@@ -278,11 +278,11 @@ uint8_t* generate_3do_bin(unsigned root_directory_sectors, unsigned binary_size,
     }
     else
     {
-      image[offset + 0x14 + 0x48 + 0x11] = (binary_size >> 16);
+      image[offset + 0x14 + 0x48 + 0x11] = (binary_size >> 16) & 0xFF;
       image[offset + 0x14 + 0x48 + 0x12] = (binary_size >> 8) & 0xFF;
       image[offset + 0x14 + 0x48 + 0x13] = (binary_size & 0xFF);
 
-      image[offset + 0x14 + 0x48 + 0x16] = ((binary_size + 2047) / 2048) >> 8;
+      image[offset + 0x14 + 0x48 + 0x16] = (((binary_size + 2047) / 2048) >> 8) & 0xFF;
       image[offset + 0x14 + 0x48 + 0x17] = ((binary_size + 2047) / 2048) & 0xFF;
 
       image[offset + 0x14 + 0x48 + 0x47] = (uint8_t)(i + 2);

--- a/test/rhash/mock_filereader.c
+++ b/test/rhash/mock_filereader.c
@@ -78,6 +78,7 @@ static size_t _mock_file_read(void* file_handle, void* buffer, size_t count)
 
 static void _mock_file_close(void* file_handle)
 {
+    (void)file_handle;
 }
 
 static void reset_mock_files()

--- a/validator/validator.c
+++ b/validator/validator.c
@@ -155,7 +155,7 @@ static void validate_richpresence_file(const char* richpresence_file, char resul
   file_contents[file_size] = '\0';
   fclose(file);
 
-  validate_richpresence(file_contents, result, sizeof(result), 0xFFFFFFFF);
+  validate_richpresence(file_contents, result, result_size, 0xFFFFFFFF);
 
   free(file_contents);
 }
@@ -286,6 +286,7 @@ static void validate_patchdata_directory(const char* patchdata_directory, int er
   char* filename;
   size_t filename_len;
   char path[2048];
+  int need_newline = 0;
 
   DIR* dir = opendir(patchdata_directory);
   if (!dir) {


### PR DESCRIPTION
Fixes more warnings captured in some of the RetroArch builds, as well as several unused variable and casting-type warnings generated when using /w4 in visual studio.
```
In function 'rc_url_builder_append',
    inlined from 'rc_url_builder_append' at deps/rcheevos/src/rapi/rc_api_common.c:862:6,
    inlined from 'rc_api_init_fetch_image_request' at deps/rcheevos/src/rapi/rc_api_common.c:1024:7:
deps/rcheevos/src/rapi/rc_api_common.c:864:5: warning: 'memcpy' forming offset [5, 8] is out of the bounds [0, 5] [-Warray-bounds]
  864 |     memcpy(builder->write, data, len);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
```
In file included from /Users/gitlab/builds/FkGsyN3z/2/libretro/RetroArch/griffin/griffin.c:198:
/Users/gitlab/builds/FkGsyN3z/2/libretro/RetroArch/griffin/../deps/rcheevos/src/rapi/rc_api_common.c:361:10: warning: implicit conversion loses integer precision: 'long' to 'unsigned int' [-Wshorten-64-to-32]
  return strtol(hex, NULL, 16);
  ~~~~~~ ^~~~~~~~~~~~~~~~~~~~~
```