### PR TITLE
don't report redundancy between trigger and non-trigger conditions

### DIFF
--- a/src/rcheevos/rc_validate.c
+++ b/src/rcheevos/rc_validate.c
@@ -665,7 +665,15 @@ static int rc_validate_conflicting_conditions(const rc_condset_t* conditions, co
           else if (compare_condition->type == RC_CONDITION_MEASURED_IF || condition->type == RC_CONDITION_MEASURED_IF)
           {
             /* MeasuredIf is a meta tag and allowed to be redundant */
-            continue;
+            if (compare_condition->type != condition->type)
+              continue;
+          }
+          else if (compare_condition->type == RC_CONDITION_TRIGGER || condition->type == RC_CONDITION_TRIGGER)
+          {
+            /* Trigger is allowed to be redundant with non-trigger conditions as there may be limits that start a
+             * challenge that are furhter reduced for the completion of the challenge */
+            if (compare_condition->type != condition->type)
+              continue;
           }
           break;
 

--- a/test/rcheevos/test_rc_validate.c
+++ b/test/rcheevos/test_rc_validate.c
@@ -263,7 +263,10 @@ void test_redundant_conditions() {
   TEST_PARAMS2(test_validate_trigger, "0xH0000=1SR:0xH0000!=1", "Core Condition 1: Redundant with Alt1 Condition 1");
   TEST_PARAMS2(test_validate_trigger, "P:0xH0000=1SP:0xH0000=1", "");
   TEST_PARAMS2(test_validate_trigger, "0xH0000=4.1._0xH0000=5_P:0xH0000<4", "");
-  TEST_PARAMS2(test_validate_trigger, "M:0xH0000=5_Q:0xH0000!=255", "");
+  TEST_PARAMS2(test_validate_trigger, "Q:0xH0000=5_Q:0xH0000!=255", "Condition 2: Redundant with Condition 1");
+  TEST_PARAMS2(test_validate_trigger, "M:0xH0000=5_Q:0xH0000!=255", ""); /* measuredif not redundant measured */
+  TEST_PARAMS2(test_validate_trigger, "T:0xH0000!=0_T:0xH0000=6", "Condition 1: Redundant with Condition 2");
+  TEST_PARAMS2(test_validate_trigger, "0xH0000!=0_T:0xH0000=6", ""); /* trigger not redundant with non-trigger */
 }
 
 void test_rc_validate(void) {


### PR DESCRIPTION
Prevents showing a warning when the trigger condition is just a more restrictive version of a non-trigger requirement.
```
        8-bit 0x1234 != 0
Trigger 8-bit 0x1234 = 7
```
https://discord.com/channels/310192285306454017/310195377993416714/960352953661804564