### PR TITLE
fix hashing for buffered n64 files without a registered filereader

### DIFF
--- a/test/rhash/mock_filereader.h
+++ b/test/rhash/mock_filereader.h
@@ -11,6 +11,8 @@ extern "C" {
 void init_mock_filereader();
 void init_mock_cdreader();
 
+void rc_hash_reset_filereader();
+
 void mock_file(int index, const char* filename, const uint8_t* buffer, size_t buffer_size);
 void mock_file_text(int index, const char* filename, const char* contents);
 void mock_empty_file(int index, const char* filename, size_t mock_size);

--- a/test/rhash/test_hash.c
+++ b/test/rhash/test_hash.c
@@ -605,7 +605,11 @@ static void test_hash_nes_file_iterator_32k()
 static void test_hash_n64(uint8_t* buffer, size_t buffer_size, const char* expected_hash)
 {
   char hash[33];
-  int result = rc_hash_generate_from_buffer(hash, RC_CONSOLE_NINTENDO_64, buffer, buffer_size);
+  int result;
+
+  rc_hash_reset_filereader(); /* explicitly unset the filereader */
+  result = rc_hash_generate_from_buffer(hash, RC_CONSOLE_NINTENDO_64, buffer, buffer_size);
+  init_mock_filereader(); /* restore the mock filereader */
 
   ASSERT_NUM_EQUALS(result, 1);
   ASSERT_STR_EQUALS(hash, expected_hash);


### PR DESCRIPTION
As seen when using the beta2 0.80 DLL in RAProject64.

The solution for #176 replaces the existing filereader with a new virtual filereader. If an existing filereader doesn't exist, the default filereader still gets registered, and then the buffered file hashing fails as the buffered file cannot be found on disk.

Because RAProject64 does not register a filereader, this resulted in the first game loaded not being recognized. This would cause the default filereader to be registered, so subsequent opens would use the virtual filereader correctly.

N64 and NDS are currently the only consoles that support buffered file hashing. The other buffered hashing routines expect the file to be loaded into memory.

RetroArch and RALibretro register their own filereaders (to support non-ascii character paths), so are not affected.