### PR TITLE
use SubSource when converting legacy value with negative multiplication coefficient

### DIFF
--- a/src/rcheevos/condition.c
+++ b/src/rcheevos/condition.c
@@ -70,6 +70,7 @@ rc_condition_t* rc_parse_condition(const char** memaddr, rc_parse_state_t* parse
   self = RC_ALLOC(rc_condition_t, parse);
   self->current_hits = 0;
   self->is_true = 0;
+  self->pause = 0;
 
   if (*aux != 0 && aux[1] == ':') {
     switch (*aux) {


### PR DESCRIPTION
For leaderboard values that use negative multiplication coefficients, this changes the generated Measured value to use SubSource instead of AddSource.

For example:
```
v100_0xh0787*v-1
```
This says the leaderboard value is 100 minus whatever is in $0787.

Previously, it would be converted to:
```
AddSource       100
AddSource 8-bit 0x0787 * 0xFFFFFFFF
Measured        0 < 0xFFFFFFFF
```

Now, it is converted to:
```
AddSource       100
SubSource 8-bit 0x0787 * 1
Measured        0 < 0xFFFFFFFF
```

They're both functionally equivalent, but the second is easier to read/process.