### PR TITLE
allow trigger to transition to active if logically true and a reset is true in an alt

### DIFF
--- a/src/rcheevos/trigger.c
+++ b/src/rcheevos/trigger.c
@@ -197,14 +197,6 @@ int rc_evaluate_trigger(rc_trigger_t* self, rc_peek_t peek, void* ud, lua_State*
     self->measured_value = eval_state.measured_value.value.u32;
   }
 
-  /* if the state is WAITING and the trigger is ready to fire, ignore it and reset the hit counts */
-  /* otherwise, if the state is WAITING, proceed to activating the trigger */
-  if (self->state == RC_TRIGGER_STATE_WAITING && ret) {
-    rc_reset_trigger(self);
-    self->has_hits = 0;
-    return RC_TRIGGER_STATE_WAITING;
-  }
-
   /* if any ResetIf condition was true, reset the hit counts */
   if (eval_state.was_reset) {
     /* if the measured value came from a hit count, reset it. do this before calling
@@ -247,6 +239,13 @@ int rc_evaluate_trigger(rc_trigger_t* self, rc_peek_t peek, void* ud, lua_State*
     is_primed = 0;
   }
   else if (ret) {
+    /* if the state is WAITING and the trigger is ready to fire, ignore it and reset the hit counts */
+    if (self->state == RC_TRIGGER_STATE_WAITING) {
+      rc_reset_trigger(self);
+      self->has_hits = 0;
+      return RC_TRIGGER_STATE_WAITING;
+    }
+
     /* trigger was triggered */
     self->state = RC_TRIGGER_STATE_TRIGGERED;
     return RC_TRIGGER_STATE_TRIGGERED;

--- a/test/rcheevos/test_condset.c
+++ b/test/rcheevos/test_condset.c
@@ -1897,6 +1897,43 @@ static void test_addsource_divide_address() {
   assert_hit_count(condset, 1, 2);
 }
 
+static void test_addsource_divide_self() {
+  unsigned char ram[] = {0x00, 0x06, 0x10, 0xAB, 0x56};
+  memory_t memory;
+  rc_condset_t* condset;
+  rc_condset_memrefs_t memrefs;
+  char buffer[2048];
+
+  memory.ram = ram;
+  memory.size = sizeof(ram);
+
+  /* byte(1) / byte(1) + byte(2) == 22 */
+  assert_parse_condset(&condset, &memrefs, buffer, "A:0xH0001/0xH00001_0xH0002=22");
+
+  /* sum is not correct (1 + 16 != 22) */
+  assert_evaluate_condset(condset, memrefs, &memory, 0);
+  assert_hit_count(condset, 0, 0);
+  assert_hit_count(condset, 1, 0);
+
+  /* sum is correct (1 + 21 == 22) */
+  ram[2] = 21;
+  assert_evaluate_condset(condset, memrefs, &memory, 1);
+  assert_hit_count(condset, 0, 0);
+  assert_hit_count(condset, 1, 1);
+
+  /* sum is not correct (0 + 21 == 22) */
+  ram[1] = 0;
+  assert_evaluate_condset(condset, memrefs, &memory, 0);
+  assert_hit_count(condset, 0, 0);
+  assert_hit_count(condset, 1, 1);
+
+  /* sum is correct (0 + 22 == 22) */
+  ram[2] = 22;
+  assert_evaluate_condset(condset, memrefs, &memory, 1);
+  assert_hit_count(condset, 0, 0);
+  assert_hit_count(condset, 1, 2);
+}
+
 static void test_addsource_mask() {
   unsigned char ram[] = {0x00, 0x06, 0x34, 0xAB, 0x56};
   memory_t memory;
@@ -3793,6 +3830,7 @@ void test_condset(void) {
   TEST(test_addsource_multiply_address);
   TEST(test_addsource_divide);
   TEST(test_addsource_divide_address);
+  TEST(test_addsource_divide_self);
   TEST(test_subsource_divide);
   TEST(test_addsource_compare_percentage);
   TEST(test_addsource_mask);

--- a/test/rcheevos/test_runtime.c
+++ b/test/rcheevos/test_runtime.c
@@ -385,6 +385,64 @@ static void test_achievement_measured_maxint(void)
   rc_runtime_destroy(&runtime);
 }
 
+static void test_two_achievements_differing_resets_in_alts(void)
+{
+  unsigned char ram[] = { 0, 10, 10 };
+  memory_t memory;
+  rc_runtime_t runtime;
+
+  memory.ram = ram;
+  memory.size = sizeof(ram);
+
+  rc_runtime_init(&runtime);
+
+  assert_activate_achievement(&runtime, 1, "0xH0001=10S1=1SR:0xH0000!=0");
+  assert_activate_achievement(&runtime, 2, "0xH0001=10S1=1SR:0xH0000!=1");
+
+  /* first achievement true (stays waiting), second not true because of reset */
+  assert_do_frame(&runtime, &memory);
+  ASSERT_NUM_EQUALS(runtime.triggers[0].trigger->state, RC_TRIGGER_STATE_WAITING);
+  ASSERT_NUM_EQUALS(runtime.triggers[1].trigger->state, RC_TRIGGER_STATE_ACTIVE);
+  ASSERT_NUM_EQUALS(event_count, 1);
+  assert_event(RC_RUNTIME_EVENT_ACHIEVEMENT_ACTIVATED, 2, 0);
+
+  /* both achievements are false, should activate */
+  ram[1] = 9;
+  assert_do_frame(&runtime, &memory);
+  ASSERT_NUM_EQUALS(runtime.triggers[0].trigger->state, RC_TRIGGER_STATE_ACTIVE);
+  ASSERT_NUM_EQUALS(runtime.triggers[1].trigger->state, RC_TRIGGER_STATE_ACTIVE);
+  ASSERT_NUM_EQUALS(event_count, 1);
+  assert_event(RC_RUNTIME_EVENT_ACHIEVEMENT_ACTIVATED, 1, 0);
+
+  /* first should fire, second prevented by reset */
+  ram[1] = 10;
+  assert_do_frame(&runtime, &memory);
+  ASSERT_NUM_EQUALS(runtime.triggers[0].trigger->state, RC_TRIGGER_STATE_TRIGGERED);
+  ASSERT_NUM_EQUALS(runtime.triggers[1].trigger->state, RC_TRIGGER_STATE_ACTIVE);
+  ASSERT_NUM_EQUALS(event_count, 1);
+  assert_event(RC_RUNTIME_EVENT_ACHIEVEMENT_TRIGGERED, 1, 0);
+
+  /* second can fire, reset first which will be activated due to reset */
+  ram[0] = 1;
+  rc_reset_trigger(runtime.triggers[0].trigger);
+  assert_do_frame(&runtime, &memory);
+  ASSERT_NUM_EQUALS(runtime.triggers[0].trigger->state, RC_TRIGGER_STATE_ACTIVE);
+  ASSERT_NUM_EQUALS(runtime.triggers[1].trigger->state, RC_TRIGGER_STATE_TRIGGERED);
+  ASSERT_NUM_EQUALS(event_count, 2);
+  assert_event(RC_RUNTIME_EVENT_ACHIEVEMENT_ACTIVATED, 1, 0);
+  assert_event(RC_RUNTIME_EVENT_ACHIEVEMENT_TRIGGERED, 2, 0);
+
+  /* both achievements are false again. second should active, first should be ignored */
+  ram[0] = 0;
+  assert_do_frame(&runtime, &memory);
+  ASSERT_NUM_EQUALS(runtime.triggers[0].trigger->state, RC_TRIGGER_STATE_TRIGGERED);
+  ASSERT_NUM_EQUALS(runtime.triggers[1].trigger->state, RC_TRIGGER_STATE_TRIGGERED);
+  ASSERT_NUM_EQUALS(event_count, 1);
+  assert_event(RC_RUNTIME_EVENT_ACHIEVEMENT_TRIGGERED, 1, 0);
+
+  rc_runtime_destroy(&runtime);
+}
+
 static void test_shared_memref(void)
 {
   unsigned char ram[] = { 0, 10, 10 };
@@ -1428,6 +1486,7 @@ void test_runtime(void) {
   TEST(test_deactivate_achievements);
   TEST(test_achievement_measured);
   TEST(test_achievement_measured_maxint);
+  TEST(test_two_achievements_differing_resets_in_alts);
 
   TEST(test_shared_memref);
   TEST(test_replace_active_trigger);


### PR DESCRIPTION
Normally, a trigger that is ready to fire will will remain in the WAITING state until it's no longer true. And as soon as it's no longer true, it will transition to ACTIVE. However, if the achievement is only not true because of a segregated ResetIf, then it would remain WAITING until one of the non-segregated conditions because false.

This was something I found while trying to test something else. A WAITING achievement cannot fire, and an ACTIVE achievement with a true ResetIf also cannot fire. The only way this could be a problem for players is if the ResetIf were the only thing preventing the achievement from triggering when the game started and the achievement was expected to trigger as soon as it became false. Additionally, the ResetIf would have to be segregated into an alt group, and the main reason for doing that is to be able to PauseIf the ResetIf without PauseIf'ing the Core group, which implies there's a hit target or something similar in the Core group that should not be paused, and will therefore be false at some point.