### PR TITLE
reset captured value of measured hitcount while paused

### DIFF
--- a/src/rhash/cdreader.c
+++ b/src/rhash/cdreader.c
@@ -131,7 +131,7 @@ static void* cdreader_open_bin_track(const char* path, uint32_t track)
 
   if (cdrom->sector_size == 0)
   {
-    size_t size;
+    int64_t size;
 
     rc_file_seek(cdrom->file_handle, 0, SEEK_END);
     size = rc_file_tell(cdrom->file_handle);


### PR DESCRIPTION
Fixes an issue where a Paused Measured hitcount would be remembered even though a Reset had occurred.

The Reset would clear the captured Measured value if "measured_from_hits" was true, but since the Pause prevented the processing of the Measured condition, the "measured_from_hits" flag was not being set, which resulted in the captured Measured value not being cleared.