### PR TITLE
fix prior being updated when unmasked bits change

### DIFF
--- a/src/rcheevos/memref.c
+++ b/src/rcheevos/memref.c
@@ -293,6 +293,38 @@ void rc_transform_memref_value(rc_typed_value_t* value, char size) {
   }
 }
 
+static const unsigned rc_memref_masks[] = {
+  0x000000ff, /* RC_MEMSIZE_8_BITS     */
+  0x0000ffff, /* RC_MEMSIZE_16_BITS    */
+  0x00ffffff, /* RC_MEMSIZE_24_BITS    */
+  0xffffffff, /* RC_MEMSIZE_32_BITS    */
+  0x0000000f, /* RC_MEMSIZE_LOW        */
+  0x000000f0, /* RC_MEMSIZE_HIGH       */
+  0x00000001, /* RC_MEMSIZE_BIT_0      */
+  0x00000002, /* RC_MEMSIZE_BIT_1      */
+  0x00000004, /* RC_MEMSIZE_BIT_2      */
+  0x00000008, /* RC_MEMSIZE_BIT_3      */
+  0x00000010, /* RC_MEMSIZE_BIT_4      */
+  0x00000020, /* RC_MEMSIZE_BIT_5      */
+  0x00000040, /* RC_MEMSIZE_BIT_6      */
+  0x00000080, /* RC_MEMSIZE_BIT_7      */
+  0x000000ff, /* RC_MEMSIZE_BITCOUNT   */
+  0x0000ffff, /* RC_MEMSIZE_16_BITS_BE */
+  0x00ffffff, /* RC_MEMSIZE_24_BITS_BE */
+  0xffffffff, /* RC_MEMSIZE_32_BITS_BE */
+  0xffffffff, /* RC_MEMSIZE_FLOAT      */
+  0xffffffff, /* RC_MEMSIZE_MBF32      */
+  0xffffffff  /* RC_MEMSIZE_VARIABLE   */
+};
+
+unsigned rc_memref_mask(char size) {
+  const size_t index = (size_t)size;
+  if (index >= sizeof(rc_memref_masks) / sizeof(rc_memref_masks[0]))
+    return 0xffffffff;
+
+  return rc_memref_masks[index];
+}
+
 /* all sizes less than 8-bits (1 byte) are mapped to 8-bits. 24-bit is mapped to 32-bit
  * as we don't expect the client to understand a request for 3 bytes. all other reads are
  * mapped to the little-endian read of the same size. */

--- a/src/rcheevos/operand.c
+++ b/src/rcheevos/operand.c
@@ -103,6 +103,16 @@ static int rc_parse_operand_memory(rc_operand_t* self, const char** memaddr, rc_
     return ret;
 
   size = rc_memref_shared_size(self->size);
+  if (size != self->size && self->type == RC_OPERAND_PRIOR) {
+    /* if the shared size differs from the requested size and it's a prior operation, we
+     * have to check to make sure both sizes use the same mask, or the prior value may be
+     * updated when bits outside the mask are modified, which would make it look like the
+     * current value once the mask is applied. if the mask differs, create a new 
+     * non-shared record for tracking the prior data. */
+    if (rc_memref_mask(size) != rc_memref_mask(self->size))
+      size = self->size;
+  }
+
   self->value.memref = rc_alloc_memref(parse, address, size, (char)is_indirect);
   if (parse->offset < 0)
     return parse->offset;

--- a/src/rcheevos/rc_internal.h
+++ b/src/rcheevos/rc_internal.h
@@ -136,6 +136,7 @@ void rc_update_memref_values(rc_memref_t* memref, rc_peek_t peek, void* ud);
 void rc_update_memref_value(rc_memref_value_t* memref, unsigned value);
 unsigned rc_get_memref_value(rc_memref_t* memref, int operand_type, rc_eval_state_t* eval_state);
 char rc_memref_shared_size(char size);
+unsigned rc_memref_mask(char size);
 void rc_transform_memref_value(rc_typed_value_t* value, char size);
 
 void rc_parse_trigger_internal(rc_trigger_t* self, const char** memaddr, rc_parse_state_t* parse);

--- a/test/rcheevos/test_memref.c
+++ b/test/rcheevos/test_memref.c
@@ -5,6 +5,36 @@
 
 #include <float.h>
 
+static void test_mask(char size, unsigned expected)
+{
+  ASSERT_NUM_EQUALS(rc_memref_mask(size), expected);
+}
+
+static void test_shared_masks(void)
+{
+  TEST_PARAMS2(test_mask, RC_MEMSIZE_8_BITS, 0x000000ff);
+  TEST_PARAMS2(test_mask, RC_MEMSIZE_BIT_0, 0x00000001);
+  TEST_PARAMS2(test_mask, RC_MEMSIZE_BIT_1, 0x00000002);
+  TEST_PARAMS2(test_mask, RC_MEMSIZE_BIT_2, 0x00000004);
+  TEST_PARAMS2(test_mask, RC_MEMSIZE_BIT_3, 0x00000008);
+  TEST_PARAMS2(test_mask, RC_MEMSIZE_BIT_4, 0x00000010);
+  TEST_PARAMS2(test_mask, RC_MEMSIZE_BIT_5, 0x00000020);
+  TEST_PARAMS2(test_mask, RC_MEMSIZE_BIT_6, 0x00000040);
+  TEST_PARAMS2(test_mask, RC_MEMSIZE_BIT_7, 0x00000080);
+  TEST_PARAMS2(test_mask, RC_MEMSIZE_LOW, 0x0000000f);
+  TEST_PARAMS2(test_mask, RC_MEMSIZE_HIGH, 0x000000f0);
+  TEST_PARAMS2(test_mask, RC_MEMSIZE_BITCOUNT, 0x000000ff);
+  TEST_PARAMS2(test_mask, RC_MEMSIZE_16_BITS, 0x0000ffff);
+  TEST_PARAMS2(test_mask, RC_MEMSIZE_16_BITS_BE, 0x0000ffff);
+  TEST_PARAMS2(test_mask, RC_MEMSIZE_24_BITS, 0x00ffffff);
+  TEST_PARAMS2(test_mask, RC_MEMSIZE_24_BITS_BE, 0x00ffffff);
+  TEST_PARAMS2(test_mask, RC_MEMSIZE_32_BITS, 0xffffffff);
+  TEST_PARAMS2(test_mask, RC_MEMSIZE_32_BITS_BE, 0xffffffff);
+  TEST_PARAMS2(test_mask, RC_MEMSIZE_FLOAT, 0xffffffff);
+  TEST_PARAMS2(test_mask, RC_MEMSIZE_MBF32, 0xffffffff);
+  TEST_PARAMS2(test_mask, RC_MEMSIZE_VARIABLE, 0xffffffff);
+}
+
 static void test_shared_size(char size, char expected)
 {
   ASSERT_NUM_EQUALS(rc_memref_shared_size(size), expected);
@@ -325,6 +355,7 @@ static void test_update_memref_values() {
 void test_memref(void) {
   TEST_SUITE_BEGIN();
 
+  test_shared_masks();
   test_shared_sizes();
   test_transforms();
 


### PR DESCRIPTION
Fixes an issue using prior with 24-bit values or sizes smaller than a single byte. 24-bit values are managed using a 32-bit memory read and sizes smaller than a single byte are managed with a full byte read. In either case, if bits not specifically related to the data being examined changed, the larger prior value was being updated, even though the masked data had not changed. Then, when the logic attempted to use the prior value, it would see the current value instead of the prior value.

For example, a `prior` on `low4($0000)` might be updated as follows:

```
        cur pri low low_pri
$0000 = 01  00  1   0
        02  01  2   1
        12  02  2   2
```
You can see that changing the upper4 of the monitored address updated the prior value for the byte, which causes the low4 and prior(low4) values to become identical.

While sharing memory like this is very beneficial, it just doesn't work with prior. As such, if prior is used on a masked value, then the mask must match for the memory reference to be shared.