### PR TITLE
allow m3u for megadrive

### DIFF
--- a/src/rhash/hash.c
+++ b/src/rhash/hash.c
@@ -84,7 +84,7 @@ static void filereader_close(void* file_handle)
 }
 
 /* for unit tests - normally would call rc_hash_init_custom_filereader(NULL) */
-void rc_hash_reset_filereader()
+void rc_hash_reset_filereader(void)
 {
   filereader = NULL;
 }
@@ -1909,7 +1909,6 @@ int rc_hash_generate_from_file(char hash[33], int console_id, const char* path)
     case RC_CONSOLE_INTELLIVISION:
     case RC_CONSOLE_MAGNAVOX_ODYSSEY2:
     case RC_CONSOLE_MASTER_SYSTEM:
-    case RC_CONSOLE_MEGA_DRIVE:
     case RC_CONSOLE_MEGADUCK:
     case RC_CONSOLE_NEOGEO_POCKET:
     case RC_CONSOLE_ORIC:
@@ -1928,6 +1927,7 @@ int rc_hash_generate_from_file(char hash[33], int console_id, const char* path)
     case RC_CONSOLE_AMSTRAD_PC:
     case RC_CONSOLE_APPLE_II:
     case RC_CONSOLE_COMMODORE_64:
+    case RC_CONSOLE_MEGA_DRIVE:
     case RC_CONSOLE_MSX:
     case RC_CONSOLE_PC8800:
       /* generic whole-file hash with m3u support - don't buffer */

--- a/test/rcheevos/test_condset.c
+++ b/test/rcheevos/test_condset.c
@@ -425,7 +425,16 @@ static void test_pauseif_short_circuit() {
   memory.ram = ram;
   memory.size = sizeof(ram);
 
-  /* evaluation of an achievement stops at the first true pauseif condition */
+  /* evaluation of an achievement stops at the first true pauseif condition
+   *
+   * this allows achievements to prevent accumulating hits on a pauselock farther down
+   * in a group. a better solution would be to use an AndNext on the pauselock, but
+   * there are achievements in the wild relying on this behavior.
+   * see https://retroachievements.org/achievement/66804, which has a PauseIf 2040 frames
+   * pass (condition 5), but don't tally those frames if the game is paused (condition 3).
+   * similarly, https://retroachievements.org/achievement/154804 has a PauseIf 480 frames
+   * (condition 5), but don't tally those frames if the map is visible (condition 4).
+   */
   assert_parse_condset(&condset, &memrefs, buffer, "P:0xH0001=1_P:0xH0002=1.3._0xH0003=1.4.");
 
   /* nothing true */

--- a/test/rhash/test_hash.c
+++ b/test/rhash/test_hash.c
@@ -1592,6 +1592,7 @@ void test_hash(void) {
 
   /* Mega Drive */
   TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_MEGA_DRIVE, "test.md", 1048576, "da9461b3b0f74becc3ccf6c2a094c516");
+  TEST_PARAMS4(test_hash_m3u, RC_CONSOLE_MEGA_DRIVE, "test.md", 1048576, "da9461b3b0f74becc3ccf6c2a094c516");
 
   /* Mega Duck */
   TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_MEGADUCK, "test.bin", 65536, "8e6576cd5c21e44e0bbfc4480577b040");


### PR DESCRIPTION
https://retroachievements.org/viewtopic.php?t=7358&c=122122#122122

RetroArch already handles this case because it has to guess the console from the file:
```
[INFO] [RCHEEVOS]: Opened Pier Solar.m3u
[INFO] [RCHEEVOS]: Extracted Pier Solar and the Great Architects (World) (Unl).md from playlist
[INFO] [RCHEEVOS]: Found 1 potential consoles for md file extension
[INFO] [RCHEEVOS]: Trying console 1
[INFO] [RCHEEVOS]: Opened Pier Solar and the Great Architects (World) (Unl).md
[INFO] [RCHEEVOS]: Hashing Pier Solar and the Great Architects (World) (Unl).md (8388608 bytes)
[INFO] [RCHEEVOS]: Generated hash daad74b872a5f1afc932e40e2d9825db
```

However, RALibretro was doing a full-file hash of the m3u because the console is explicitly specified when selecting the core:
- Select Core > **Sega Genesis** > Genesis Plus GX

This PR allows the `RC_CONSOLE_MEGA_DRIVE` hasher to detect being passed an m3u and hash the first file instead of the m3u.