### PR TITLE
fix value capture for serialized leaderboad data

### DIFF
--- a/src/rcheevos/runtime_progress.c
+++ b/src/rcheevos/runtime_progress.c
@@ -320,9 +320,6 @@ static int rc_runtime_progress_write_variable(rc_runtime_progress_t* progress, c
 {
   unsigned flags;
 
-  unsigned djb2 = rc_runtime_progress_djb2(variable->name);
-  rc_runtime_progress_write_uint(progress, djb2);
-
   flags = rc_runtime_progress_should_serialize_variable_condset(variable->conditions);
   if (variable->value.changed)
     flags |= RC_MEMREF_FLAG_CHANGED_THIS_FRAME;
@@ -354,7 +351,12 @@ static int rc_runtime_progress_write_variables(rc_runtime_progress_t* progress)
   rc_runtime_progress_write_uint(progress, count);
 
   for (variable = progress->runtime->variables; variable; variable = variable->next)
+  {
+    unsigned djb2 = rc_runtime_progress_djb2(variable->name);
+    rc_runtime_progress_write_uint(progress, djb2);
+
     rc_runtime_progress_write_variable(progress, variable);
+  }
 
   rc_runtime_progress_end_chunk(progress);
   return RC_OK;

--- a/test/rcheevos/test_runtime_progress.c
+++ b/test/rcheevos/test_runtime_progress.c
@@ -1187,6 +1187,8 @@ static void test_single_leaderboard()
   assert_sub_hitcount(&runtime, 1, 0, 0, 2);
   assert_can_hitcount(&runtime, 1, 0, 0, 0);
   ASSERT_NUM_EQUALS(find_lboard(&runtime, 1)->state, RC_LBOARD_STATE_STARTED);
+  ASSERT_NUM_EQUALS(find_lboard(&runtime, 1)->value.value.value, 6);
+  ASSERT_NUM_EQUALS(find_lboard(&runtime, 1)->value.value.prior, 0);
 
   assert_serialize(&runtime, buffer, sizeof(buffer));
 
@@ -1199,6 +1201,8 @@ static void test_single_leaderboard()
   assert_sub_hitcount(&runtime, 1, 0, 0, 2);
   assert_can_hitcount(&runtime, 1, 0, 0, 0);
   ASSERT_NUM_EQUALS(find_lboard(&runtime, 1)->state, RC_LBOARD_STATE_STARTED);
+  ASSERT_NUM_EQUALS(find_lboard(&runtime, 1)->value.value.value, 6);
+  ASSERT_NUM_EQUALS(find_lboard(&runtime, 1)->value.value.prior, 0);
 
   rc_runtime_destroy(&runtime);
 }
@@ -1231,7 +1235,11 @@ static void test_multiple_leaderboards()
   assert_sta_hitcount(&runtime, 2, 0, 0, 2);
   assert_sub_hitcount(&runtime, 2, 0, 0, 0);
   ASSERT_NUM_EQUALS(find_lboard(&runtime, 1)->state, RC_LBOARD_STATE_STARTED);
+  ASSERT_NUM_EQUALS(find_lboard(&runtime, 1)->value.value.value, 6);
+  ASSERT_NUM_EQUALS(find_lboard(&runtime, 1)->value.value.prior, 0);
   ASSERT_NUM_EQUALS(find_lboard(&runtime, 2)->state, RC_LBOARD_STATE_STARTED);
+  ASSERT_NUM_EQUALS(find_lboard(&runtime, 2)->value.value.value, 2);
+  ASSERT_NUM_EQUALS(find_lboard(&runtime, 2)->value.value.prior, 0);
 
   assert_serialize(&runtime, buffer, sizeof(buffer));
 
@@ -1244,7 +1252,11 @@ static void test_multiple_leaderboards()
   assert_sta_hitcount(&runtime, 2, 0, 0, 2);
   assert_sub_hitcount(&runtime, 2, 0, 0, 0);
   ASSERT_NUM_EQUALS(find_lboard(&runtime, 1)->state, RC_LBOARD_STATE_STARTED);
+  ASSERT_NUM_EQUALS(find_lboard(&runtime, 1)->value.value.value, 6);
+  ASSERT_NUM_EQUALS(find_lboard(&runtime, 1)->value.value.prior, 0);
   ASSERT_NUM_EQUALS(find_lboard(&runtime, 2)->state, RC_LBOARD_STATE_STARTED);
+  ASSERT_NUM_EQUALS(find_lboard(&runtime, 2)->value.value.value, 2);
+  ASSERT_NUM_EQUALS(find_lboard(&runtime, 2)->value.value.prior, 0);
 
   rc_runtime_destroy(&runtime);
 }
@@ -1278,7 +1290,11 @@ static void test_multiple_leaderboards_ignore_inactive()
   assert_sta_hitcount(&runtime, 2, 0, 0, 2);
   assert_sub_hitcount(&runtime, 2, 0, 0, 0);
   ASSERT_NUM_EQUALS(find_lboard(&runtime, 1)->state, RC_LBOARD_STATE_DISABLED);
+  ASSERT_NUM_EQUALS(find_lboard(&runtime, 1)->value.value.value, 6);
+  ASSERT_NUM_EQUALS(find_lboard(&runtime, 1)->value.value.prior, 0);
   ASSERT_NUM_EQUALS(find_lboard(&runtime, 2)->state, RC_LBOARD_STATE_STARTED);
+  ASSERT_NUM_EQUALS(find_lboard(&runtime, 2)->value.value.value, 2);
+  ASSERT_NUM_EQUALS(find_lboard(&runtime, 2)->value.value.prior, 0);
 
   assert_serialize(&runtime, buffer, sizeof(buffer));
 
@@ -1291,11 +1307,15 @@ static void test_multiple_leaderboards_ignore_inactive()
   assert_sta_hitcount(&runtime, 1, 0, 0, 0);
   assert_sub_hitcount(&runtime, 1, 0, 0, 0);
   ASSERT_NUM_EQUALS(find_lboard(&runtime, 1)->state, RC_LBOARD_STATE_WAITING);
+  ASSERT_NUM_EQUALS(find_lboard(&runtime, 1)->value.value.value, 0);
+  ASSERT_NUM_EQUALS(find_lboard(&runtime, 1)->value.value.prior, 0);
 
   /* serialized leaderboard should be restored */
   assert_sta_hitcount(&runtime, 2, 0, 0, 2);
   assert_sub_hitcount(&runtime, 2, 0, 0, 0);
   ASSERT_NUM_EQUALS(find_lboard(&runtime, 2)->state, RC_LBOARD_STATE_STARTED);
+  ASSERT_NUM_EQUALS(find_lboard(&runtime, 2)->value.value.value, 2);
+  ASSERT_NUM_EQUALS(find_lboard(&runtime, 2)->value.value.prior, 0);
 
   rc_runtime_destroy(&runtime);
 }
@@ -1328,7 +1348,11 @@ static void test_multiple_leaderboards_ignore_modified()
   assert_sta_hitcount(&runtime, 2, 0, 0, 2);
   assert_sub_hitcount(&runtime, 2, 0, 0, 0);
   ASSERT_NUM_EQUALS(find_lboard(&runtime, 1)->state, RC_LBOARD_STATE_STARTED);
+  ASSERT_NUM_EQUALS(find_lboard(&runtime, 1)->value.value.value, 6);
+  ASSERT_NUM_EQUALS(find_lboard(&runtime, 1)->value.value.prior, 0);
   ASSERT_NUM_EQUALS(find_lboard(&runtime, 2)->state, RC_LBOARD_STATE_STARTED);
+  ASSERT_NUM_EQUALS(find_lboard(&runtime, 2)->value.value.value, 2);
+  ASSERT_NUM_EQUALS(find_lboard(&runtime, 2)->value.value.prior, 0);
 
   assert_serialize(&runtime, buffer, sizeof(buffer));
 
@@ -1341,11 +1365,15 @@ static void test_multiple_leaderboards_ignore_modified()
   assert_sta_hitcount(&runtime, 1, 0, 0, 0);
   assert_sub_hitcount(&runtime, 1, 0, 0, 0);
   ASSERT_NUM_EQUALS(find_lboard(&runtime, 1)->state, RC_LBOARD_STATE_WAITING);
+  ASSERT_NUM_EQUALS(find_lboard(&runtime, 1)->value.value.value, 0);
+  ASSERT_NUM_EQUALS(find_lboard(&runtime, 1)->value.value.prior, 0);
 
   /* serialized leaderboard should be restored */
   assert_sta_hitcount(&runtime, 2, 0, 0, 2);
   assert_sub_hitcount(&runtime, 2, 0, 0, 0);
   ASSERT_NUM_EQUALS(find_lboard(&runtime, 2)->state, RC_LBOARD_STATE_STARTED);
+  ASSERT_NUM_EQUALS(find_lboard(&runtime, 2)->value.value.value, 2);
+  ASSERT_NUM_EQUALS(find_lboard(&runtime, 2)->value.value.prior, 0);
 
   rc_runtime_destroy(&runtime);
 }


### PR DESCRIPTION
Fixes an issue in #165 where a leaderboard value field was outputting one more field than it was expecting when reading the data back in.