### PR TITLE
ensure invalid credential errors are returned

### DIFF
--- a/src/rapi/rc_api_runtime.c
+++ b/src/rapi/rc_api_runtime.c
@@ -129,7 +129,7 @@ int rc_api_process_fetch_game_data_response(rc_api_fetch_game_data_response_t* r
   rc_buf_init(&response->response.buffer);
 
   result = rc_json_parse_response(&response->response, server_response, fields, sizeof(fields) / sizeof(fields[0]));
-  if (result != RC_OK)
+  if (result != RC_OK || !response->response.succeeded)
     return result;
 
   if (!rc_json_get_required_object(patchdata_fields, sizeof(patchdata_fields) / sizeof(patchdata_fields[0]), &response->response, &fields[2], "PatchData"))
@@ -477,7 +477,7 @@ int rc_api_process_submit_lboard_entry_response(rc_api_submit_lboard_entry_respo
   rc_buf_init(&response->response.buffer);
 
   result = rc_json_parse_response(&response->response, server_response, fields, sizeof(fields) / sizeof(fields[0]));
-  if (result != RC_OK)
+  if (result != RC_OK || !response->response.succeeded)
     return result;
 
   if (!rc_json_get_required_object(response_fields, sizeof(response_fields) / sizeof(response_fields[0]), &response->response, &fields[2], "Response"))

--- a/src/rapi/rc_api_user.c
+++ b/src/rapi/rc_api_user.c
@@ -138,7 +138,7 @@ int rc_api_process_fetch_user_unlocks_response(rc_api_fetch_user_unlocks_respons
   rc_buf_init(&response->response.buffer);
 
   result = rc_json_parse_response(&response->response, server_response, fields, sizeof(fields) / sizeof(fields[0]));
-  if (result != RC_OK)
+  if (result != RC_OK || !response->response.succeeded)
     return result;
 
   result = rc_json_get_required_unum_array(&response->achievement_ids, &response->num_achievement_ids, &response->response, &fields[2], "UserUnlocks");

--- a/test/rapi/test_rc_api_editor.c
+++ b/test/rapi/test_rc_api_editor.c
@@ -215,6 +215,19 @@ static void test_init_update_code_note_response()
   rc_api_destroy_update_code_note_response(&update_code_note_response);
 }
 
+static void test_init_update_code_note_response_invalid_credentials()
+{
+  rc_api_update_code_note_response_t update_code_note_response;
+  const char* server_response = "{\"Success\":false,\"Error\":\"Credentials invalid (0)\"}";
+  memset(&update_code_note_response, 0, sizeof(update_code_note_response));
+
+  ASSERT_NUM_EQUALS(rc_api_process_update_code_note_response(&update_code_note_response, server_response), RC_OK);
+  ASSERT_NUM_EQUALS(update_code_note_response.response.succeeded, 0);
+  ASSERT_STR_EQUALS(update_code_note_response.response.error_message, "Credentials invalid (0)");
+
+  rc_api_destroy_update_code_note_response(&update_code_note_response);
+}
+
 static void test_init_update_achievement_request()
 {
   rc_api_update_achievement_request_t update_achievement_request;
@@ -293,6 +306,20 @@ static void test_init_update_achievement_response()
   ASSERT_NUM_EQUALS(update_achievement_response.response.succeeded, 1);
   ASSERT_PTR_NULL(update_achievement_response.response.error_message);
   ASSERT_UNUM_EQUALS(update_achievement_response.achievement_id, 1234);
+
+  rc_api_destroy_update_achievement_response(&update_achievement_response);
+}
+
+static void test_init_update_achievement_response_invalid_credentials()
+{
+  rc_api_update_achievement_response_t update_achievement_response;
+  const char* server_response = "{\"Success\":false,\"Error\":\"Credentials invalid (0)\"}";
+  memset(&update_achievement_response, 0, sizeof(update_achievement_response));
+
+  ASSERT_NUM_EQUALS(rc_api_process_update_achievement_response(&update_achievement_response, server_response), RC_OK);
+  ASSERT_NUM_EQUALS(update_achievement_response.response.succeeded, 0);
+  ASSERT_STR_EQUALS(update_achievement_response.response.error_message, "Credentials invalid (0)");
+  ASSERT_UNUM_EQUALS(update_achievement_response.achievement_id, 0);
 
   rc_api_destroy_update_achievement_response(&update_achievement_response);
 }
@@ -420,6 +447,20 @@ static void test_init_update_leaderboard_response()
   ASSERT_NUM_EQUALS(update_leaderboard_response.response.succeeded, 1);
   ASSERT_PTR_NULL(update_leaderboard_response.response.error_message);
   ASSERT_UNUM_EQUALS(update_leaderboard_response.leaderboard_id, 1234);
+
+  rc_api_destroy_update_leaderboard_response(&update_leaderboard_response);
+}
+
+static void test_init_update_leaderboard_response_invalid_credentials()
+{
+  rc_api_update_leaderboard_response_t update_leaderboard_response;
+  const char* server_response = "{\"Success\":false,\"Error\":\"Credentials invalid (0)\"}";
+  memset(&update_leaderboard_response, 0, sizeof(update_leaderboard_response));
+
+  ASSERT_NUM_EQUALS(rc_api_process_update_leaderboard_response(&update_leaderboard_response, server_response), RC_OK);
+  ASSERT_NUM_EQUALS(update_leaderboard_response.response.succeeded, 0);
+  ASSERT_STR_EQUALS(update_leaderboard_response.response.error_message, "Credentials invalid (0)");
+  ASSERT_UNUM_EQUALS(update_leaderboard_response.leaderboard_id, 0);
 
   rc_api_destroy_update_leaderboard_response(&update_leaderboard_response);
 }
@@ -593,6 +634,20 @@ static void test_init_add_game_hash_response_error()
   rc_api_destroy_add_game_hash_response(&add_game_hash_response);
 }
 
+static void test_init_add_game_hash_response_invalid_credentials()
+{
+  rc_api_add_game_hash_response_t add_game_hash_response;
+  const char* server_response = "{\"Success\":false,\"Error\":\"Credentials invalid (0)\"}";
+  memset(&add_game_hash_response, 0, sizeof(add_game_hash_response));
+
+  ASSERT_NUM_EQUALS(rc_api_process_add_game_hash_response(&add_game_hash_response, server_response), RC_OK);
+  ASSERT_NUM_EQUALS(add_game_hash_response.response.succeeded, 0);
+  ASSERT_STR_EQUALS(add_game_hash_response.response.error_message, "Credentials invalid (0)");
+  ASSERT_UNUM_EQUALS(add_game_hash_response.game_id, 0);
+
+  rc_api_destroy_add_game_hash_response(&add_game_hash_response);
+}
+
 void test_rapi_editor(void) {
   TEST_SUITE_BEGIN();
 
@@ -612,6 +667,7 @@ void test_rapi_editor(void) {
   TEST(test_init_update_code_note_request_empty_note);
 
   TEST(test_init_update_code_note_response);
+  TEST(test_init_update_code_note_response_invalid_credentials);
 
   /* update achievement */
   TEST(test_init_update_achievement_request);
@@ -619,6 +675,7 @@ void test_rapi_editor(void) {
   TEST(test_init_update_achievement_request_no_game_id);
 
   TEST(test_init_update_achievement_response);
+  TEST(test_init_update_achievement_response_invalid_credentials);
   TEST(test_init_update_achievement_response_invalid_perms);
 
   /* update leaderboard */
@@ -628,6 +685,7 @@ void test_rapi_editor(void) {
   TEST(test_init_update_leaderboard_request_no_description);
 
   TEST(test_init_update_leaderboard_response);
+  TEST(test_init_update_leaderboard_response_invalid_credentials);
   TEST(test_init_update_leaderboard_response_invalid_perms);
 
   /* fetch badge range */
@@ -644,6 +702,7 @@ void test_rapi_editor(void) {
 
   TEST(test_init_add_game_hash_response);
   TEST(test_init_add_game_hash_response_error);
+  TEST(test_init_add_game_hash_response_invalid_credentials);
 
   TEST_SUITE_END();
 }

--- a/test/rapi/test_rc_api_runtime.c
+++ b/test/rapi/test_rc_api_runtime.c
@@ -139,6 +139,26 @@ static void test_process_fetch_game_data_response_empty() {
   rc_api_destroy_fetch_game_data_response(&fetch_game_data_response);
 }
 
+static void test_process_fetch_game_data_response_invalid_credentials() {
+  rc_api_fetch_game_data_response_t fetch_game_data_response;
+  const char* server_response = "{\"Success\":false,\"Error\":\"Credentials invalid (0)\"}";
+
+  memset(&fetch_game_data_response, 0, sizeof(fetch_game_data_response));
+
+  ASSERT_NUM_EQUALS(rc_api_process_fetch_game_data_response(&fetch_game_data_response, server_response), RC_OK);
+  ASSERT_NUM_EQUALS(fetch_game_data_response.response.succeeded, 0);
+  ASSERT_STR_EQUALS(fetch_game_data_response.response.error_message, "Credentials invalid (0)");
+  ASSERT_NUM_EQUALS(fetch_game_data_response.id, 0);
+  ASSERT_PTR_NULL(fetch_game_data_response.title);
+  ASSERT_NUM_EQUALS(fetch_game_data_response.console_id, 0);
+  ASSERT_PTR_NULL(fetch_game_data_response.image_name);
+  ASSERT_PTR_NULL(fetch_game_data_response.rich_presence_script);
+  ASSERT_NUM_EQUALS(fetch_game_data_response.num_achievements, 0);
+  ASSERT_NUM_EQUALS(fetch_game_data_response.num_leaderboards, 0);
+
+  rc_api_destroy_fetch_game_data_response(&fetch_game_data_response);
+}
+
 static void test_process_fetch_game_data_response_achievements() {
   rc_api_fetch_game_data_response_t fetch_game_data_response;
   const char* server_response = "{\"Success\":true,\"PatchData\":{"
@@ -571,6 +591,22 @@ static void test_process_award_achievement_response_empty() {
   rc_api_destroy_award_achievement_response(&award_achievement_response);
 }
 
+static void test_process_award_achievement_response_invalid_credentials() {
+  rc_api_award_achievement_response_t award_achievement_response;
+  const char* server_response = "{\"Success\":false,\"Error\":\"Credentials invalid (0)\"}";
+
+  memset(&award_achievement_response, 0, sizeof(award_achievement_response));
+
+  ASSERT_NUM_EQUALS(rc_api_process_award_achievement_response(&award_achievement_response, server_response), RC_OK);
+  ASSERT_NUM_EQUALS(award_achievement_response.response.succeeded, 0);
+  ASSERT_STR_EQUALS(award_achievement_response.response.error_message, "Credentials invalid (0)");
+  ASSERT_UNUM_EQUALS(award_achievement_response.new_player_score, 0);
+  ASSERT_UNUM_EQUALS(award_achievement_response.awarded_achievement_id, 0);
+  ASSERT_UNUM_EQUALS(award_achievement_response.achievements_remaining, 0);
+
+  rc_api_destroy_award_achievement_response(&award_achievement_response);
+}
+
 static void test_process_award_achievement_response_text() {
   rc_api_award_achievement_response_t award_achievement_response;
   const char* server_response = "You do not have access to that resource";
@@ -724,6 +760,26 @@ static void test_process_submit_lb_entry_response_no_entries() {
   rc_api_destroy_submit_lboard_entry_response(&submit_lb_entry_response);
 }
 
+static void test_process_submit_lb_entry_response_invalid_credentials() {
+  rc_api_submit_lboard_entry_response_t submit_lb_entry_response;
+  const char* server_response = "{\"Success\":false,\"Error\":\"Credentials invalid (0)\"}";
+
+  memset(&submit_lb_entry_response, 0, sizeof(submit_lb_entry_response));
+
+  ASSERT_NUM_EQUALS(rc_api_process_submit_lboard_entry_response(&submit_lb_entry_response, server_response), RC_OK);
+  ASSERT_NUM_EQUALS(submit_lb_entry_response.response.succeeded, 0);
+  ASSERT_STR_EQUALS(submit_lb_entry_response.response.error_message, "Credentials invalid (0)");
+  ASSERT_NUM_EQUALS(submit_lb_entry_response.submitted_score, 0);
+  ASSERT_NUM_EQUALS(submit_lb_entry_response.best_score, 0);
+  ASSERT_NUM_EQUALS(submit_lb_entry_response.new_rank, 0);
+  ASSERT_NUM_EQUALS(submit_lb_entry_response.num_entries, 0);
+
+  ASSERT_NUM_EQUALS(submit_lb_entry_response.num_top_entries, 0);
+  ASSERT_PTR_NULL(submit_lb_entry_response.top_entries);
+
+  rc_api_destroy_submit_lboard_entry_response(&submit_lb_entry_response);
+}
+
 static void test_process_submit_lb_entry_response_entries_not_array() {
   rc_api_submit_lboard_entry_response_t submit_lb_entry_response;
   const char* server_response = "{\"Success\":true,\"Response\":{\"Score\":1234,\"BestScore\":2345,"
@@ -756,6 +812,7 @@ void test_rapi_runtime(void) {
   TEST(test_init_fetch_game_data_request_no_id);
 
   TEST(test_process_fetch_game_data_response_empty);
+  TEST(test_process_fetch_game_data_response_invalid_credentials);
   TEST(test_process_fetch_game_data_response_achievements);
   TEST(test_process_fetch_game_data_response_leaderboards);
   TEST(test_process_fetch_game_data_response_rich_presence);
@@ -781,6 +838,7 @@ void test_rapi_runtime(void) {
   TEST(test_process_award_achievement_response_non_hardcore_already_unlocked);
   TEST(test_process_award_achievement_response_generic_failure);
   TEST(test_process_award_achievement_response_empty);
+  TEST(test_process_award_achievement_response_invalid_credentials);
   TEST(test_process_award_achievement_response_text);
   TEST(test_process_award_achievement_response_no_fields);
 
@@ -792,6 +850,7 @@ void test_rapi_runtime(void) {
 
   TEST(test_process_submit_lb_entry_response_success);
   TEST(test_process_submit_lb_entry_response_no_entries);
+  TEST(test_process_submit_lb_entry_response_invalid_credentials);
   TEST(test_process_submit_lb_entry_response_entries_not_array);
 
   TEST_SUITE_END();

--- a/test/rapi/test_rc_api_user.c
+++ b/test/rapi/test_rc_api_user.c
@@ -50,6 +50,20 @@ static void test_process_start_session_response()
   rc_api_destroy_start_session_response(&start_session_response);
 }
 
+static void test_process_start_session_response_invalid_credentials()
+{
+  rc_api_start_session_response_t start_session_response;
+  const char* server_response = "{\"Success\":false,\"Error\":\"Credentials invalid (0)\"}";
+
+  memset(&start_session_response, 0, sizeof(start_session_response));
+
+  ASSERT_NUM_EQUALS(rc_api_process_start_session_response(&start_session_response, server_response), RC_OK);
+  ASSERT_NUM_EQUALS(start_session_response.response.succeeded, 0);
+  ASSERT_STR_EQUALS(start_session_response.response.error_message, "Credentials invalid (0)");
+
+  rc_api_destroy_start_session_response(&start_session_response);
+}
+
 static void test_init_login_request_password()
 {
   rc_api_login_request_t login_request;
@@ -384,6 +398,21 @@ static void test_init_fetch_user_unlocks_response_empty_array()
   rc_api_destroy_fetch_user_unlocks_response(&fetch_user_unlocks_response);
 }
 
+static void test_init_fetch_user_unlocks_response_invalid_credentials()
+{
+  rc_api_fetch_user_unlocks_response_t fetch_user_unlocks_response;
+  const char* server_response = "{\"Success\":false,\"Error\":\"Credentials invalid (0)\"}";
+  memset(&fetch_user_unlocks_response, 0, sizeof(fetch_user_unlocks_response));
+
+  ASSERT_NUM_EQUALS(rc_api_process_fetch_user_unlocks_response(&fetch_user_unlocks_response, server_response), RC_OK);
+  ASSERT_NUM_EQUALS(fetch_user_unlocks_response.response.succeeded, 0);
+  ASSERT_STR_EQUALS(fetch_user_unlocks_response.response.error_message, "Credentials invalid (0)");
+  ASSERT_PTR_NULL(fetch_user_unlocks_response.achievement_ids);
+  ASSERT_NUM_EQUALS(fetch_user_unlocks_response.num_achievement_ids, 0);
+
+  rc_api_destroy_fetch_user_unlocks_response(&fetch_user_unlocks_response);
+}
+
 static void test_init_fetch_user_unlocks_response_one_item()
 {
   rc_api_fetch_user_unlocks_response_t fetch_user_unlocks_response;
@@ -427,6 +456,7 @@ void test_rapi_user(void) {
   TEST(test_init_start_session_request_no_game);
 
   TEST(test_process_start_session_response);
+  TEST(test_process_start_session_response_invalid_credentials);
 
   /* login */
   TEST(test_init_login_request_password);
@@ -452,6 +482,7 @@ void test_rapi_user(void) {
   TEST(test_init_fetch_user_unlocks_request_hardcore);
 
   TEST(test_init_fetch_user_unlocks_response_empty_array);
+  TEST(test_init_fetch_user_unlocks_response_invalid_credentials);
   TEST(test_init_fetch_user_unlocks_response_one_item);
   TEST(test_init_fetch_user_unlocks_response_several_items);
 


### PR DESCRIPTION
Fixes an issue where some APIs (`fetch_game_data`, `fetch_user_unlocks`, and `submit_lboard_entry`) would return `RC_MISSING_VALUE` instead of acknowledging a server error.