### PR TITLE
Add built-in macros

### DIFF
--- a/src/rcheevos/richpresence.c
+++ b/src/rcheevos/richpresence.c
@@ -175,6 +175,12 @@ static rc_richpresence_display_t* rc_parse_richpresence_display_internal(const c
 
       if (!lookup) {
         static const rc_richpresence_builtin_macro_t builtin_macros[] = {
+          {"Number", 6, RC_FORMAT_VALUE},
+          {"Score", 5, RC_FORMAT_SCORE},
+          {"Centiseconds", 12, RC_FORMAT_CENTISECS},
+          {"Seconds", 7, RC_FORMAT_SECONDS},
+          {"Minutes", 7, RC_FORMAT_MINUTES},
+          {"SecondsAsMinutes", 16, RC_FORMAT_SECONDS_AS_MINUTES},
           {"ASCIIChar", 9, RC_FORMAT_ASCIICHAR},
           {"UnicodeChar", 11, RC_FORMAT_UNICODECHAR},
         };

--- a/src/rcheevos/richpresence.c
+++ b/src/rcheevos/richpresence.c
@@ -190,7 +190,7 @@ static rc_richpresence_display_t* rc_parse_richpresence_display_internal(const c
           {"Float5", 6, RC_FORMAT_FLOAT5},
           {"Float6", 6, RC_FORMAT_FLOAT6},
         };
-        int i;
+        size_t i;
 
         for (i = 0; i < sizeof(builtin_macros) / sizeof(builtin_macros[0]); ++i) {
           if (macro_len == builtin_macros[i].name_len &&

--- a/test/rcheevos/test_richpresence.c
+++ b/test/rcheevos/test_richpresence.c
@@ -1031,6 +1031,22 @@ static void test_builtin_macro(const char* macro, const char* expected) {
   assert_richpresence_output(richpresence, &memory, expected);
 }
 
+static void test_builtin_macro_float(const char* macro, const char* expected) {
+  unsigned char ram[] = { 0x92, 0x44, 0x9A, 0x42 }; /* 77.133926 */
+  memory_t memory;
+  rc_richpresence_t* richpresence;
+  char script[128];
+  char buffer[512];
+
+  memory.ram = ram;
+  memory.size = sizeof(ram);
+
+  snprintf(script, sizeof(script), "Display:\n@%s(fF0000)", macro);
+
+  assert_parse_richpresence(&richpresence, buffer, script);
+  assert_richpresence_output(richpresence, &memory, expected);
+}
+
 static void test_builtin_macro_override() {
   unsigned char ram[] = { 0x39, 0x30 };
   memory_t memory;
@@ -1256,6 +1272,12 @@ void test_richpresence(void) {
   TEST_PARAMS2(test_builtin_macro, "SecondsAsMinutes", "3h25");
   TEST_PARAMS2(test_builtin_macro, "ASCIIChar", "?"); // 0x3039 is not a single ASCII char
   TEST_PARAMS2(test_builtin_macro, "UnicodeChar", "\xe3\x80\xb9");
+  TEST_PARAMS2(test_builtin_macro_float, "Float1", "77.1");
+  TEST_PARAMS2(test_builtin_macro_float, "Float2", "77.13");
+  TEST_PARAMS2(test_builtin_macro_float, "Float3", "77.134");
+  TEST_PARAMS2(test_builtin_macro_float, "Float4", "77.1339");
+  TEST_PARAMS2(test_builtin_macro_float, "Float5", "77.13393");
+  TEST_PARAMS2(test_builtin_macro_float, "Float6", "77.133926");
   TEST(test_builtin_macro_override);
 
   /* asciichar */

--- a/test/rcheevos/test_richpresence.c
+++ b/test/rcheevos/test_richpresence.c
@@ -1270,7 +1270,7 @@ void test_richpresence(void) {
   TEST_PARAMS2(test_builtin_macro, "Seconds", "3h25:45");
   TEST_PARAMS2(test_builtin_macro, "Minutes", "205h45");
   TEST_PARAMS2(test_builtin_macro, "SecondsAsMinutes", "3h25");
-  TEST_PARAMS2(test_builtin_macro, "ASCIIChar", "?"); // 0x3039 is not a single ASCII char
+  TEST_PARAMS2(test_builtin_macro, "ASCIIChar", "?"); /* 0x3039 is not a single ASCII char */
   TEST_PARAMS2(test_builtin_macro, "UnicodeChar", "\xe3\x80\xb9");
   TEST_PARAMS2(test_builtin_macro_float, "Float1", "77.1");
   TEST_PARAMS2(test_builtin_macro_float, "Float2", "77.13");

--- a/test/rcheevos/test_richpresence.c
+++ b/test/rcheevos/test_richpresence.c
@@ -993,6 +993,22 @@ static void test_macro_non_numeric_parameter() {
   ASSERT_NUM_EQUALS(lines, 5);
 }
 
+static void test_builtin_macro(const char* macro, const char* expected) {
+  unsigned char ram[] = { 0x39, 0x30 };
+  memory_t memory;
+  rc_richpresence_t* richpresence;
+  char script[128];
+  char buffer[256];
+
+  memory.ram = ram;
+  memory.size = sizeof(ram);
+
+  snprintf(script, sizeof(script), "Display:\n@%s(0x 0)", macro);
+
+  assert_parse_richpresence(&richpresence, buffer, script);
+  assert_richpresence_output(richpresence, &memory, expected);
+}
+
 static void test_asciichar() {
   unsigned char ram[] = { 'K', 'e', 'n', '\0', 'V', 'e', 'g', 'a', 1 };
   memory_t memory;
@@ -1183,6 +1199,16 @@ void test_richpresence(void) {
   TEST(test_macro_without_parameter);
   TEST(test_macro_without_parameter_conditional_display);
   TEST(test_macro_non_numeric_parameter);
+
+  /* builtin macros */
+  TEST_PARAMS2(test_builtin_macro, "Number", "12345");
+  TEST_PARAMS2(test_builtin_macro, "Score", "012345");
+  TEST_PARAMS2(test_builtin_macro, "Centiseconds", "2:03.45");
+  TEST_PARAMS2(test_builtin_macro, "Seconds", "3h25:45");
+  TEST_PARAMS2(test_builtin_macro, "Minutes", "205h45");
+  TEST_PARAMS2(test_builtin_macro, "SecondsAsMinutes", "3h25");
+  TEST_PARAMS2(test_builtin_macro, "ASCIIChar", "?"); // 0x3039 is not a single ASCII char
+  TEST_PARAMS2(test_builtin_macro, "UnicodeChar", "\xe3\x80\xb9");
 
   /* asciichar */
   TEST(test_asciichar);

--- a/test/rcheevos/test_richpresence.c
+++ b/test/rcheevos/test_richpresence.c
@@ -1009,6 +1009,19 @@ static void test_builtin_macro(const char* macro, const char* expected) {
   assert_richpresence_output(richpresence, &memory, expected);
 }
 
+static void test_builtin_macro_override() {
+  unsigned char ram[] = { 0x39, 0x30 };
+  memory_t memory;
+  rc_richpresence_t* richpresence;
+  char buffer[256];
+
+  memory.ram = ram;
+  memory.size = sizeof(ram);
+
+  assert_parse_richpresence(&richpresence, buffer, "Format:Number\nFormatType=SECS\n\nDisplay:\n@Number(0x 0)");
+  assert_richpresence_output(richpresence, &memory, "3h25:45");
+}
+
 static void test_asciichar() {
   unsigned char ram[] = { 'K', 'e', 'n', '\0', 'V', 'e', 'g', 'a', 1 };
   memory_t memory;
@@ -1209,6 +1222,7 @@ void test_richpresence(void) {
   TEST_PARAMS2(test_builtin_macro, "SecondsAsMinutes", "3h25");
   TEST_PARAMS2(test_builtin_macro, "ASCIIChar", "?"); // 0x3039 is not a single ASCII char
   TEST_PARAMS2(test_builtin_macro, "UnicodeChar", "\xe3\x80\xb9");
+  TEST(test_builtin_macro_override);
 
   /* asciichar */
   TEST(test_asciichar);

--- a/test/test_framework.h
+++ b/test/test_framework.h
@@ -110,6 +110,16 @@ extern const char* test_framework_basename(const char* path);
   TEST_INIT() \
   func(p1, p2, p3, p4, p5, p6, p7);
 
+#define TEST_PARAMS8(func, p1, p2, p3, p4, p5, p6, p7, p8) \
+  __test_framework_state.current_test = #func "(" #p1 ", " #p2 ", " #p3 ", " #p4 ", " #p5 ", " #p6 ", " #p7 ", " #p8 ")"; \
+  TEST_INIT() \
+  func(p1, p2, p3, p4, p5, p6, p7, p8);
+
+#define TEST_PARAMS9(func, p1, p2, p3, p4, p5, p6, p7, p8, p9) \
+  __test_framework_state.current_test = #func "(" #p1 ", " #p2 ", " #p3 ", " #p4 ", " #p5 ", " #p6 ", " #p7 ", " #p8 ", " #p9 ")"; \
+  TEST_INIT() \
+  func(p1, p2, p3, p4, p5, p6, p7, p8, p9);
+
 #define ASSERT_HELPER(func_call, func_name) { \
   TEST_PUSH_CURRENT_LINE(func_name); \
   func_call; \


### PR DESCRIPTION
Adds built-in macros for several format types.

Instead of:
```
Format:Lives
FormatType=Value

Display:
@Lives(0xH1234) lives
```
You can simply do:
```
Display:
@Number(0xH1234) lives
```
Supported built-in macros:
* `@Number()`: FormatType=Value
* `@Score()`: FormatType=Score
* `@Centisecs()`: FormatType=Millisecs
* `@Seconds()`: FormatType=Secs
* `@Minutes()`: FormatType=Minutes
* `@Float1()`: FormatType=Float1
* `@Float2()`: FormatType=Float2
* `@Float3()`: FormatType=Float3
* `@Float4()`: FormatType=Float4
* `@Float5()`: FormatType=Float5
* `@Float6()`: FormatType=Float6

Also introduces two new character lookup macros:
* `@ASCIIChar()`: converts any value from 0x20-0x7E into a character using the ASCII character map. Other values will be converted to a question mark.
* `@UnicodeChar()`: converts any value from 0x20-0xFFFF into a character using the Unicode character map. Other values will be converted to the Unicode replacement character.

These names are case sensitive. Also, for backwards compatibility, if any of these names are already associated to user-defined Format/Lookups, the user-defined ones will be given preference.