### PR TITLE
support for hashing dreamcast bin/cues

### DIFF
--- a/include/rc_hash.h
+++ b/include/rc_hash.h
@@ -101,7 +101,7 @@ extern "C" {
    */
   typedef void* (*rc_hash_cdreader_open_track_handler)(const char* path, uint32_t track);
 
-  /* attempts to read the specified number of bytes from the file starting at the read pointer.
+  /* attempts to read the specified number of bytes from the file starting at the specified absolute sector.
    * returns the number of bytes actually read.
    */
   typedef size_t (*rc_hash_cdreader_read_sector_handler)(void* track_handle, uint32_t sector, void* buffer, size_t requested_bytes);
@@ -109,15 +109,15 @@ extern "C" {
   /* closes the track handle */
   typedef void (*rc_hash_cdreader_close_track_handler)(void* track_handle);
 
-  /* convert absolute sector to track sector */
-  typedef uint32_t(*rc_hash_cdreader_absolute_sector_to_track_sector)(void* track_handle, uint32_t sector);
+  /* gets the absolute sector index for the first sector of a track */
+  typedef uint32_t(*rc_hash_cdreader_first_track_sector_handler)(void* track_handle);
 
   struct rc_hash_cdreader
   {
     rc_hash_cdreader_open_track_handler              open_track;
     rc_hash_cdreader_read_sector_handler             read_sector;
     rc_hash_cdreader_close_track_handler             close_track;
-    rc_hash_cdreader_absolute_sector_to_track_sector absolute_sector_to_track_sector;
+    rc_hash_cdreader_first_track_sector_handler      first_track_sector;
   };
 
   void rc_hash_init_default_cdreader(void);

--- a/src/rhash/cdreader.c
+++ b/src/rhash/cdreader.c
@@ -371,7 +371,7 @@ static void* cdreader_open_cue_track(const char* path, uint32_t track)
             verbose_message_callback(message);
           }
 
-          if (current_track.id == (int)track)
+          if (current_track.id == track)
           {
             done = 1;
             break;

--- a/src/rhash/cdreader.c
+++ b/src/rhash/cdreader.c
@@ -19,12 +19,28 @@ extern rc_hash_message_callback verbose_message_callback;
 
 struct cdrom_t
 {
-  void* file_handle;      /* the file handle for reading the track data */
-  int sector_size;        /* the size of each sector in the track data */
-  int sector_header_size; /* the offset to the raw data within a sector block */
-  int first_sector;       /* the first absolute sector associated to the track (includes pregap) */
-  int64_t index1_offset;  /* the offset within the file where the non-pregap data for the track starts */
+  void* file_handle;        /* the file handle for reading the track data */
+  int sector_size;          /* the size of each sector in the track data */
+  int sector_header_size;   /* the offset to the raw data within a sector block */
+  int64_t file_track_offset;/* the offset of the track data within the file */
+  int track_first_sector;   /* the first absolute sector associated to the track (includes pregap) */
+  int track_pregap_sectors; /* the number of pregap sectors */
+#ifndef NDEBUG
+  uint32_t track_id;        /* the index of the track */
+#endif
 };
+
+static int cdreader_get_sector(unsigned char header[16])
+{
+  int minutes = (header[12] >> 4) * 10 + (header[12] & 0x0F);
+  int seconds = (header[13] >> 4) * 10 + (header[13] & 0x0F);
+  int frames = (header[14] >> 4) * 10 + (header[14] & 0x0F);
+
+  /* convert the MSF value to a sector index, and subtract 150 (2 seconds) per:
+   *   For data and mixed mode media (those conforming to ISO/IEC 10149), logical block address
+   *   zero shall be assigned to the block at MSF address 00/02/00 */
+  return ((minutes * 60) + seconds) * 75 + frames - 150;
+}
 
 static void cdreader_determine_sector_size(struct cdrom_t* cdrom)
 {
@@ -38,12 +54,12 @@ static void cdreader_determine_sector_size(struct cdrom_t* cdrom)
   };
 
   unsigned char header[32];
-  const int64_t toc_sector = 16;
+  const int64_t toc_sector = 16 + cdrom->track_pregap_sectors;
 
   cdrom->sector_size = 0;
   cdrom->sector_header_size = 0;
 
-  rc_file_seek(cdrom->file_handle, toc_sector * 2352 + cdrom->index1_offset, SEEK_SET);
+  rc_file_seek(cdrom->file_handle, toc_sector * 2352 + cdrom->file_track_offset, SEEK_SET);
   if (rc_file_read(cdrom->file_handle, header, sizeof(header)) < sizeof(header))
     return;
 
@@ -55,10 +71,12 @@ static void cdreader_determine_sector_size(struct cdrom_t* cdrom)
       cdrom->sector_header_size = 24;
     else
       cdrom->sector_header_size = 16;
+
+    cdrom->track_first_sector = cdreader_get_sector(header) - (int)toc_sector;
   }
   else
   {
-    rc_file_seek(cdrom->file_handle, toc_sector * 2336 + cdrom->index1_offset, SEEK_SET);
+    rc_file_seek(cdrom->file_handle, toc_sector * 2336 + cdrom->file_track_offset, SEEK_SET);
     rc_file_read(cdrom->file_handle, header, sizeof(header));
 
     if (memcmp(header, sync_pattern, 12) == 0)
@@ -69,10 +87,12 @@ static void cdreader_determine_sector_size(struct cdrom_t* cdrom)
         cdrom->sector_header_size = 24;
       else
         cdrom->sector_header_size = 16;
+
+      cdrom->track_first_sector = cdreader_get_sector(header) - (int)toc_sector;
     }
     else
     {
-      rc_file_seek(cdrom->file_handle, toc_sector * 2048 + cdrom->index1_offset, SEEK_SET);
+      rc_file_seek(cdrom->file_handle, toc_sector * 2048 + cdrom->file_track_offset, SEEK_SET);
       rc_file_read(cdrom->file_handle, header, sizeof(header));
 
       if (memcmp(&header[1], "CD001", 5) == 0)
@@ -103,6 +123,9 @@ static void* cdreader_open_bin_track(const char* path, uint32_t track)
 
   cdrom = (struct cdrom_t*)calloc(1, sizeof(*cdrom));
   cdrom->file_handle = file_handle;
+#ifndef NDEBUG
+  cdrom->track_id = track;
+#endif
 
   cdreader_determine_sector_size(cdrom);
 
@@ -192,6 +215,11 @@ static int cdreader_open_bin(struct cdrom_t* cdrom, const char* path, const char
       cdrom->sector_size = 2352;
       cdrom->sector_header_size = 16;
     }
+    else if (memcmp(mode, "AUDIO", 5) == 0)
+    {
+      cdrom->sector_size = 2352;
+      cdrom->sector_header_size = 0;
+    }
   }
 
   return (cdrom->sector_size != 0);
@@ -244,35 +272,35 @@ static void* cdreader_open_cue_track(const char* path, uint32_t track)
 {
   void* cue_handle;
   int64_t cue_offset = 0;
-  char buffer[1024], mode[16];
-  char* bin_filename;
-  char file[256];
+  char buffer[1024];
+  char* bin_filename = NULL;
   char *ptr, *ptr2, *end;
-  int current_track = 0;
-  int sector_size = 0;
-  int file_first_sector = 0;
-  int file_offset = 0;
-  int track_first_sector = 0;
-  int previous_sector_size = 0;
-  int previous_index_sector_offset = 0;
-  int previous_track_is_data = 0;
-  int64_t previous_track_index1_offset = 0;
-  char previous_track_mode[16];
-  int largest_track = 0;
-  int largest_track_sector_count = 0;
-  int64_t largest_track_index1_offset = 0;
-  char largest_track_mode[16];
-  char largest_track_file[256];
-  int64_t index1_offset = 0;
   int done = 0;
   size_t num_read = 0;
   struct cdrom_t* cdrom = NULL;
+
+  struct track_t
+  {
+    uint32_t id;
+    int sector_size;
+    int sector_count;
+    int first_sector;
+    int pregap_sectors;
+    int is_data;
+    int file_track_offset;
+    int file_first_sector;
+    char mode[16];
+    char filename[256];
+  } current_track, previous_track, largest_track;
 
   cue_handle = rc_file_open(path);
   if (!cue_handle)
     return NULL;
 
-  file[0] = '\0';
+  memset(&current_track, 0, sizeof(current_track));
+  memset(&previous_track, 0, sizeof(previous_track));
+  memset(&largest_track, 0, sizeof(largest_track));
+
   do
   {
     num_read = rc_file_read(cue_handle, buffer, sizeof(buffer) - 1);
@@ -308,59 +336,50 @@ static void* cdreader_open_cue_track(const char* path, uint32_t track)
         sscanf(ptr, "%d:%d:%d", &m, &s, &f);
         sector_offset = ((m * 60) + s) * 75 + f;
 
-        if (track_first_sector == -1)
-          track_first_sector = file_first_sector + sector_offset;
-
-        /* if looking for the largest data track, determine previous track size */
-        if (index == 1 && track == RC_HASH_CDTRACK_LARGEST && previous_track_is_data)
+        if (current_track.first_sector == -1)
         {
-          if ((sector_offset - previous_index_sector_offset) > largest_track_sector_count)
+          current_track.first_sector = sector_offset;
+          if (strcmp(current_track.filename, previous_track.filename) == 0)
           {
-            largest_track_sector_count = (sector_offset - previous_index_sector_offset);
-            largest_track_index1_offset = previous_track_index1_offset;
-            largest_track = current_track - 1;
-            memcpy(largest_track_mode, previous_track_mode, sizeof(largest_track_mode));
-            strcpy(largest_track_file, file);
+            previous_track.sector_count = current_track.first_sector - previous_track.first_sector;
+            current_track.file_track_offset += previous_track.sector_count * previous_track.sector_size;
+          }
+
+          /* if looking for the largest data track, determine previous track size */
+          if (track == RC_HASH_CDTRACK_LARGEST && previous_track.sector_count > largest_track.sector_count &&
+              previous_track.is_data)
+          {
+            memcpy(&largest_track, &previous_track, sizeof(largest_track));
           }
         }
 
-        /* calculate the true offset and update the counters for the next INDEX marker */
-        file_offset += (int64_t)(sector_offset - previous_index_sector_offset) * previous_sector_size;
-
-        previous_sector_size = sector_size;
-        previous_index_sector_offset = sector_offset;
-
         if (index == 1)
         {
-          index1_offset = file_offset;
+          current_track.pregap_sectors = (sector_offset - current_track.first_sector);
 
           if (verbose_message_callback)
           {
             char message[128];
-            char* scan = mode;
+            char* scan = current_track.mode;
             while (*scan && !isspace((unsigned char)*scan))
               ++scan;
             *scan = '\0';
 
             /* it's undesirable to truncate offset to 32-bits, but %lld isn't defined in c89. */
-            snprintf(message, sizeof(message), "Found %s track %d (first sector %d, sector size %d, track starts at %d)",
-                     mode, current_track, track_first_sector, sector_size, (int)index1_offset);
+            snprintf(message, sizeof(message), "Found %s track %d (first sector %d, sector size %d, %d pregap sectors)",
+                     current_track.mode, current_track.id, current_track.first_sector, current_track.sector_size, current_track.pregap_sectors);
             verbose_message_callback(message);
           }
 
-          if (current_track == (int)track)
+          if (current_track.id == (int)track)
           {
             done = 1;
             break;
           }
 
-          memcpy(previous_track_mode, mode, sizeof(previous_track_mode));
-          previous_track_is_data = (memcmp(mode, "MODE", 4) == 0);
-          previous_track_index1_offset = index1_offset;
-
-          if (previous_track_is_data && track == RC_HASH_CDTRACK_FIRST_DATA)
+          if (track == RC_HASH_CDTRACK_FIRST_DATA && current_track.is_data)
           {
-            track = current_track;
+            track = current_track.id;
             done = 1;
             break;
           }
@@ -368,49 +387,56 @@ static void* cdreader_open_cue_track(const char* path, uint32_t track)
       }
       else if (strncasecmp(ptr, "TRACK ", 6) == 0)
       {
+        if (current_track.sector_size)
+          memcpy(&previous_track, &current_track, sizeof(current_track));
+
         ptr += 6;
-        current_track = atoi(ptr);
-        track_first_sector = -1;
+        current_track.id = atoi(ptr);
+
+        current_track.pregap_sectors = -1;
+        current_track.first_sector = -1;
 
         while (*ptr != ' ')
           ++ptr;
         while (*ptr == ' ')
           ++ptr;
-        memcpy(mode, ptr, sizeof(mode));
+        memcpy(current_track.mode, ptr, sizeof(current_track.mode));
+        current_track.is_data = (memcmp(current_track.mode, "MODE", 4) == 0);
 
-        previous_sector_size = sector_size;
-
-        if (memcmp(mode, "MODE", 4) == 0)
+        if (current_track.is_data)
         {
-          sector_size = atoi(ptr + 6);
+          current_track.sector_size = atoi(ptr + 6);
         }
         else
         {
           /* assume AUDIO */
-          sector_size = 2352;
+          current_track.sector_size = 2352;
         }
       }
       else if (strncasecmp(ptr, "FILE ", 5) == 0)
       {
-        if (previous_sector_size > 0)
+        if (current_track.sector_size)
         {
-          /* determine previous track size */
-          int sector_count = (int)cdreader_get_bin_size(path, file) / previous_sector_size;
-          file_first_sector += sector_count;
+          memcpy(&previous_track, &current_track, sizeof(previous_track));
+
+          if (previous_track.sector_count == 0)
+          {
+            const uint32_t file_sector_count = (uint32_t)cdreader_get_bin_size(path, previous_track.filename) / previous_track.sector_size;
+            previous_track.sector_count = file_sector_count - previous_track.first_sector;
+          }
 
           /* if looking for the largest data track, check to see if this one is larger */
-          if (track == RC_HASH_CDTRACK_LARGEST && previous_track_is_data)
+          if (track == RC_HASH_CDTRACK_LARGEST && previous_track.is_data &&
+              previous_track.sector_count > largest_track.sector_count)
           {
-            if (sector_count > largest_track_sector_count)
-            {
-              largest_track_sector_count = sector_count;
-              largest_track_index1_offset = previous_track_index1_offset;
-              largest_track = current_track;
-              memcpy(largest_track_mode, previous_track_mode, sizeof(largest_track_mode));
-              strcpy(largest_track_file, file);
-            }
+            memcpy(&largest_track, &previous_track, sizeof(largest_track));
           }
         }
+
+        memset(&current_track, 0, sizeof(current_track));
+
+        current_track.file_first_sector = previous_track.file_first_sector + 
+            previous_track.first_sector + previous_track.sector_count;
 
         ptr += 5;
         ptr2 = ptr;
@@ -430,20 +456,8 @@ static void* cdreader_open_cue_track(const char* path, uint32_t track)
           } while (*ptr2 && *ptr2 != '\n' && *ptr2 != ' ');
         }
 
-        if (ptr2 - ptr < (int)sizeof(file))
-        {
-          memcpy(file, ptr, ptr2 - ptr);
-          file[ptr2 - ptr] = '\0';
-        }
-        else
-        {
-          file[0] = '\0';
-        }
-
-        current_track = 0;
-        previous_sector_size = 0;
-        previous_index_sector_offset = 0;
-        file_offset = 0;
+        if (ptr2 - ptr < (int)sizeof(current_track.filename))
+          memcpy(current_track.filename, ptr, ptr2 - ptr);
       }
 
       while (*ptr && *ptr != '\n')
@@ -462,36 +476,27 @@ static void* cdreader_open_cue_track(const char* path, uint32_t track)
 
   if (track == RC_HASH_CDTRACK_LARGEST)
   {
-    previous_track_is_data = (memcmp(mode, "MODE", 4) == 0);
-    if (previous_track_is_data)
+    if (current_track.sector_size && current_track.is_data)
     {
-      int sector_count = (int)cdreader_get_bin_size(path, file) / previous_sector_size;
-      sector_count -= previous_index_sector_offset;
+      const uint32_t file_sector_count = (uint32_t)cdreader_get_bin_size(path, current_track.filename) / current_track.sector_size;
+      current_track.sector_count = file_sector_count - current_track.first_sector;
 
-      if (sector_count > largest_track_sector_count)
-      {
-        largest_track_sector_count = sector_count;
-        largest_track_index1_offset = previous_track_index1_offset;
-        largest_track = current_track;
-        memcpy(largest_track_mode, previous_track_mode, sizeof(largest_track_mode));
-        strcpy(largest_track_file, file);
-      }
+      if (largest_track.sector_count > current_track.sector_count)
+        memcpy(&current_track, &largest_track, sizeof(current_track));
+    }
+    else
+    {
+      memcpy(&current_track, &largest_track, sizeof(current_track));
     }
 
-    if (largest_track > 0)
-    {
-      current_track = largest_track;
-      track = (uint32_t)largest_track;
-      index1_offset = largest_track_index1_offset;
-      memcpy(mode, largest_track_mode, sizeof(mode));
-      strcpy(file, largest_track_file);
-    }
+    track = current_track.id;
+  }
+  else if (track == RC_HASH_CDTRACK_LAST && !done)
+  {
+    track = current_track.id;
   }
 
-  if (track == RC_HASH_CDTRACK_LAST && !done)
-    track = current_track;
-
-  if (current_track == (int)track)
+  if (current_track.id == track)
   {
     cdrom = (struct cdrom_t*)calloc(1, sizeof(*cdrom));
     if (!cdrom)
@@ -501,20 +506,24 @@ static void* cdreader_open_cue_track(const char* path, uint32_t track)
       return NULL;
     }
 
-    cdrom->index1_offset = index1_offset;
-    cdrom->first_sector = track_first_sector;
+    cdrom->file_track_offset = current_track.file_track_offset;
+    cdrom->track_pregap_sectors = current_track.pregap_sectors;
+    cdrom->track_first_sector = current_track.file_first_sector + current_track.first_sector;
+#ifndef NDEBUG
+    cdrom->track_id = current_track.id;
+#endif
 
     /* verify existance of bin file */
-    bin_filename = cdreader_get_bin_path(path, file);
+    bin_filename = cdreader_get_bin_path(path, current_track.filename);
     if (bin_filename)
     {
-      if (cdreader_open_bin(cdrom, bin_filename, mode))
+      if (cdreader_open_bin(cdrom, bin_filename, current_track.mode))
       {
         if (verbose_message_callback)
         {
-          if (cdrom->index1_offset)
-            snprintf((char*)buffer, sizeof(buffer), "Opened track %d (sector size %d, track starts at %d)",
-                     track, cdrom->sector_size, (int)cdrom->index1_offset);
+          if (cdrom->track_pregap_sectors)
+            snprintf((char*)buffer, sizeof(buffer), "Opened track %d (sector size %d, %d pregap sectors)",
+                     track, cdrom->sector_size, cdrom->track_pregap_sectors);
           else
             snprintf((char*)buffer, sizeof(buffer), "Opened track %d (sector size %d)", track, cdrom->sector_size);
 
@@ -523,7 +532,16 @@ static void* cdreader_open_cue_track(const char* path, uint32_t track)
       }
       else
       {
-        snprintf((char*)buffer, sizeof(buffer), "Could not open %s", bin_filename);
+        if (cdrom->file_handle)
+        {
+          rc_file_close(cdrom->file_handle);
+          snprintf((char*)buffer, sizeof(buffer), "Could not determine sector size for %s track", current_track.mode);
+        }
+        else
+        {
+          snprintf((char*)buffer, sizeof(buffer), "Could not open %s", bin_filename);
+        }
+
         rc_hash_error((const char*)buffer);
 
         free(cdrom);
@@ -601,7 +619,7 @@ static void* cdreader_open_gdi_track(const char* path, uint32_t track)
         ++ptr;
 
       current_track = (uint32_t)atoi(ptr);
-      if (track && current_track != track)
+      if (track && current_track != track && track != RC_HASH_CDTRACK_FIRST_DATA)
         continue;
 
       while (isdigit((unsigned char)*ptr))
@@ -651,8 +669,14 @@ static void* cdreader_open_gdi_track(const char* path, uint32_t track)
       }
       *ptr2 = '\0';
 
-      if (track == current_track || (track == RC_HASH_CDTRACK_FIRST_DATA && track_type == 4))
+      if (track == current_track)
       {
+        found = 1;
+        break;
+      }
+      else if (track == RC_HASH_CDTRACK_FIRST_DATA && track_type == 4)
+      {
+        track = current_track;
         found = 1;
         break;
       }
@@ -708,12 +732,15 @@ static void* cdreader_open_gdi_track(const char* path, uint32_t track)
   bin_path = cdreader_get_bin_path(path, file);
   if (cdreader_open_bin(cdrom, bin_path, mode))
   {
-    cdrom->index1_offset = 0;
-    cdrom->first_sector = lba;
+    cdrom->track_pregap_sectors = 0;
+    cdrom->track_first_sector = lba;
+#ifndef NDEBUG
+    cdrom->track_id = current_track;
+#endif
 
     if (verbose_message_callback)
     {
-      snprintf((char*)buffer, sizeof(buffer), "Opened track %d (sector size %d)", track, cdrom->sector_size);
+      snprintf((char*)buffer, sizeof(buffer), "Opened track %d (sector size %d)", current_track, cdrom->sector_size);
       verbose_message_callback((const char*)buffer);
     }
   }
@@ -755,7 +782,11 @@ static size_t cdreader_read_sector(void* track_handle, uint32_t sector, void* bu
   if (!cdrom)
     return 0;
 
-  sector_start = (int64_t)sector * cdrom->sector_size + cdrom->sector_header_size + cdrom->index1_offset;
+  if (sector < (uint32_t)cdrom->track_first_sector)
+    return 0;
+
+  sector_start = (int64_t)(sector - cdrom->track_first_sector) * cdrom->sector_size + 
+      cdrom->sector_header_size + cdrom->file_track_offset;
 
   while (requested_bytes > 2048)
   {
@@ -790,15 +821,11 @@ static void cdreader_close_track(void* track_handle)
   }
 }
 
-static uint32_t cdreader_absolute_sector_to_track_sector(void* track_handle, uint32_t sector)
+static uint32_t cdreader_first_track_sector(void* track_handle)
 {
   struct cdrom_t* cdrom = (struct cdrom_t*)track_handle;
   if (cdrom)
-  {
-    /* cdreader_read_sector assumes the track sector 0 data is pointed at by the index1_offset, so we
-     * have to include that in the adjustment to convert the absolute sector to a track sector */
-    return sector - cdrom->first_sector - (int32_t)(cdrom->index1_offset / cdrom->sector_size);
-  }
+    return cdrom->track_first_sector + cdrom->track_pregap_sectors;
 
   return 0;
 }
@@ -810,7 +837,7 @@ void rc_hash_init_default_cdreader()
   cdreader.open_track = cdreader_open_track;
   cdreader.read_sector = cdreader_read_sector;
   cdreader.close_track = cdreader_close_track;
-  cdreader.absolute_sector_to_track_sector = cdreader_absolute_sector_to_track_sector;
+  cdreader.first_track_sector = cdreader_first_track_sector;
 
   rc_hash_init_custom_cdreader(&cdreader);
 }

--- a/src/rhash/hash.c
+++ b/src/rhash/hash.c
@@ -1267,14 +1267,17 @@ static int rc_hash_dreamcast(char hash[33], const char* path)
   sector = rc_cd_find_file_sector(track_handle, exe_file, &size);
   if (sector == 0)
   {
-    /* a dreamcast cue file does not accurately represent the space betwee the low density and high
+    /* a dreamcast cue file does not accurately represent the space between the low density and high
      * density areas. we expect track 3 to start at sector 45000, regardless of what information we
-     * got from the cue file. so forcibly adjust the absolute sector using 45000 and try again. */
-    rc_hash_cdreader_absolute_sector_to_track_sector old_function = cdreader_funcs.absolute_sector_to_track_sector;
-    cdreader_funcs.absolute_sector_to_track_sector = rc_cd_absolute_sector_to_track_sector_dreamcast;
-    sector = rc_cd_find_file_sector(track_handle, exe_file, &size);
-    cdreader_funcs.absolute_sector_to_track_sector = old_function;
-    high_density_offset = old_function(track_handle, 45000);
+     * got from the cue file, so forcibly adjust the absolute sector using 45000 and try again. */
+    high_density_offset = rc_cd_absolute_sector_to_track_sector(track_handle, 45000);
+    if (high_density_offset > 0)
+    {
+      rc_hash_cdreader_absolute_sector_to_track_sector old_function = cdreader_funcs.absolute_sector_to_track_sector;
+      cdreader_funcs.absolute_sector_to_track_sector = rc_cd_absolute_sector_to_track_sector_dreamcast;
+      sector = rc_cd_find_file_sector(track_handle, exe_file, &size);
+      cdreader_funcs.absolute_sector_to_track_sector = old_function;
+    }
   }
 
   rc_cd_close_track(track_handle);
@@ -2105,10 +2108,11 @@ void rc_hash_initialize_iterator(struct rc_hash_iterator* iterator, const char* 
         {
           iterator->consoles[0] = RC_CONSOLE_PLAYSTATION;
           iterator->consoles[1] = RC_CONSOLE_PLAYSTATION_2;
-          iterator->consoles[2] = RC_CONSOLE_PC_ENGINE;
-          iterator->consoles[3] = RC_CONSOLE_3DO;
-          iterator->consoles[4] = RC_CONSOLE_PCFX;
-          iterator->consoles[5] = RC_CONSOLE_SEGA_CD; /* ASSERT: handles both Sega CD and Saturn */
+          iterator->consoles[2] = RC_CONSOLE_DREAMCAST;
+          iterator->consoles[3] = RC_CONSOLE_SEGA_CD; /* ASSERT: handles both Sega CD and Saturn */
+          iterator->consoles[4] = RC_CONSOLE_PC_ENGINE;
+          iterator->consoles[5] = RC_CONSOLE_3DO;
+          iterator->consoles[6] = RC_CONSOLE_PCFX;
           need_path = 1;
         }
         else if (rc_path_compare_extension(ext, "chd"))
@@ -2116,10 +2120,10 @@ void rc_hash_initialize_iterator(struct rc_hash_iterator* iterator, const char* 
           iterator->consoles[0] = RC_CONSOLE_PLAYSTATION;
           iterator->consoles[1] = RC_CONSOLE_PLAYSTATION_2;
           iterator->consoles[2] = RC_CONSOLE_DREAMCAST;
-          iterator->consoles[3] = RC_CONSOLE_PC_ENGINE;
-          iterator->consoles[4] = RC_CONSOLE_3DO;
-          iterator->consoles[5] = RC_CONSOLE_PCFX;
-          iterator->consoles[6] = RC_CONSOLE_SEGA_CD; /* ASSERT: handles both Sega CD and Saturn */
+          iterator->consoles[3] = RC_CONSOLE_SEGA_CD; /* ASSERT: handles both Sega CD and Saturn */
+          iterator->consoles[4] = RC_CONSOLE_PC_ENGINE;
+          iterator->consoles[5] = RC_CONSOLE_3DO;
+          iterator->consoles[6] = RC_CONSOLE_PCFX;
           need_path = 1;
         }
         else if (rc_path_compare_extension(ext, "col"))

--- a/test/rhash/data.c
+++ b/test/rhash/data.c
@@ -642,6 +642,7 @@ uint8_t* convert_to_2352(uint8_t* input, size_t* size, uint32_t first_sector)
     uint8_t* input_ptr = input;
     uint8_t* ptr = output;
     uint8_t minutes, seconds, frames;
+    uint32_t i;
 
     first_sector += 150;
     frames = (first_sector % 75);
@@ -649,9 +650,9 @@ uint8_t* convert_to_2352(uint8_t* input, size_t* size, uint32_t first_sector)
     seconds = (first_sector % 60);
     minutes = first_sector / 60;
 
-    for (uint32_t i = 0; i < num_sectors; i++)
+    for (i = 0; i < num_sectors; i++)
     {
-      // 16-byte sync header
+      /* 16 - byte sync header */
       memcpy(ptr, sync_pattern, 12);
       ptr += 12;
       *ptr++ = ((minutes / 10) << 4) | (minutes % 10);
@@ -668,11 +669,11 @@ uint8_t* convert_to_2352(uint8_t* input, size_t* size, uint32_t first_sector)
       }
       *ptr++ = 2;
 
-      // 2048 bytes data
+      /* 2048 bytes data */
       memcpy(ptr, input_ptr, 2048);
       input_ptr += 2048;
 
-      // 288 bytes parity/checksums
+      /* 288 bytes parity / checksums */
       ptr += 2352 - 16;
     }
 

--- a/test/rhash/data.h
+++ b/test/rhash/data.h
@@ -10,6 +10,8 @@ extern "C" {
 
 uint8_t* generate_generic_file(size_t size);
 
+uint8_t* convert_to_2352(uint8_t* input, size_t* input_size, uint32_t first_sector);
+
 uint8_t* generate_3do_bin(unsigned root_directory_sectors, unsigned binary_size, size_t* image_size);
 uint8_t* generate_dreamcast_bin(unsigned track_first_sector, unsigned binary_size, size_t* image_size);
 uint8_t* generate_pce_cd_bin(unsigned binary_sectors, size_t* image_size);

--- a/test/rhash/mock_filereader.c
+++ b/test/rhash/mock_filereader.c
@@ -186,14 +186,17 @@ static void* _mock_cd_open_track(const char* path, uint32_t track)
 
 static size_t _mock_cd_read_sector(void* track_handle, uint32_t sector, void* buffer, size_t requested_bytes)
 {
+  mock_file_data* file = (mock_file_data*)track_handle;
+  sector -= file->first_sector;
+
   _mock_file_seek(track_handle, sector * 2048, SEEK_SET);
   return _mock_file_read(track_handle, buffer, requested_bytes);
 }
 
-static uint32_t _mock_cd_absolute_sector_to_track_sector(void* track_handle, uint32_t sector)
+static uint32_t _mock_cd_first_track_sector(void* track_handle)
 {
   mock_file_data* file = (mock_file_data*)track_handle;
-  return sector - file->first_sector;
+  return file->first_sector;
 }
 
 void mock_cd_num_tracks(int num_tracks)
@@ -208,7 +211,7 @@ void init_mock_cdreader()
   cdreader.open_track = _mock_cd_open_track;
   cdreader.close_track = _mock_file_close;
   cdreader.read_sector = _mock_cd_read_sector;
-  cdreader.absolute_sector_to_track_sector = _mock_cd_absolute_sector_to_track_sector;
+  cdreader.first_track_sector = _mock_cd_first_track_sector;
 
   rc_hash_init_custom_cdreader(&cdreader);
 

--- a/test/rhash/test_cdreader.c
+++ b/test/rhash/test_cdreader.c
@@ -672,10 +672,10 @@ static void test_absolute_sector_to_track_sector_cue_pregap()
 
   ASSERT_PTR_NOT_NULL(track_handle->file_handle);
   ASSERT_STR_EQUALS(get_mock_filename(track_handle->file_handle), "game2.bin");
-  
+
   /* pregap of second track starts at sector 500 */
   ASSERT_NUM_EQUALS(track_handle->first_sector, 500);
-  
+
   /* data for second track starts at sector 650 */
   ASSERT_NUM_EQUALS(cdreader->absolute_sector_to_track_sector(track_handle, 818), 818 - 650);
 

--- a/test/rhash/test_cdreader.c
+++ b/test/rhash/test_cdreader.c
@@ -15,7 +15,7 @@ typedef struct cdrom_t
   int sector_size;
   int sector_header_size;
   int first_sector;
-  int64_t first_sector_offset;
+  int64_t index1_offset;
 } cdrom_t;
 
 static const unsigned char sync_pattern[] = {
@@ -121,7 +121,7 @@ static void test_open_cue_track_2()
 
   ASSERT_PTR_NOT_NULL(track_handle->file_handle);
   ASSERT_STR_EQUALS(get_mock_filename(track_handle->file_handle), "game.bin");
-  ASSERT_NUM64_EQUALS(track_handle->first_sector_offset, 9807840); /* track 2: 0x95A7E0 */
+  ASSERT_NUM64_EQUALS(track_handle->index1_offset, 9807840); /* track 2: 0x95A7E0 */
   ASSERT_NUM_EQUALS(track_handle->sector_size, 2352);
   ASSERT_NUM_EQUALS(track_handle->sector_header_size, 16);
 
@@ -140,7 +140,7 @@ static void test_open_cue_track_12()
 
   ASSERT_PTR_NOT_NULL(track_handle->file_handle);
   ASSERT_STR_EQUALS(get_mock_filename(track_handle->file_handle), "game.bin");
-  ASSERT_NUM64_EQUALS(track_handle->first_sector_offset, 664047216); /* track 12: 0x27948E70 */
+  ASSERT_NUM64_EQUALS(track_handle->index1_offset, 664047216); /* track 12: 0x27948E70 */
   ASSERT_NUM_EQUALS(track_handle->sector_size, 2352);
   ASSERT_NUM_EQUALS(track_handle->sector_header_size, 16);
 
@@ -181,7 +181,7 @@ static void test_open_gdi_track_3()
 
   ASSERT_PTR_NOT_NULL(track_handle->file_handle);
   ASSERT_STR_EQUALS(get_mock_filename(track_handle->file_handle), "track03.bin");
-  ASSERT_NUM64_EQUALS(track_handle->first_sector_offset, 0);
+  ASSERT_NUM64_EQUALS(track_handle->index1_offset, 0);
   ASSERT_NUM_EQUALS(track_handle->first_sector, 45000);
   ASSERT_NUM_EQUALS(track_handle->sector_size, 2352);
   ASSERT_NUM_EQUALS(track_handle->sector_header_size, 16);
@@ -207,7 +207,7 @@ static void test_open_gdi_track_3_quoted()
 
   ASSERT_PTR_NOT_NULL(track_handle->file_handle);
   ASSERT_STR_EQUALS(get_mock_filename(track_handle->file_handle), "track 03.bin");
-  ASSERT_NUM64_EQUALS(track_handle->first_sector_offset, 0);
+  ASSERT_NUM64_EQUALS(track_handle->index1_offset, 0);
   ASSERT_NUM_EQUALS(track_handle->first_sector, 45000);
   ASSERT_NUM_EQUALS(track_handle->sector_size, 2352);
   ASSERT_NUM_EQUALS(track_handle->sector_header_size, 16);
@@ -233,7 +233,7 @@ static void test_open_gdi_track_3_extra_whitespace()
 
   ASSERT_PTR_NOT_NULL(track_handle->file_handle);
   ASSERT_STR_EQUALS(get_mock_filename(track_handle->file_handle), "track 03.bin");
-  ASSERT_NUM64_EQUALS(track_handle->first_sector_offset, 0);
+  ASSERT_NUM64_EQUALS(track_handle->index1_offset, 0);
   ASSERT_NUM_EQUALS(track_handle->first_sector, 45000);
   ASSERT_NUM_EQUALS(track_handle->sector_size, 2352);
   ASSERT_NUM_EQUALS(track_handle->sector_header_size, 16);
@@ -253,7 +253,7 @@ static void test_open_gdi_track_last()
 
   ASSERT_PTR_NOT_NULL(track_handle->file_handle);
   ASSERT_STR_EQUALS(get_mock_filename(track_handle->file_handle), "track26.bin");
-  ASSERT_NUM64_EQUALS(track_handle->first_sector_offset, 0);
+  ASSERT_NUM64_EQUALS(track_handle->index1_offset, 0);
   ASSERT_NUM_EQUALS(track_handle->first_sector, 548106);
   ASSERT_NUM_EQUALS(track_handle->sector_size, 2352);
   ASSERT_NUM_EQUALS(track_handle->sector_header_size, 16);
@@ -273,7 +273,7 @@ static void test_open_cue_track_largest_data()
 
   ASSERT_PTR_NOT_NULL(track_handle->file_handle);
   ASSERT_STR_EQUALS(get_mock_filename(track_handle->file_handle), "game.bin");
-  ASSERT_NUM64_EQUALS(track_handle->first_sector_offset, 146190912); /* track 5: 0x8B6B240 */
+  ASSERT_NUM64_EQUALS(track_handle->index1_offset, 146190912); /* track 5: 0x8B6B240 */
   ASSERT_NUM_EQUALS(track_handle->sector_size, 2352);
   ASSERT_NUM_EQUALS(track_handle->sector_header_size, 16);
 
@@ -293,7 +293,7 @@ static void test_open_cue_track_largest_data_multiple_bin()
 
   ASSERT_PTR_NOT_NULL(track_handle->file_handle);
   ASSERT_STR_EQUALS(get_mock_filename(track_handle->file_handle), "track2.bin");
-  ASSERT_NUM64_EQUALS(track_handle->first_sector_offset, 529200); /* INDEX 01 00:03:00 */
+  ASSERT_NUM64_EQUALS(track_handle->index1_offset, 529200); /* INDEX 01 00:03:00 */
   ASSERT_NUM_EQUALS(track_handle->sector_size, 2352);
   ASSERT_NUM_EQUALS(track_handle->sector_header_size, 16);
 
@@ -313,7 +313,7 @@ static void test_open_cue_track_largest_data_backwards_compatibility()
 
   ASSERT_PTR_NOT_NULL(track_handle->file_handle);
   ASSERT_STR_EQUALS(get_mock_filename(track_handle->file_handle), "game.bin");
-  ASSERT_NUM64_EQUALS(track_handle->first_sector_offset, 146190912); /* track 5: 0x8B6B240 */
+  ASSERT_NUM64_EQUALS(track_handle->index1_offset, 146190912); /* track 5: 0x8B6B240 */
   ASSERT_NUM_EQUALS(track_handle->sector_size, 2352);
   ASSERT_NUM_EQUALS(track_handle->sector_header_size, 16);
 
@@ -345,7 +345,7 @@ static void test_open_cue_track_largest_data_last_track()
 
   ASSERT_PTR_NOT_NULL(track_handle->file_handle);
   ASSERT_STR_EQUALS(get_mock_filename(track_handle->file_handle), "game.bin");
-  ASSERT_NUM64_EQUALS(track_handle->first_sector_offset, 146190912); /* track 5: 0x8B6B240 (13:48:56) */
+  ASSERT_NUM64_EQUALS(track_handle->index1_offset, 146190912); /* track 5: 0x8B6B240 (13:48:56) */
   ASSERT_NUM_EQUALS(track_handle->sector_size, 2352);
   ASSERT_NUM_EQUALS(track_handle->sector_header_size, 16);
 
@@ -374,7 +374,7 @@ static void test_open_cue_track_largest_data_index0s()
 
   ASSERT_PTR_NOT_NULL(track_handle->file_handle);
   ASSERT_STR_EQUALS(get_mock_filename(track_handle->file_handle), "game.bin");
-  ASSERT_NUM64_EQUALS(track_handle->first_sector_offset, 8443680); /* track 2: 0x80D720 (00:47:65) */
+  ASSERT_NUM64_EQUALS(track_handle->index1_offset, 8443680); /* track 2: 0x80D720 (00:47:65) */
   ASSERT_NUM_EQUALS(track_handle->sector_size, 2352);
   ASSERT_NUM_EQUALS(track_handle->sector_header_size, 16);
 
@@ -401,7 +401,7 @@ static void test_open_cue_track_largest_data_index2()
 
   ASSERT_PTR_NOT_NULL(track_handle->file_handle);
   ASSERT_STR_EQUALS(get_mock_filename(track_handle->file_handle), "game.bin");
-  ASSERT_NUM64_EQUALS(track_handle->first_sector_offset, 352800); /* 00:02:00 = 150 frames in */
+  ASSERT_NUM64_EQUALS(track_handle->index1_offset, 352800); /* 00:02:00 = 150 frames in */
   ASSERT_NUM_EQUALS(track_handle->sector_size, 2352);
   ASSERT_NUM_EQUALS(track_handle->sector_header_size, 16);
 
@@ -423,7 +423,7 @@ static void test_open_cue_track_largest_data_multiple_bins()
 
   ASSERT_PTR_NOT_NULL(track_handle->file_handle);
   ASSERT_STR_EQUALS(get_mock_filename(track_handle->file_handle), "track3.bin");
-  ASSERT_NUM64_EQUALS(track_handle->first_sector_offset, 352800); /* 00:02:00 = 150 frames in */
+  ASSERT_NUM64_EQUALS(track_handle->index1_offset, 352800); /* 00:02:00 = 150 frames in */
   ASSERT_NUM_EQUALS(track_handle->sector_size, 2352);
   ASSERT_NUM_EQUALS(track_handle->sector_header_size, 16);
 
@@ -471,7 +471,7 @@ static void test_open_cue_track_first_data()
 
   ASSERT_PTR_NOT_NULL(track_handle->file_handle);
   ASSERT_STR_EQUALS(get_mock_filename(track_handle->file_handle), "game.bin");
-  ASSERT_NUM64_EQUALS(track_handle->first_sector_offset, 9807840); /* track 2: 0x0095a7e0 (00:55:45) */
+  ASSERT_NUM64_EQUALS(track_handle->index1_offset, 9807840); /* track 2: 0x0095a7e0 (00:55:45) */
   ASSERT_NUM_EQUALS(track_handle->sector_size, 2352);
   ASSERT_NUM_EQUALS(track_handle->sector_header_size, 16);
 
@@ -494,7 +494,7 @@ static void test_determine_sector_size_sync(int sector_size)
 
   ASSERT_PTR_NOT_NULL(track_handle->file_handle);
   ASSERT_STR_EQUALS(get_mock_filename(track_handle->file_handle), "game.bin");
-  ASSERT_NUM64_EQUALS(track_handle->first_sector_offset, 0);
+  ASSERT_NUM64_EQUALS(track_handle->index1_offset, 0);
   ASSERT_NUM_EQUALS(track_handle->sector_size, sector_size);
   ASSERT_NUM_EQUALS(track_handle->sector_header_size, 16);
 
@@ -519,7 +519,7 @@ static void test_determine_sector_size_sync_primary_volume_descriptor(int sector
 
   ASSERT_PTR_NOT_NULL(track_handle->file_handle);
   ASSERT_STR_EQUALS(get_mock_filename(track_handle->file_handle), "game.bin");
-  ASSERT_NUM64_EQUALS(track_handle->first_sector_offset, 0);
+  ASSERT_NUM64_EQUALS(track_handle->index1_offset, 0);
   ASSERT_NUM_EQUALS(track_handle->sector_size, sector_size);
   ASSERT_NUM_EQUALS(track_handle->sector_header_size, 24);
 
@@ -554,7 +554,7 @@ static void test_determine_sector_size_sync_primary_volume_descriptor_index0(int
 
   ASSERT_PTR_NOT_NULL(track_handle->file_handle);
   ASSERT_STR_EQUALS(get_mock_filename(track_handle->file_handle), "game.bin");
-  ASSERT_NUM64_EQUALS(track_handle->first_sector_offset, sector_size * 150);
+  ASSERT_NUM64_EQUALS(track_handle->index1_offset, sector_size * 150);
   ASSERT_NUM_EQUALS(track_handle->sector_size, sector_size);
   ASSERT_NUM_EQUALS(track_handle->sector_header_size, 24);
 
@@ -579,7 +579,7 @@ static void test_determine_sector_size_sync_2048()
 
   ASSERT_PTR_NOT_NULL(track_handle->file_handle);
   ASSERT_STR_EQUALS(get_mock_filename(track_handle->file_handle), "game.bin");
-  ASSERT_NUM64_EQUALS(track_handle->first_sector_offset, 0);
+  ASSERT_NUM64_EQUALS(track_handle->index1_offset, 0);
   ASSERT_NUM_EQUALS(track_handle->sector_size, 2352);
   ASSERT_NUM_EQUALS(track_handle->sector_header_size, 24);
 
@@ -604,7 +604,7 @@ static void test_determine_sector_size_sync_primary_volume_descriptor_2048()
 
   ASSERT_PTR_NOT_NULL(track_handle->file_handle);
   ASSERT_STR_EQUALS(get_mock_filename(track_handle->file_handle), "game.bin");
-  ASSERT_NUM64_EQUALS(track_handle->first_sector_offset, 0);
+  ASSERT_NUM64_EQUALS(track_handle->index1_offset, 0);
   ASSERT_NUM_EQUALS(track_handle->sector_size, sector_size);
   ASSERT_NUM_EQUALS(track_handle->sector_header_size, 0);
 
@@ -639,7 +639,7 @@ static void test_determine_sector_size_sync_primary_volume_descriptor_index0_204
 
   ASSERT_PTR_NOT_NULL(track_handle->file_handle);
   ASSERT_STR_EQUALS(get_mock_filename(track_handle->file_handle), "game.bin");
-  ASSERT_NUM64_EQUALS(track_handle->first_sector_offset, sector_size * 150);
+  ASSERT_NUM64_EQUALS(track_handle->index1_offset, sector_size * 150);
   ASSERT_NUM_EQUALS(track_handle->sector_size, sector_size);
   ASSERT_NUM_EQUALS(track_handle->sector_header_size, 0);
 
@@ -650,13 +650,13 @@ static void test_determine_sector_size_sync_primary_volume_descriptor_index0_204
 static void test_absolute_sector_to_track_sector_cue_pregap()
 {
   const char cue[] =
-    "FILE \"game1.bin\" BINARY\n"
+    "FILE \"game1.bin\" BINARY\n"/* file contains 500 sectors of data [1176000 bytes] */
     "  TRACK 01 MODE2/2352\n"
-    "    INDEX 00 00:00:00\n"    /* 150 non-existant sectors */
-    "    INDEX 01 00:02:00\n"    /* 500 sectors of data [1176000 bytes] */
+    "    INDEX 00 00:00:00\n"    /* 150 pre-gap sectors */
+    "    INDEX 01 00:02:00\n"    /* 350 sectors of data */
     "FILE \"game2.bin\" BINARY\n"
 	"  TRACK 02 MODE2/2352\n"
-	"    INDEX 00 00:00:00\n"    /* 150 non-existant sectors */
+	"    INDEX 00 00:00:00\n"    /* 150 pre-gap sectors */
 	"    INDEX 01 00:02:00\n";
 
   cdrom_t* track_handle;
@@ -672,9 +672,12 @@ static void test_absolute_sector_to_track_sector_cue_pregap()
 
   ASSERT_PTR_NOT_NULL(track_handle->file_handle);
   ASSERT_STR_EQUALS(get_mock_filename(track_handle->file_handle), "game2.bin");
-  ASSERT_NUM_EQUALS(track_handle->first_sector, 800); /* 150 + 500 + 150 */
-
-  ASSERT_NUM_EQUALS(cdreader->absolute_sector_to_track_sector(track_handle, 818), 18);
+  
+  /* pregap of second track starts at sector 500 */
+  ASSERT_NUM_EQUALS(track_handle->first_sector, 500);
+  
+  /* data for second track starts at sector 650 */
+  ASSERT_NUM_EQUALS(cdreader->absolute_sector_to_track_sector(track_handle, 818), 818 - 650);
 
   cdreader->close_track(track_handle);
   free(image);
@@ -727,7 +730,7 @@ static void test_read_sector()
 
   ASSERT_PTR_NOT_NULL(track_handle->file_handle);
   ASSERT_STR_EQUALS(get_mock_filename(track_handle->file_handle), "game.bin");
-  ASSERT_NUM64_EQUALS(track_handle->first_sector_offset, 0);
+  ASSERT_NUM64_EQUALS(track_handle->index1_offset, 0);
   ASSERT_NUM_EQUALS(track_handle->sector_size, 2352);
   ASSERT_NUM_EQUALS(track_handle->sector_header_size, 16);
 

--- a/test/rhash/test_hash.c
+++ b/test/rhash/test_hash.c
@@ -439,23 +439,21 @@ static void test_hash_dreamcast_cue()
       "    INDEX 01 00:02:00\n"
       "FILE \"track05.bin\" BINARY\n"
       "  TRACK 05 MODE1/2352\n"
-      "    INDEX 00 00:00:00\n"  /* first_sector = 2545 (606+676+737+526) [real=45000+737+526] */
-      "    INDEX 01 00:03:00\n"; /* index1_offset = 529200 (225 sectors) */
-                                 /* file data = 18 sectors in, so absolute address 
-                                  * will be 46506 (45000+737+526+225+18) */
+      "    INDEX 00 00:00:00\n"
+      "    INDEX 01 00:03:00\n";
   size_t image_size;
-  uint8_t* image = generate_dreamcast_bin(46506 - 18, 1697028, &image_size);
+  uint8_t* image = convert_to_2352(generate_dreamcast_bin(45000, 1697028, &image_size), &image_size, 45000);
   char hash_file[33], hash_iterator[33];
-  const char* expected_md5 = "f4b8c11f61410efe5809e1636dfd0e53";
+  const char* expected_md5 = "c952864c3364591d2a8793ce2cfbf3a0";
 
   mock_file(0, "game.cue", (uint8_t*)cue_file, strlen(cue_file));
   mock_file(1, "track01.bin", image, 1425312);    /* 606 sectors */
   mock_file(2, "track02.bin", image, 1589952);    /* 676 sectors */
-  mock_file(3, "track03.bin", image, image_size); /* 737 sectors, starting at 45000 */
+  mock_file(3, "track03.bin", image, image_size); /* 737 sectors */
   mock_file(4, "track04.bin", image, 1237152);    /* 526 sectors */
   mock_file(5, "track05.bin", image, image_size);
 
-  rc_hash_init_default_cdreader(); /* want to test actual absolute_sector_to_track_sector calculation */
+  rc_hash_init_default_cdreader(); /* want to test actual first_track_sector calculation */
 
   /* test file hash */
   int result_file = rc_hash_generate_from_file(hash_file, RC_CONSOLE_DREAMCAST, "game.cue");


### PR DESCRIPTION
Dreamcast cue files don't accurately represent the area between the low-density tracks and the high-density tracks.
```
REM SINGLE-DENSITY AREA
FILE "track01.bin" BINARY
  TRACK 01 MODE1/2352
    INDEX 01 00:00:00
    REM file is 705600 bytes (300 sectors)
FILE "track02.bin" BINARY
  TRACK 02 AUDIO
    INDEX 00 00:00:00
    REM two second pregap is 150 sectors, putting track 2 at sector 450 (correct)
    INDEX 01 00:02:00
    REM file is 1589952 bytes (676 sectors), putting track 3 at sector 1126 (should be 45000)
REM HIGH-DENSITY AREA
FILE "track03.bin" BINARY
  TRACK 03 MODE1/2352
    INDEX 01 00:00:00
```

Track 3 (the start of the high-density area) is expected to always start at sector 45000, but this isn't reflected in any of the cue files that I've seen for Dreamcast. Since the Dreamcast filesystem uses absolute sector addresses, this causes the code that locates the primary executable to not find the executable and not generate a hash.

The solution is to force track 3 to start at sector 45000 when generating a Dreamcast hash.

I've also made some additional changes to the cue processing code to better handle absolute sector to file location conversions for tracks with pregaps.