### PR TITLE
use optimized comparators for most common condition logic

### DIFF
--- a/include/rc_runtime_types.h
+++ b/include/rc_runtime_types.h
@@ -200,6 +200,9 @@ struct rc_condition_t {
 
   /* Whether or not the condition evaluated true on the last check */
   char is_true;
+
+  /* Unique identifier of optimized comparator to use */
+  char optimized_comparator;
 };
 
 /*****************************************************************************\

--- a/src/rcheevos/condition.c
+++ b/src/rcheevos/condition.c
@@ -1,6 +1,78 @@
 #include "rc_internal.h"
 
 #include <stdlib.h>
+#include <assert.h>
+
+static int rc_test_condition_compare(unsigned value1, unsigned value2, char oper) {
+  switch (oper) {
+    case RC_OPERATOR_EQ: return value1 == value2;
+    case RC_OPERATOR_NE: return value1 != value2;
+    case RC_OPERATOR_LT: return value1 < value2;
+    case RC_OPERATOR_LE: return value1 <= value2;
+    case RC_OPERATOR_GT: return value1 > value2;
+    case RC_OPERATOR_GE: return value1 >= value2;
+    default: return 1;
+  }
+}
+
+static char rc_condition_determine_comparator(const rc_condition_t* self) {
+  switch (self->oper) {
+    case RC_OPERATOR_EQ:
+    case RC_OPERATOR_NE:
+    case RC_OPERATOR_LT:
+    case RC_OPERATOR_LE:
+    case RC_OPERATOR_GT:
+    case RC_OPERATOR_GE:
+      break;
+
+    default:
+      /* not a comparison. should not be getting compared. but if it is, legacy behavior was to return 1 */
+      return RC_PROCESSING_COMPARE_ALWAYS_TRUE;
+  }
+
+  if ((self->operand1.type == RC_OPERAND_ADDRESS || self->operand1.type == RC_OPERAND_DELTA) &&
+      !self->operand1.value.memref->value.is_indirect && !rc_operand_is_float(&self->operand1)) {
+    /* left side is an integer memory reference */
+    int needs_translate = (self->operand1.size != self->operand1.value.memref->value.size);
+
+    if (self->operand2.type == RC_OPERAND_CONST) {
+      /* right side is a constant */
+      if (self->operand1.type == RC_OPERAND_ADDRESS)
+        return needs_translate ? RC_PROCESSING_COMPARE_MEMREF_TO_CONST_TRANSFORMED : RC_PROCESSING_COMPARE_MEMREF_TO_CONST;
+
+      return needs_translate ? RC_PROCESSING_COMPARE_DELTA_TO_CONST_TRANSFORMED : RC_PROCESSING_COMPARE_DELTA_TO_CONST;
+    }
+    else if ((self->operand2.type == RC_OPERAND_ADDRESS || self->operand2.type == RC_OPERAND_DELTA) &&
+             !self->operand2.value.memref->value.is_indirect && !rc_operand_is_float(&self->operand2)) {
+      /* right side is an integer memory reference */
+      needs_translate |= (self->operand2.size != self->operand2.value.memref->value.size);
+
+      if (self->operand1.type == RC_OPERAND_ADDRESS) {
+        if (self->operand2.type == RC_OPERAND_ADDRESS) {
+          if (self->operand1.value.memref == self->operand2.value.memref && self->operand1.size == self->operand2.size)
+            return rc_test_condition_compare(0, 0, self->oper) ? RC_PROCESSING_COMPARE_ALWAYS_TRUE : RC_PROCESSING_COMPARE_ALWAYS_FALSE;
+
+          return needs_translate ? RC_PROCESSING_COMPARE_MEMREF_TO_MEMREF_TRANSFORMED : RC_PROCESSING_COMPARE_MEMREF_TO_MEMREF;
+        }
+
+        assert(self->operand2.type == RC_OPERAND_DELTA);
+        return needs_translate ? RC_PROCESSING_COMPARE_MEMREF_TO_DELTA_TRANSFORMED : RC_PROCESSING_COMPARE_MEMREF_TO_DELTA;
+      }
+
+      assert(self->operand1.type == RC_OPERAND_DELTA);
+
+      if (self->operand2.type == RC_OPERAND_ADDRESS)
+        return needs_translate ? RC_PROCESSING_COMPARE_DELTA_TO_MEMREF_TRANSFORMED : RC_PROCESSING_COMPARE_DELTA_TO_MEMREF;
+    }
+  }
+
+  if (self->operand1.type == RC_OPERAND_CONST && self->operand2.type == RC_OPERAND_CONST) {
+    return rc_test_condition_compare(self->operand1.value.num, self->operand2.value.num, self->oper) ?
+        RC_PROCESSING_COMPARE_ALWAYS_TRUE : RC_PROCESSING_COMPARE_ALWAYS_FALSE;
+  }
+
+  return RC_PROCESSING_COMPARE_DEFAULT;
+}
 
 static int rc_parse_operator(const char** memaddr) {
   const char* oper = *memaddr;
@@ -75,6 +147,7 @@ rc_condition_t* rc_parse_condition(const char** memaddr, rc_parse_state_t* parse
   self->current_hits = 0;
   self->is_true = 0;
   self->pause = 0;
+  self->optimized_comparator = RC_PROCESSING_COMPARE_DEFAULT;
 
   if (*aux != 0 && aux[1] == ':') {
     switch (*aux) {
@@ -214,6 +287,8 @@ rc_condition_t* rc_parse_condition(const char** memaddr, rc_parse_state_t* parse
     self->required_hits = 0;
   }
 
+  self->optimized_comparator = rc_condition_determine_comparator(self);
+
   *memaddr = aux;
   return self;
 }
@@ -233,12 +308,203 @@ int rc_condition_is_combining(const rc_condition_t* self) {
   }
 }
 
+static int rc_test_condition_compare_memref_to_const(rc_condition_t* self) {
+  const unsigned value1 = self->operand1.value.memref->value.value;
+  const unsigned value2 = self->operand2.value.num;
+  assert(self->operand1.size == self->operand1.value.memref->value.size);
+  return rc_test_condition_compare(value1, value2, self->oper);
+}
+
+static int rc_test_condition_compare_delta_to_const(rc_condition_t* self) {
+  const rc_memref_value_t* memref1 = &self->operand1.value.memref->value;
+  const unsigned value1 = (memref1->changed) ? memref1->prior : memref1->value;
+  const unsigned value2 = self->operand2.value.num;
+  assert(self->operand1.size == self->operand1.value.memref->value.size);
+  return rc_test_condition_compare(value1, value2, self->oper);
+}
+
+static int rc_test_condition_compare_memref_to_memref(rc_condition_t* self) {
+  const unsigned value1 = self->operand1.value.memref->value.value;
+  const unsigned value2 = self->operand2.value.memref->value.value;
+  assert(self->operand1.size == self->operand1.value.memref->value.size);
+  assert(self->operand2.size == self->operand2.value.memref->value.size);
+  return rc_test_condition_compare(value1, value2, self->oper);
+}
+
+static int rc_test_condition_compare_memref_to_delta(rc_condition_t* self) {
+  const rc_memref_value_t* memref = &self->operand1.value.memref->value;
+  assert(self->operand1.value.memref == self->operand2.value.memref);
+  assert(self->operand1.size == self->operand1.value.memref->value.size);
+  assert(self->operand2.size == self->operand2.value.memref->value.size);
+
+  if (memref->changed)
+    return rc_test_condition_compare(memref->value, memref->prior, self->oper);
+
+  switch (self->oper) {
+    case RC_OPERATOR_EQ:
+    case RC_OPERATOR_GE:
+    case RC_OPERATOR_LE:
+      return 1;
+
+    default:
+      return 0;
+  }
+}
+
+static int rc_test_condition_compare_delta_to_memref(rc_condition_t* self) {
+  const rc_memref_value_t* memref = &self->operand1.value.memref->value;
+  assert(self->operand1.value.memref == self->operand2.value.memref);
+  assert(self->operand1.size == self->operand1.value.memref->value.size);
+  assert(self->operand2.size == self->operand2.value.memref->value.size);
+
+  if (memref->changed)
+    return rc_test_condition_compare(memref->prior, memref->value, self->oper);
+
+  switch (self->oper) {
+    case RC_OPERATOR_EQ:
+    case RC_OPERATOR_GE:
+    case RC_OPERATOR_LE:
+      return 1;
+
+    default:
+      return 0;
+  }
+}
+
+static int rc_test_condition_compare_memref_to_const_transformed(rc_condition_t* self) {
+  rc_typed_value_t value1;
+  const unsigned value2 = self->operand2.value.num;
+
+  value1.type = RC_VALUE_TYPE_UNSIGNED;
+  value1.value.u32 = self->operand1.value.memref->value.value;
+  rc_transform_memref_value(&value1, self->operand1.size);
+
+  return rc_test_condition_compare(value1.value.u32, value2, self->oper);
+}
+
+static int rc_test_condition_compare_delta_to_const_transformed(rc_condition_t* self) {
+  rc_typed_value_t value1;
+  const rc_memref_value_t* memref1 = &self->operand1.value.memref->value;
+  const unsigned value2 = self->operand2.value.num;
+
+  value1.type = RC_VALUE_TYPE_UNSIGNED;
+  value1.value.u32 = (memref1->changed) ? memref1->prior : memref1->value;
+  rc_transform_memref_value(&value1, self->operand1.size);
+
+  return rc_test_condition_compare(value1.value.u32, value2, self->oper);
+}
+
+static int rc_test_condition_compare_memref_to_memref_transformed(rc_condition_t* self) {
+  rc_typed_value_t value1, value2;
+
+  value1.type = RC_VALUE_TYPE_UNSIGNED;
+  value1.value.u32 = self->operand1.value.memref->value.value;
+  rc_transform_memref_value(&value1, self->operand1.size);
+
+  value2.type = RC_VALUE_TYPE_UNSIGNED;
+  value2.value.u32 = self->operand2.value.memref->value.value;
+  rc_transform_memref_value(&value2, self->operand2.size);
+
+  return rc_test_condition_compare(value1.value.u32, value2.value.u32, self->oper);
+}
+
+static int rc_test_condition_compare_memref_to_delta_transformed(rc_condition_t* self) {
+  const rc_memref_value_t* memref = &self->operand1.value.memref->value;
+  assert(self->operand1.value.memref == self->operand2.value.memref);
+
+  if (memref->changed) {
+    rc_typed_value_t value1, value2;
+
+    value1.type = RC_VALUE_TYPE_UNSIGNED;
+    value1.value.u32 = memref->value;
+    rc_transform_memref_value(&value1, self->operand1.size);
+
+    value2.type = RC_VALUE_TYPE_UNSIGNED;
+    value2.value.u32 = memref->prior;
+    rc_transform_memref_value(&value2, self->operand2.size);
+
+    return rc_test_condition_compare(value1.value.u32, value2.value.u32, self->oper);
+  }
+
+  switch (self->oper) {
+    case RC_OPERATOR_EQ:
+    case RC_OPERATOR_GE:
+    case RC_OPERATOR_LE:
+      return 1;
+
+    default:
+      return 0;
+  }
+}
+
+static int rc_test_condition_compare_delta_to_memref_transformed(rc_condition_t* self) {
+  const rc_memref_value_t* memref = &self->operand1.value.memref->value;
+  assert(self->operand1.value.memref == self->operand2.value.memref);
+
+  if (memref->changed) {
+    rc_typed_value_t value1, value2;
+
+    value1.type = RC_VALUE_TYPE_UNSIGNED;
+    value1.value.u32 = memref->prior;
+    rc_transform_memref_value(&value1, self->operand1.size);
+
+    value2.type = RC_VALUE_TYPE_UNSIGNED;
+    value2.value.u32 = memref->value;
+    rc_transform_memref_value(&value2, self->operand2.size);
+
+    return rc_test_condition_compare(value1.value.u32, value2.value.u32, self->oper);
+  }
+
+  switch (self->oper) {
+    case RC_OPERATOR_EQ:
+    case RC_OPERATOR_GE:
+    case RC_OPERATOR_LE:
+      return 1;
+
+    default:
+      return 0;
+  }
+}
+
 int rc_test_condition(rc_condition_t* self, rc_eval_state_t* eval_state) {
   rc_typed_value_t value1, value2;
 
-  rc_evaluate_operand(&value1, &self->operand1, eval_state);
-  if (eval_state->add_value.type != RC_VALUE_TYPE_NONE)
+  if (eval_state->add_value.type != RC_VALUE_TYPE_NONE) {
+    /* if there's an accumulator, we can't use the optimized comparators */
+    rc_evaluate_operand(&value1, &self->operand1, eval_state);
     rc_typed_value_add(&value1, &eval_state->add_value);
+  } else {
+    /* use an optimized comparator whenever possible */
+    switch (self->optimized_comparator) {
+      case RC_PROCESSING_COMPARE_MEMREF_TO_CONST:
+        return rc_test_condition_compare_memref_to_const(self);
+      case RC_PROCESSING_COMPARE_MEMREF_TO_DELTA:
+        return rc_test_condition_compare_memref_to_delta(self);
+      case RC_PROCESSING_COMPARE_MEMREF_TO_MEMREF:
+        return rc_test_condition_compare_memref_to_memref(self);
+      case RC_PROCESSING_COMPARE_DELTA_TO_CONST:
+        return rc_test_condition_compare_delta_to_const(self);
+      case RC_PROCESSING_COMPARE_DELTA_TO_MEMREF:
+        return rc_test_condition_compare_delta_to_memref(self);
+      case RC_PROCESSING_COMPARE_MEMREF_TO_CONST_TRANSFORMED:
+        return rc_test_condition_compare_memref_to_const_transformed(self);
+      case RC_PROCESSING_COMPARE_MEMREF_TO_DELTA_TRANSFORMED:
+        return rc_test_condition_compare_memref_to_delta_transformed(self);
+      case RC_PROCESSING_COMPARE_MEMREF_TO_MEMREF_TRANSFORMED:
+        return rc_test_condition_compare_memref_to_memref_transformed(self);
+      case RC_PROCESSING_COMPARE_DELTA_TO_CONST_TRANSFORMED:
+        return rc_test_condition_compare_delta_to_const_transformed(self);
+      case RC_PROCESSING_COMPARE_DELTA_TO_MEMREF_TRANSFORMED:
+        return rc_test_condition_compare_delta_to_memref_transformed(self);
+      case RC_PROCESSING_COMPARE_ALWAYS_TRUE:
+        return 1;
+      case RC_PROCESSING_COMPARE_ALWAYS_FALSE:
+        return 0;
+      default:
+        rc_evaluate_operand(&value1, &self->operand1, eval_state);
+        break;
+    }
+  }
 
   rc_evaluate_operand(&value2, &self->operand2, eval_state);
 

--- a/src/rcheevos/condition.c
+++ b/src/rcheevos/condition.c
@@ -287,7 +287,8 @@ rc_condition_t* rc_parse_condition(const char** memaddr, rc_parse_state_t* parse
     self->required_hits = 0;
   }
 
-  self->optimized_comparator = rc_condition_determine_comparator(self);
+  if (parse->buffer != 0)
+    self->optimized_comparator = rc_condition_determine_comparator(self);
 
   *memaddr = aux;
   return self;

--- a/src/rcheevos/memref.c
+++ b/src/rcheevos/memref.c
@@ -444,7 +444,7 @@ void rc_init_parse_state_memrefs(rc_parse_state_t* parse, rc_memref_t** memrefs)
   *memrefs = 0;
 }
 
-static unsigned rc_get_memref_value_value(rc_memref_value_t* memref, int operand_type) {
+static unsigned rc_get_memref_value_value(const rc_memref_value_t* memref, int operand_type) {
   switch (operand_type)
   {
     /* most common case explicitly first, even though it could be handled by default case.

--- a/src/rcheevos/rc_internal.h
+++ b/src/rcheevos/rc_internal.h
@@ -146,6 +146,22 @@ rc_condset_t* rc_parse_condset(const char** memaddr, rc_parse_state_t* parse, in
 int rc_test_condset(rc_condset_t* self, rc_eval_state_t* eval_state);
 void rc_reset_condset(rc_condset_t* self);
 
+enum {
+  RC_PROCESSING_COMPARE_DEFAULT = 0,
+  RC_PROCESSING_COMPARE_MEMREF_TO_CONST,
+  RC_PROCESSING_COMPARE_MEMREF_TO_DELTA,
+  RC_PROCESSING_COMPARE_MEMREF_TO_MEMREF,
+  RC_PROCESSING_COMPARE_DELTA_TO_MEMREF,
+  RC_PROCESSING_COMPARE_DELTA_TO_CONST,
+  RC_PROCESSING_COMPARE_MEMREF_TO_CONST_TRANSFORMED,
+  RC_PROCESSING_COMPARE_MEMREF_TO_DELTA_TRANSFORMED,
+  RC_PROCESSING_COMPARE_MEMREF_TO_MEMREF_TRANSFORMED,
+  RC_PROCESSING_COMPARE_DELTA_TO_MEMREF_TRANSFORMED,
+  RC_PROCESSING_COMPARE_DELTA_TO_CONST_TRANSFORMED,
+  RC_PROCESSING_COMPARE_ALWAYS_TRUE,
+  RC_PROCESSING_COMPARE_ALWAYS_FALSE
+};
+
 rc_condition_t* rc_parse_condition(const char** memaddr, rc_parse_state_t* parse, int is_indirect);
 int rc_test_condition(rc_condition_t* self, rc_eval_state_t* eval_state);
 void rc_evaluate_condition_value(rc_typed_value_t* value, rc_condition_t* self, rc_eval_state_t* eval_state);

--- a/src/rcheevos/rc_libretro.c
+++ b/src/rcheevos/rc_libretro.c
@@ -613,7 +613,7 @@ void rc_libretro_hash_set_init(struct rc_libretro_hash_set_t* hash_set,
   char image_path[1024];
   char* m3u_contents;
   char* ptr;
-  size_t file_len;
+  int64_t file_len;
   void* file_handle;
   int index = 0;
 

--- a/test/rcheevos-test.vcxproj
+++ b/test/rcheevos-test.vcxproj
@@ -204,6 +204,7 @@
     <ClCompile Include="rcheevos\test_richpresence.c" />
     <ClCompile Include="rcheevos\test_runtime.c" />
     <ClCompile Include="rcheevos\test_runtime_progress.c" />
+    <ClCompile Include="rcheevos\test_timing.c" />
     <ClCompile Include="rcheevos\test_trigger.c" />
     <ClCompile Include="rcheevos\test_value.c" />
     <ClCompile Include="rhash\data.c" />

--- a/test/rcheevos-test.vcxproj.filters
+++ b/test/rcheevos-test.vcxproj.filters
@@ -285,6 +285,9 @@
     <ClCompile Include="rcheevos\test_rc_validate.c">
       <Filter>tests\rcheevos</Filter>
     </ClCompile>
+    <ClCompile Include="rcheevos\test_timing.c">
+      <Filter>tests\rcheevos</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\include\rcheevos.h">

--- a/test/rcheevos/test_condition.c
+++ b/test/rcheevos/test_condition.c
@@ -137,7 +137,7 @@ static void test_evaluate_condition(const char* memaddr, int expected_comparator
   ASSERT_NUM_GREATER(parse.offset, 0);
   ASSERT_NUM_EQUALS(*memaddr, 0);
 
-  rc_update_memref_values(memrefs, peek, &memory); // capture delta for ram[1]
+  rc_update_memref_values(memrefs, peek, &memory); /* capture delta for ram[1] */
   ram[1] = 0x12;
 
   ASSERT_NUM_EQUALS(self->optimized_comparator, expected_comparator);

--- a/test/rcheevos/test_condition.c
+++ b/test/rcheevos/test_condition.c
@@ -510,6 +510,10 @@ void test_condition(void) {
   TEST_PARAMS1(test_default_comparator, "p0xH0001=0"); /* prior is not common enough to be optimized */
   TEST_PARAMS1(test_default_comparator, "b0xH0001=0"); /* bcd is not common enough to be optimized */
   TEST_PARAMS1(test_default_comparator, "~0xH0001=0"); /* inverted is not common enough to be optimized */
+  TEST_PARAMS1(test_default_comparator, "d0xH0001=0x 0001"); /* delta comparison only optimized for same address, same size */
+  TEST_PARAMS1(test_default_comparator, "0xH0001=d0x 0001"); /* delta comparison only optimized for same address, same size */
+  TEST_PARAMS1(test_default_comparator, "d0xH0001=0xH0002"); /* delta comparison only optimized for same address, same size */
+  TEST_PARAMS1(test_default_comparator, "0xH0001=d0xH0002"); /* delta comparison only optimized for same address, same size */
 
   /* float evaluations (ram[0] = 2.0, ram[4] = 3.14159 */
   TEST_PARAMS2(test_evaluate_condition_float, "fF0000=f2.0", 1);

--- a/test/rcheevos/test_timing.c
+++ b/test/rcheevos/test_timing.c
@@ -1,0 +1,166 @@
+#include "rc_runtime.h"
+#include "rc_internal.h"
+
+#include "mock_memory.h"
+
+#include "../test_framework.h"
+
+static rc_runtime_t runtime;
+static int trigger_count[128];
+
+static void event_handler(const rc_runtime_event_t* e)
+{
+  if (e->type == RC_RUNTIME_EVENT_ACHIEVEMENT_TRIGGERED)
+  {
+    rc_trigger_t* trigger = rc_runtime_get_achievement(&runtime, e->id);
+    trigger_count[e->id]++;
+    
+    rc_reset_trigger(trigger);
+    trigger->state = RC_TRIGGER_STATE_ACTIVE;
+  }
+}
+
+static void _assert_activate_achievement(rc_runtime_t* runtime, unsigned int id, const char* memaddr)
+{
+  int result = rc_runtime_activate_achievement(runtime, id, memaddr, NULL, 0);
+  ASSERT_NUM_EQUALS(result, RC_OK);
+}
+#define assert_activate_achievement(runtime, id, memaddr) ASSERT_HELPER(_assert_activate_achievement(runtime, id, memaddr), "assert_activate_achievement")
+
+static void do_timing(void)
+{
+  unsigned char ram[256], last, next, bitcount;
+  memory_t memory;
+  int i, j, mask;
+  clock_t total_clocks = 0, start, end;
+  double elapsed, average;
+
+  memory.ram = ram;
+  memory.size = sizeof(ram);
+  memset(&ram[0], 0, sizeof(ram));
+  for (i = 0; i < 0x3F; i++)
+    ram[0xC0 + i] = i;
+
+  memset(&trigger_count, 0, sizeof(trigger_count));
+
+  rc_runtime_init(&runtime);
+
+  assert_activate_achievement(&runtime, 1, "0xH0000=1");
+  assert_activate_achievement(&runtime, 2, "0xH0001=1");
+  assert_activate_achievement(&runtime, 3, "0xH0001=0");
+  assert_activate_achievement(&runtime, 4, "0xH0002!=d0xH0002");
+  assert_activate_achievement(&runtime, 5,
+      "A:0xH0000_A:0xH0001_A:0xH0002_A:0xH0003_A:0xH0004_A:0xH0005_A:0xH0006_A:0xH0007_"
+      "A:0xH0008_A:0xH0009_A:0xH000A_A:0xH000B_A:0xH000C_A:0xH000D_A:0xH000E_0xH000F=0xH0084");
+  assert_activate_achievement(&runtime, 6,
+      "A:0xH0000_A:0xH0001_A:0xH0002_A:0xH0003_A:0xH0004_A:0xH0005_A:0xH0006_0xH0007=0xK0080_"
+      "A:0xH0008_A:0xH0009_A:0xH000A_A:0xH000B_A:0xH000C_A:0xH000D_A:0xH000E_0xH000F=0xK0081");
+  assert_activate_achievement(&runtime, 7, "I:0xH0024_0xL00C0>8");
+  assert_activate_achievement(&runtime, 8, "O:0xH0000=1_O:0xH0001=1_O:0xH0002=1_O:0xH0003=1_O:0xH0004=1_O:0xH0005=1_O:0xH0006=1_0xH0007=1");
+  assert_activate_achievement(&runtime, 9, "N:0xH0000=1_N:0xH0001=1_N:0xH0002=1_N:0xH0003=1_N:0xH0004=1_N:0xH0005=1_N:0xH0006=1_0xH0007=1");
+  assert_activate_achievement(&runtime, 10, "0xH008A>0xH008B_0xH008A<0xH0089");
+  assert_activate_achievement(&runtime, 11,
+      "0xH0040=0xH0060_0xH0041=0xH0061_0xH0042=0xH0062_0xH0043=0xH0063_"
+      "0xH0044=0xH0064_0xH0045=0xH0065_0xH0046=0xH0066_0xH0047=0xH0067_"
+      "0xH0048=0xH0068_0xH0049=0xH0069_0xH004A=0xH006A_0xH004B=0xH006B_"
+      "0xH004C=0xH006C_0xH004D=0xH006D_0xH004E=0xH006E_0xH004F=0xH006F");
+  assert_activate_achievement(&runtime, 12, "0xH0003=1.3._R:0xH0004=1_P:0xH0005=1");
+  assert_activate_achievement(&runtime, 13, "0xH0003=1.3.SR:0xH0004=1_P:0xH0005=1");
+  assert_activate_achievement(&runtime, 14, "I:0xH0024_0xH0040>d0xH0040");
+  assert_activate_achievement(&runtime, 15, "b0xH0085=0xH0080");
+  assert_activate_achievement(&runtime, 16, "0xH0026=0xH0028S0xH0023=0xH0027S0xH0025=0xH0022");
+  assert_activate_achievement(&runtime, 17,
+      "C:0xH0000!=0_C:0xH0001!=0_C:0xH0002!=0_C:0xH0003!=0_C:0xH0004!=0_C:0xH0005!=0_C:0xH0006!=0_C:0xH0007!=0_"
+      "C:0xH0008!=0_C:0xH0009!=0_C:0xH000A!=0_C:0xH000B!=0_C:0xH000C!=0_C:0xH000D!=0_C:0xH000E!=0_0xH000F!=0.20.");
+  assert_activate_achievement(&runtime, 18, "A:0xL0087*10000_A:0xU0086*1000_A:0xL0086*100_A:0xU0085*10_0xL0x0085=0x 0080");
+
+  /* we expect these to only be true initially, so forcibly change them from WAITING to ACTIVE */
+  rc_runtime_get_achievement(&runtime, 5)->state = RC_TRIGGER_STATE_ACTIVE;
+  rc_runtime_get_achievement(&runtime, 6)->state = RC_TRIGGER_STATE_ACTIVE;
+  rc_runtime_get_achievement(&runtime, 15)->state = RC_TRIGGER_STATE_ACTIVE;
+  rc_runtime_get_achievement(&runtime, 18)->state = RC_TRIGGER_STATE_ACTIVE;
+
+  for (i = 0; i < 65536; i++)
+  {
+    /*
+     * $00-$1F = individual bits of i
+     * $20-$3F = number of times individual bits changed
+     * $40-$5F = number of times individual bits were 0
+     * $60-$7F = number of times individual bits were 1
+     * $80-$83 = i
+     * $84     = bitcount i
+     * $85-$87 = bcd i (LE)
+     * $88-$8C = ASCII i
+     * $C0-$FF = 0-63
+     */
+    mask = 1;
+    bitcount = 0;
+    for (j = 0; j < 32; j++)
+    {
+      next = ((i & mask) != 0) * 1;
+      mask <<= 1;
+      last = ram[j];
+
+      ram[j] = next;
+      ram[j + 0x60] += next;
+      bitcount += next;
+      ram[j + 0x40] += (1 - next);
+      ram[j + 0x20] += (next != last) * 1;
+    }
+    ram[0x80] = i & 0xFF;
+    ram[0x81] = (i >> 8) & 0xFF;
+    ram[0x82] = (i >> 16) & 0xFF;
+    ram[0x83] = (i >> 24) & 0xFF;
+    ram[0x84] = bitcount;
+    ram[0x85] = (i % 10) | ((i / 10) % 10) << 4;
+    ram[0x86] = ((i / 100) % 10) | ((i / 1000) % 10) << 4;
+    ram[0x87] = ((i / 10000) % 10);
+    ram[0x88] = ((i / 10000) % 10) + '0';
+    ram[0x89] = ((i / 1000) % 10) + '0';
+    ram[0x8A] = ((i / 100) % 10) + '0';
+    ram[0x8B] = ((i / 10) % 10) + '0';
+    ram[0x8C] = (i % 10) + '0';
+
+    start = clock();
+    rc_runtime_do_frame(&runtime, event_handler, peek, &memory, NULL);
+    end = clock();
+
+    total_clocks += (end - start);
+  }
+
+  elapsed = (double)total_clocks * 1000 / CLOCKS_PER_SEC;
+  average = elapsed * 1000 / i;
+  printf("\n%0.6fms elapsed, %0.6fus average", elapsed, average);
+
+  ASSERT_NUM_EQUALS(trigger_count[ 0],     0); /* no achievement 0 */
+  ASSERT_NUM_EQUALS(trigger_count[ 1], 32768); /* 0xH0000 = 1 every other frame */
+  ASSERT_NUM_EQUALS(trigger_count[ 2], 32768); /* 0xH0001 = 1 2 / 4 frames */
+  ASSERT_NUM_EQUALS(trigger_count[ 3], 32766); /* 0xH0001 = 0 2 / 4 frames (won't trigger until after first time it's 1) */
+  ASSERT_NUM_EQUALS(trigger_count[ 4], 16383); /* 0xH0002!=d0xH0002 every two frames (no delta for first frame) */
+  ASSERT_NUM_EQUALS(trigger_count[ 5], 65536); /* sum of bits = bitcount (16-bit) */
+  ASSERT_NUM_EQUALS(trigger_count[ 6], 65536); /* sum of bits = bitcount (8-bit) */
+  ASSERT_NUM_EQUALS(trigger_count[ 7],  6912); /* I:0xH0024_0xL00C0>8 pointer advances every eight frames */
+  ASSERT_NUM_EQUALS(trigger_count[ 8], 65280); /* number of times any bit is set in lower byte */
+  ASSERT_NUM_EQUALS(trigger_count[ 9],   256); /* number of times all bits are set in lower byte */
+  ASSERT_NUM_EQUALS(trigger_count[10],  7400); /* hundreds digit less than thousands, but greater than tens */
+  ASSERT_NUM_EQUALS(trigger_count[11],   256); /* number of times individual bits were 0 or 1 is equal */
+  ASSERT_NUM_EQUALS(trigger_count[12],  2048); /* number of times bit3 was set without bit 4 or 5 */
+  ASSERT_NUM_EQUALS(trigger_count[13],  3071); /* number of times bit3 was set without bit 4 xor 5 */
+  ASSERT_NUM_EQUALS(trigger_count[14], 10350); /* I:0xH0024_0xH0040>d0xH0040 - delta increase across moving target */
+  ASSERT_NUM_EQUALS(trigger_count[15],  1100); /* BCD check (only valid for two digits) */
+  ASSERT_NUM_EQUALS(trigger_count[16],    24); /* random collection of bit changes being equal */
+  ASSERT_NUM_EQUALS(trigger_count[17], 22187); /* number of times 20 bits or more are set across frames */
+  ASSERT_NUM_EQUALS(trigger_count[18], 65536); /* BCD reconstruction */
+
+  rc_runtime_destroy(&runtime);
+}
+
+void test_timing(void) {
+  TEST_SUITE_BEGIN();
+  TEST(do_timing);
+  TEST(do_timing);
+  TEST(do_timing);
+  TEST(do_timing);
+  TEST(do_timing);
+  TEST_SUITE_END();
+}

--- a/test/test.c
+++ b/test/test.c
@@ -11,6 +11,8 @@
 #include "rcheevos/mock_memory.h"
 #endif
 
+#define TIMING_TEST 0
+
 static void test_lua(void) {
   {
     /*------------------------------------------------------------------------
@@ -44,6 +46,8 @@ static void test_lua(void) {
   }
 }
 
+extern void test_timing();
+
 extern void test_condition();
 extern void test_memref();
 extern void test_operand();
@@ -76,6 +80,9 @@ TEST_FRAMEWORK_DECLARATIONS()
 int main(void) {
   TEST_FRAMEWORK_INIT();
 
+#if TIMING_TEST
+  test_timing();
+#else
   test_memref();
   test_operand();
   test_condition();
@@ -104,6 +111,7 @@ int main(void) {
   test_rapi_runtime();
   test_rapi_info();
   test_rapi_editor();
+#endif
 
   TEST_FRAMEWORK_SHUTDOWN();
 


### PR DESCRIPTION
Provides optimized logic processing for some of the most common logic:
* comparing a memory address to a constant
* comparing a memory address to its delta
* comparing a memory address to another memory address of the same size

Does not optimize indirect memory addresses (pointers), floats, or priors

When processing an arbitrary set of logic for 65536 frames, showed a ~33% decrease in time spent processing the achievements.

before (average 5.34us):
```
321.000000ms elapsed, 4.898071us average.
349.000000ms elapsed, 5.325317us average.
302.000000ms elapsed, 4.608154us average.
430.000000ms elapsed, 6.561279us average.
```
after (average 3.49us)
```
241.000000ms elapsed, 3.677368us average.
232.000000ms elapsed, 3.540039us average.
247.000000ms elapsed, 3.768921us average.
196.000000ms elapsed, 2.990723us average.
```
