### PR TITLE
fix handling of double slash in psx BOOT path

### DIFF
--- a/src/rhash/hash.c
+++ b/src/rhash/hash.c
@@ -230,6 +230,10 @@ static uint32_t rc_cd_find_file_sector(void* track_handle, const char* path, uns
   if (!track_handle)
     return 0;
 
+  /* we start at the root. don't need to explicitly find it */
+  if (*path == '\\')
+    ++path;
+
   filename_length = strlen(path);
   slash = strrchr(path, '\\');
   if (slash)
@@ -1472,7 +1476,7 @@ static int rc_hash_find_playstation_executable(void* track_handle, const char* b
 
         if (strncmp(ptr, cdrom_prefix, cdrom_prefix_len) == 0)
           ptr += cdrom_prefix_len;
-        if (*ptr == '\\')
+        while (*ptr == '\\')
           ++ptr;
 
         start = ptr;

--- a/test/rhash/data.c
+++ b/test/rhash/data.c
@@ -534,6 +534,10 @@ uint8_t* generate_iso9660_file(uint8_t* image, const char* filename, const uint8
       (image[root_directory_record_offset - 3] << 8) | (image[root_directory_record_offset - 2] << 16);
   const char* separator;
 
+  /* we start at the root. ignore explicit root path */
+  if (*filename == '\\')
+    ++filename;
+
   /* handle subdirectories */
   do
   {


### PR DESCRIPTION
https://retroachievements.org/viewtopic.php?t=5578&c=139793#139793

The SYSTEM.CNF for the affected game includes a double slash in the path:
```
BOOT=cdrom:\\SLUS_011.15;1
```

Whereas most games only use a single slash:
```
BOOT=cdrom:\SLUS_011.15;1
```

The hashing code is only stripping one slash, so the second slash is considered part of the filename, and therefore included in the hash. Additionally, as it's part of the filename, it causes the file system traversal logic to attempt to explicitly locate the entry for the root folder. Because of changes made to support file names without the ";1" suffix, the attempt to locate the root folder fails because it it is identified as "\0", not "".

I've made a couple changes here:
1) If the filename starts with a backslash, ignore it, as the file system traversal logic always starts in the root directory.
2) When extracting the filename from the SYSTEM.CNF, ignore all backslashes. This will cause the hash to change in RetroArch/RAlibretro.