### PR TITLE
support for hashing buffered NDS ROMs

### DIFF
--- a/test/rhash/data.c
+++ b/test/rhash/data.c
@@ -158,6 +158,49 @@ uint8_t* generate_fds_file(size_t sides, int with_header, size_t* image_size)
   return image;
 }
 
+uint8_t* generate_nds_file(size_t mb, unsigned arm9_size, unsigned arm7_size, size_t* image_size)
+{
+  uint8_t* image;
+  const size_t size_needed = mb * 1024 * 1024;
+
+  image = (uint8_t*)calloc(size_needed, 1);
+  if (image != NULL)
+  {
+    uint32_t arm9_addr = 65536;
+    uint32_t arm7_addr = arm9_addr + arm9_size;
+    uint32_t icon_addr = arm7_addr + arm7_size;
+
+    fill_image(image, size_needed);
+
+    image[0x20] = (arm9_addr & 0xFF);
+    image[0x21] = ((arm9_addr >> 8) & 0xFF);
+    image[0x22] = ((arm9_addr >> 16) & 0xFF);
+    image[0x23] = ((arm9_addr >> 24) & 0xFF);
+    image[0x2C] = (arm9_size & 0xFF);
+    image[0x2D] = ((arm9_size >> 8) & 0xFF);
+    image[0x2E] = ((arm9_size >> 16) & 0xFF);
+    image[0x2F] = ((arm9_size >> 24) & 0xFF);
+
+    image[0x30] = (arm7_addr & 0xFF);
+    image[0x31] = ((arm7_addr >> 8) & 0xFF);
+    image[0x32] = ((arm7_addr >> 16) & 0xFF);
+    image[0x33] = ((arm7_addr >> 24) & 0xFF);
+    image[0x3C] = (arm7_size & 0xFF);
+    image[0x3D] = ((arm7_size >> 8) & 0xFF);
+    image[0x3E] = ((arm7_size >> 16) & 0xFF);
+    image[0x3F] = ((arm7_size >> 24) & 0xFF);
+
+    image[0x68] = (icon_addr & 0xFF);
+    image[0x69] = ((icon_addr >> 8) & 0xFF);
+    image[0x6A] = ((icon_addr >> 16) & 0xFF);
+    image[0x6B] = ((icon_addr >> 24) & 0xFF);
+  }
+
+  if (image_size)
+    *image_size = size_needed;
+  return image;
+}
+
 uint8_t* generate_atari_7800_file(size_t kb, int with_header, size_t* image_size)
 {
   uint8_t* image;

--- a/test/rhash/data.h
+++ b/test/rhash/data.h
@@ -20,6 +20,7 @@ uint8_t* generate_ps2_bin(const char* binary_name, unsigned binary_size, size_t*
 uint8_t* generate_atari_7800_file(size_t kb, int with_header, size_t* image_size);
 uint8_t* generate_nes_file(size_t kb, int with_header, size_t* image_size);
 uint8_t* generate_fds_file(size_t sides, int with_header, size_t* image_size);
+uint8_t* generate_nds_file(size_t mb, unsigned arm9_size, unsigned arm7_size, size_t* image_size);
 
 uint8_t* generate_iso9660_bin(unsigned binary_sectors, const char* volume_label, size_t* image_size);
 uint8_t* generate_iso9660_file(uint8_t* image, const char* filename, const uint8_t* contents, size_t contents_size);

--- a/test/rhash/test_hash.c
+++ b/test/rhash/test_hash.c
@@ -618,18 +618,19 @@ static void test_hash_nds_supercard()
   const char* expected_hash = "56b30c276cba4affa886bd38e8e34d7e";
 
   /* inject the SuperCard header (512 bytes) */
-  memcpy(&image[512], &image[0], image_size - 512);
-  memset(&image[0], 0, 512);
-  image[0] = 0x2E;
-  image[1] = 0x00;
-  image[2] = 0x00;
-  image[3] = 0xEA;
-  image[0xB0] = 0x44;
-  image[0xB1] = 0x46;
-  image[0xB2] = 0x96;
-  image[0xB3] = 0x00;
+  uint8_t* image2 = malloc(image_size + 512);
+  memcpy(&image2[512], &image[0], image_size);
+  memset(&image2[0], 0, 512);
+  image2[0] = 0x2E;
+  image2[1] = 0x00;
+  image2[2] = 0x00;
+  image2[3] = 0xEA;
+  image2[0xB0] = 0x44;
+  image2[0xB1] = 0x46;
+  image2[0xB2] = 0x96;
+  image2[0xB3] = 0x00;
 
-  mock_file(0, "game.nds", image, image_size);
+  mock_file(0, "game.nds", image2, image_size);
 
   /* test file hash */
   int result_file = rc_hash_generate_from_file(hash_file, RC_CONSOLE_NINTENDO_DS, "game.nds");
@@ -644,6 +645,7 @@ static void test_hash_nds_supercard()
 
   /* cleanup */
   free(image);
+  free(image2);
 
   /* validation */
   ASSERT_NUM_EQUALS(result_file, 1);

--- a/test/rhash/test_hash.c
+++ b/test/rhash/test_hash.c
@@ -579,6 +579,111 @@ static void test_hash_n64_file(const char* filename, uint8_t* buffer, size_t buf
 
 /* ========================================================================= */
 
+static void test_hash_nds()
+{
+  size_t image_size;
+  uint8_t* image = generate_nds_file(2, 1234567, 654321, &image_size);
+  char hash_file[33], hash_iterator[33];
+  const char* expected_hash = "56b30c276cba4affa886bd38e8e34d7e";
+
+  mock_file(0, "game.nds", image, image_size);
+
+  /* test file hash */
+  int result_file = rc_hash_generate_from_file(hash_file, RC_CONSOLE_NINTENDO_DS, "game.nds");
+
+  /* test file identification from iterator */
+  int result_iterator;
+  struct rc_hash_iterator iterator;
+
+  rc_hash_initialize_iterator(&iterator, "game.nds", NULL, 0);
+  result_iterator = rc_hash_iterate(hash_iterator, &iterator);
+  rc_hash_destroy_iterator(&iterator);
+
+  /* cleanup */
+  free(image);
+
+  /* validation */
+  ASSERT_NUM_EQUALS(result_file, 1);
+  ASSERT_STR_EQUALS(hash_file, expected_hash);
+
+  ASSERT_NUM_EQUALS(result_iterator, 1);
+  ASSERT_STR_EQUALS(hash_iterator, expected_hash);
+}
+
+static void test_hash_nds_supercard()
+{
+  size_t image_size;
+  uint8_t* image = generate_nds_file(2, 1234567, 654321, &image_size);
+  char hash_file[33], hash_iterator[33];
+  const char* expected_hash = "56b30c276cba4affa886bd38e8e34d7e";
+
+  /* inject the SuperCard header (512 bytes) */
+  memcpy(&image[512], &image[0], image_size - 512);
+  memset(&image[0], 0, 512);
+  image[0] = 0x2E;
+  image[1] = 0x00;
+  image[2] = 0x00;
+  image[3] = 0xEA;
+  image[0xB0] = 0x44;
+  image[0xB1] = 0x46;
+  image[0xB2] = 0x96;
+  image[0xB3] = 0x00;
+
+  mock_file(0, "game.nds", image, image_size);
+
+  /* test file hash */
+  int result_file = rc_hash_generate_from_file(hash_file, RC_CONSOLE_NINTENDO_DS, "game.nds");
+
+  /* test file identification from iterator */
+  int result_iterator;
+  struct rc_hash_iterator iterator;
+
+  rc_hash_initialize_iterator(&iterator, "game.nds", NULL, 0);
+  result_iterator = rc_hash_iterate(hash_iterator, &iterator);
+  rc_hash_destroy_iterator(&iterator);
+
+  /* cleanup */
+  free(image);
+
+  /* validation */
+  ASSERT_NUM_EQUALS(result_file, 1);
+  ASSERT_STR_EQUALS(hash_file, expected_hash);
+
+  ASSERT_NUM_EQUALS(result_iterator, 1);
+  ASSERT_STR_EQUALS(hash_iterator, expected_hash);
+}
+
+static void test_hash_nds_buffered()
+{
+  size_t image_size;
+  uint8_t* image = generate_nds_file(2, 1234567, 654321, &image_size);
+  char hash_buffer[33], hash_iterator[33];
+  const char* expected_hash = "56b30c276cba4affa886bd38e8e34d7e";
+
+  /* test file hash */
+  int result_buffer = rc_hash_generate_from_buffer(hash_buffer, RC_CONSOLE_NINTENDO_DS, image, image_size);
+
+  /* test file identification from iterator */
+  int result_iterator;
+  struct rc_hash_iterator iterator;
+
+  rc_hash_initialize_iterator(&iterator, "game.nds", image, image_size);
+  result_iterator = rc_hash_iterate(hash_iterator, &iterator);
+  rc_hash_destroy_iterator(&iterator);
+
+  /* cleanup */
+  free(image);
+
+  /* validation */
+  ASSERT_NUM_EQUALS(result_buffer, 1);
+  ASSERT_STR_EQUALS(hash_buffer, expected_hash);
+
+  ASSERT_NUM_EQUALS(result_iterator, 1);
+  ASSERT_STR_EQUALS(hash_iterator, expected_hash);
+}
+
+/* ========================================================================= */
+
 static void test_hash_pce_cd()
 {
   size_t image_size;
@@ -1335,6 +1440,11 @@ void test_hash(void) {
   TEST_PARAMS4(test_hash_n64_file, "game.n64", test_rom_n64, sizeof(test_rom_n64), "06096d7ce21cb6bcde38391534c4eb91");
   TEST_PARAMS4(test_hash_n64_file, "game.n64", test_rom_z64, sizeof(test_rom_z64), "06096d7ce21cb6bcde38391534c4eb91"); /* misnamed */
   TEST_PARAMS4(test_hash_n64_file, "game.z64", test_rom_n64, sizeof(test_rom_n64), "06096d7ce21cb6bcde38391534c4eb91"); /* misnamed */
+
+  /* Nintendo DS */
+  TEST(test_hash_nds);
+  TEST(test_hash_nds_supercard);
+  TEST(test_hash_nds_buffered);
 
   /* Oric (no fixed file size) */
   TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_ORIC, "test.tap", 18119, "953a2baa3232c63286aeae36b2172cef");


### PR DESCRIPTION
leverages same logic to avoid code duplication for hashing N64 ROMs