### PR TITLE
validate comparison of integer memory reference and float constant

### DIFF
--- a/src/rcheevos/operand.c
+++ b/src/rcheevos/operand.c
@@ -282,6 +282,17 @@ static int rc_luapeek(lua_State* L) {
 
 #endif /* RC_DISABLE_LUA */
 
+int rc_operand_is_float_memref(const rc_operand_t* self) {
+  switch (self->size) {
+    case RC_MEMSIZE_FLOAT:
+    case RC_MEMSIZE_MBF32:
+      return 1;
+
+    default:
+      return 0;
+  }
+}
+
 int rc_operand_is_memref(const rc_operand_t* self) {
   switch (self->type) {
     case RC_OPERAND_CONST:

--- a/src/rcheevos/rc_internal.h
+++ b/src/rcheevos/rc_internal.h
@@ -152,6 +152,7 @@ int rc_condition_is_combining(const rc_condition_t* self);
 
 int rc_parse_operand(rc_operand_t* self, const char** memaddr, int is_indirect, rc_parse_state_t* parse);
 void rc_evaluate_operand(rc_typed_value_t* value, rc_operand_t* self, rc_eval_state_t* eval_state);
+int rc_operand_is_float_memref(const rc_operand_t* self);
 
 void rc_parse_value_internal(rc_value_t* self, const char** memaddr, rc_parse_state_t* parse);
 int rc_evaluate_value_typed(rc_value_t* self, rc_typed_value_t* value, rc_peek_t peek, void* ud, lua_State* L);

--- a/src/rcheevos/rc_validate.c
+++ b/src/rcheevos/rc_validate.c
@@ -215,7 +215,39 @@ int rc_validate_condset(const rc_condset_t* condset, char result[], const size_t
 
     /* if either side is a memref, or there's a running add source chain, check for impossible comparisons */
     if (is_memref1 || is_memref2 || add_source_max) {
-      const unsigned min_val = (cond->operand2.type == RC_OPERAND_CONST) ? cond->operand2.value.num : 0;
+      unsigned min_val;
+      switch (cond->operand2.type) {
+        case RC_OPERAND_CONST:
+          min_val = cond->operand2.value.num;
+          break;
+
+        case RC_OPERAND_FP:
+          min_val = (int)cond->operand2.value.dbl;
+
+          /* cannot compare an integer memory reference to a non-integral floating point value */
+          /* assert: is_memref1 (because operand2==FP means !is_memref2) */
+          if (!add_source_max && !rc_operand_is_float_memref(&cond->operand1) &&
+              (float)min_val != cond->operand2.value.dbl) {
+            snprintf(result, result_size, "Condition %d: Comparison is never true", index);
+            return 0;
+          }
+
+          break;
+
+        default:
+          min_val = 0;
+
+          /* cannot compare an integer memory reference to a non-integral floating point value */
+          /* assert: is_memref2 (because operand1==FP means !is_memref1) */
+          if (cond->operand1.type == RC_OPERAND_FP && !add_source_max && !rc_operand_is_float_memref(&cond->operand2) &&
+              (float)((int)cond->operand1.value.dbl) != cond->operand1.value.dbl) {
+            snprintf(result, result_size, "Condition %d: Comparison is never true", index);
+            return 0;
+          }
+
+          break;
+      }
+
       const size_t prefix_length = snprintf(result, result_size, "Condition %d: ", index);
       if (!rc_validate_range(min_val, max_val, cond->oper, max, result + prefix_length, result_size - prefix_length))
         return 0;

--- a/src/rcheevos/rc_validate.c
+++ b/src/rcheevos/rc_validate.c
@@ -215,6 +215,8 @@ int rc_validate_condset(const rc_condset_t* condset, char result[], const size_t
 
     /* if either side is a memref, or there's a running add source chain, check for impossible comparisons */
     if (is_memref1 || is_memref2 || add_source_max) {
+      const size_t prefix_length = snprintf(result, result_size, "Condition %d: ", index);
+
       unsigned min_val;
       switch (cond->operand2.type) {
         case RC_OPERAND_CONST:
@@ -228,7 +230,7 @@ int rc_validate_condset(const rc_condset_t* condset, char result[], const size_t
           /* assert: is_memref1 (because operand2==FP means !is_memref2) */
           if (!add_source_max && !rc_operand_is_float_memref(&cond->operand1) &&
               (float)min_val != cond->operand2.value.dbl) {
-            snprintf(result, result_size, "Condition %d: Comparison is never true", index);
+            snprintf(result + prefix_length, result_size - prefix_length, "Comparison is never true");
             return 0;
           }
 
@@ -241,14 +243,13 @@ int rc_validate_condset(const rc_condset_t* condset, char result[], const size_t
           /* assert: is_memref2 (because operand1==FP means !is_memref1) */
           if (cond->operand1.type == RC_OPERAND_FP && !add_source_max && !rc_operand_is_float_memref(&cond->operand2) &&
               (float)((int)cond->operand1.value.dbl) != cond->operand1.value.dbl) {
-            snprintf(result, result_size, "Condition %d: Comparison is never true", index);
+            snprintf(result + prefix_length, result_size - prefix_length, "Comparison is never true");
             return 0;
           }
 
           break;
       }
 
-      const size_t prefix_length = snprintf(result, result_size, "Condition %d: ", index);
       if (!rc_validate_range(min_val, max_val, cond->oper, max, result + prefix_length, result_size - prefix_length))
         return 0;
     }

--- a/test/rcheevos/test_rc_validate.c
+++ b/test/rcheevos/test_rc_validate.c
@@ -170,6 +170,28 @@ void test_delta_pointers() {
   TEST_PARAMS2(test_validate_trigger, "I:0xX1234_I:0xH0010_0xH0000=1", "");
 }
 
+void test_float_comparisons() {
+  TEST_PARAMS2(test_validate_trigger, "fF1234=f2.3", "");
+  TEST_PARAMS2(test_validate_trigger, "fM1234=f2.3", "");
+  TEST_PARAMS2(test_validate_trigger, "fF1234=2", "");
+  TEST_PARAMS2(test_validate_trigger, "0xX1234=2", "");
+  TEST_PARAMS2(test_validate_trigger, "0xX1234=f2.3", "Condition 1: Comparison is never true"); /* non integral comparison */
+  TEST_PARAMS2(test_validate_trigger, "0xX1234!=f2.3", "Condition 1: Comparison is never true"); /* non integral comparison */
+  TEST_PARAMS2(test_validate_trigger, "0xX1234<f2.3", "Condition 1: Comparison is never true"); /* non integral comparison */
+  TEST_PARAMS2(test_validate_trigger, "0xX1234<=f2.3", "Condition 1: Comparison is never true"); /* non integral comparison */
+  TEST_PARAMS2(test_validate_trigger, "0xX1234>f2.3", "Condition 1: Comparison is never true"); /* non integral comparison */
+  TEST_PARAMS2(test_validate_trigger, "0xX1234>=f2.3", "Condition 1: Comparison is never true"); /* non integral comparison */
+  TEST_PARAMS2(test_validate_trigger, "0xX1234=f2.0", ""); /* float can be converted to int without loss of data*/
+  TEST_PARAMS2(test_validate_trigger, "0xH1234=f2.3", "Condition 1: Comparison is never true");
+  TEST_PARAMS2(test_validate_trigger, "0xH1234=f300.0", "Condition 1: Comparison is never true"); /* value out of range */
+  TEST_PARAMS2(test_validate_trigger, "f2.3=fF1234", "");
+  TEST_PARAMS2(test_validate_trigger, "f2.3=0xX1234", "Condition 1: Comparison is never true"); /* non integral comparison */
+  TEST_PARAMS2(test_validate_trigger, "f2.0=0xX1234", "");
+  TEST_PARAMS2(test_validate_trigger, "A:Ff2345_fF1234=f2.3", "");
+  TEST_PARAMS2(test_validate_trigger, "A:0xX2345_fF1234=f2.3", "");
+  TEST_PARAMS2(test_validate_trigger, "A:Ff2345_0x1234=f2.3", "");
+}
+
 void test_rc_validate(void) {
   TEST_SUITE_BEGIN();
 
@@ -183,6 +205,7 @@ void test_rc_validate(void) {
   test_size_comparisons();
   test_address_range();
   test_delta_pointers();
+  test_float_comparisons();
 
   TEST_SUITE_END();
 }


### PR DESCRIPTION
Generates warning when comparing a non-float memory reference to a float (i.e. "`32-bit 0x1234 == 2.3`")