### PR TITLE
allow float values in SubSource calculations

### DIFF
--- a/src/rcheevos/condset.c
+++ b/src/rcheevos/condset.c
@@ -210,8 +210,7 @@ static int rc_test_condset_internal(rc_condset_t* self, int processing_pause, rc
 
       case RC_CONDITION_SUB_SOURCE:
         rc_evaluate_condition_value(&value, condition, eval_state);
-        rc_typed_value_convert(&value, RC_VALUE_TYPE_SIGNED);
-        value.value.i32 = -value.value.i32;
+        rc_typed_value_negate(&value);
         rc_typed_value_add(&eval_state->add_value, &value);
         eval_state->add_address = 0;
         continue;

--- a/src/rcheevos/rc_internal.h
+++ b/src/rcheevos/rc_internal.h
@@ -184,6 +184,7 @@ void rc_typed_value_convert(rc_typed_value_t* value, char new_type);
 void rc_typed_value_add(rc_typed_value_t* value, const rc_typed_value_t* amount);
 void rc_typed_value_multiply(rc_typed_value_t* value, const rc_typed_value_t* amount);
 void rc_typed_value_divide(rc_typed_value_t* value, const rc_typed_value_t* amount);
+void rc_typed_value_negate(rc_typed_value_t* value);
 int rc_typed_value_compare(const rc_typed_value_t* value1, const rc_typed_value_t* value2, char oper);
 void rc_typed_value_from_memref_value(rc_typed_value_t* value, const rc_memref_value_t* memref);
 

--- a/src/rcheevos/value.c
+++ b/src/rcheevos/value.c
@@ -428,6 +428,26 @@ static rc_typed_value_t* rc_typed_value_convert_into(rc_typed_value_t* dest, con
   return dest;
 }
 
+void rc_typed_value_negate(rc_typed_value_t* value) {
+  switch (value->type)
+  {
+    case RC_VALUE_TYPE_UNSIGNED:
+      rc_typed_value_convert(value, RC_VALUE_TYPE_SIGNED);
+      /* fallthrough to RC_VALUE_TYPE_SIGNED */
+
+    case RC_VALUE_TYPE_SIGNED:
+      value->value.i32 = -(value->value.i32);
+      break;
+
+    case RC_VALUE_TYPE_FLOAT:
+      value->value.f32 = -(value->value.f32);
+      break;
+
+    default:
+      break;
+  }
+}
+
 void rc_typed_value_add(rc_typed_value_t* value, const rc_typed_value_t* amount) {
   rc_typed_value_t converted;
 

--- a/test/rcheevos/test_condset.c
+++ b/test/rcheevos/test_condset.c
@@ -2337,6 +2337,27 @@ static void test_subsource_overflow_comparison_lesser_or_equal() {
   assert_evaluate_condset(condset, memrefs, &memory, 0);
 }
 
+static void test_subsource_float() {
+  unsigned char ram[] = {0x06, 0x00, 0x00, 0x00, 0x92, 0x44, 0x9A, 0x42}; /* fF0004 = 77.133926 */
+  memory_t memory;
+  rc_condset_t* condset;
+  rc_condset_memrefs_t memrefs;
+  char buffer[2048];
+
+  memory.ram = ram;
+  memory.size = sizeof(ram);
+
+  /* float(0x0004) - word(0) * 1.666667 > 65.8 */
+  assert_parse_condset(&condset, &memrefs, buffer, "B:0x 0000*f1.666667_fF0004>f65.8");
+
+  /* 77.133926 - (6 * 1.666667) = 77.133926 - 10 = 67.133926 */
+  assert_evaluate_condset(condset, memrefs, &memory, 1);
+
+  /* 77.133926 - (7 * 1.666667) = 77.133926 - 11.6667 = 65.4672 */
+  ram[0] = 7;
+  assert_evaluate_condset(condset, memrefs, &memory, 0);
+}
+
 static void test_addhits() {
   unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
@@ -3843,6 +3864,7 @@ void test_condset(void) {
   TEST(test_subsource_overflow_comparison_greater_or_equal);
   TEST(test_subsource_overflow_comparison_lesser);
   TEST(test_subsource_overflow_comparison_lesser_or_equal);
+  TEST(test_subsource_float);
 
   /* addhits/subhits */
   TEST(test_addhits);

--- a/test/rcheevos/test_value.c
+++ b/test/rcheevos/test_value.c
@@ -193,7 +193,7 @@ static void _assert_typed_value(const rc_typed_value_t* value, char type, unsign
       break;
 
     case RC_VALUE_TYPE_FLOAT:
-      ASSERT_NUM_EQUALS(value->value.f32, (float)f32);
+      ASSERT_FLOAT_EQUALS(value->value.f32, (float)f32);
       break;
 
     default:
@@ -445,6 +445,38 @@ static void test_typed_value_division() {
   TEST_PARAMS9(test_typed_value_divide, RC_VALUE_TYPE_FLOAT, 0, 3.14159, RC_VALUE_TYPE_FLOAT, 0, -8.0, RC_VALUE_TYPE_FLOAT, 0, -0.39269875);
 }
 
+static void test_typed_value_negate(char type, int i32, double f32, char expected_type, signed result_i32, double result_f32) {
+  rc_typed_value_t value;
+
+  init_typed_value(&value, type, (unsigned)i32, f32);
+
+  rc_typed_value_negate(&value);
+
+  assert_typed_value(&value, expected_type, (unsigned)result_i32, result_f32);
+}
+
+static void test_typed_value_negation() {
+  /* unsigned source */
+  TEST_PARAMS6(test_typed_value_negate, RC_VALUE_TYPE_UNSIGNED, 0, 0.0, RC_VALUE_TYPE_SIGNED, 0, 0.0);
+  TEST_PARAMS6(test_typed_value_negate, RC_VALUE_TYPE_UNSIGNED, 99, 0.0, RC_VALUE_TYPE_SIGNED, -99, 0.0);
+  TEST_PARAMS6(test_typed_value_negate, RC_VALUE_TYPE_UNSIGNED, 0xFFFFFFFF, 0.0, RC_VALUE_TYPE_SIGNED, 1, 0.0);
+
+  /* signed source */
+  TEST_PARAMS6(test_typed_value_negate, RC_VALUE_TYPE_SIGNED, 0, 0.0, RC_VALUE_TYPE_SIGNED, 0, 0.0);
+  TEST_PARAMS6(test_typed_value_negate, RC_VALUE_TYPE_SIGNED, 99, 0.0, RC_VALUE_TYPE_SIGNED, -99, 0.0);
+  TEST_PARAMS6(test_typed_value_negate, RC_VALUE_TYPE_SIGNED, -1, 0.0, RC_VALUE_TYPE_SIGNED, 1, 0.0);
+
+  /* float source (whole numbers) */
+  TEST_PARAMS6(test_typed_value_negate, RC_VALUE_TYPE_FLOAT, 0, 0.0, RC_VALUE_TYPE_FLOAT, 0, 0.0);
+  TEST_PARAMS6(test_typed_value_negate, RC_VALUE_TYPE_FLOAT, 0, 99.0, RC_VALUE_TYPE_FLOAT, 0, -99.0);
+  TEST_PARAMS6(test_typed_value_negate, RC_VALUE_TYPE_FLOAT, 0, -1.0, RC_VALUE_TYPE_FLOAT, 0, 1.0);
+
+  /* float source (non-whole numbers) */
+  TEST_PARAMS6(test_typed_value_negate, RC_VALUE_TYPE_FLOAT, 0, 0.1, RC_VALUE_TYPE_FLOAT, 0, -0.1);
+  TEST_PARAMS6(test_typed_value_negate, RC_VALUE_TYPE_FLOAT, 0, 3.14159, RC_VALUE_TYPE_FLOAT, 0, -3.14159);
+  TEST_PARAMS6(test_typed_value_negate, RC_VALUE_TYPE_FLOAT, 0, -2.7, RC_VALUE_TYPE_FLOAT, 0, 2.7);
+}
+
 void test_value(void) {
   TEST_SUITE_BEGIN();
 
@@ -560,6 +592,7 @@ void test_value(void) {
   test_typed_value_addition();
   test_typed_value_multiplication();
   test_typed_value_division();
+  test_typed_value_negation();
 
   TEST_SUITE_END();
 }

--- a/test/test_framework.h
+++ b/test/test_framework.h
@@ -165,7 +165,15 @@ extern const char* test_framework_basename(const char* path);
 #define ASSERT_NUM_LESS(value, expected)           ASSERT_COMPARE(value, <,  expected, int, "%d")
 #define ASSERT_NUM_LESS_EQUALS(value, expected)    ASSERT_COMPARE(value, <=, expected, int, "%d")
 
-#define ASSERT_FLOAT_EQUALS(value, expected)       ASSERT_COMPARE(value, ==, expected, float, "%f")
+#define ASSERT_FLOAT_EQUALS(value, expected) { \
+  float __v = (float)value; \
+  float __e = (float)expected; \
+  double diff = (__v > __e) ? ((double)__v - (double)__e) : ((double)__e - (double)__v); \
+  if (diff >= 0.0000002) { /* FLT_EPSILON is ~1.19e-7 */ \
+    ASSERT_FAIL("Expected: " #value " = " #expected " (%s:%d)\n  Found:    %f = %f", \
+                test_framework_basename(__FILE__), __LINE__, __v, __e); \
+  } \
+}
 
 /* TODO: figure out some way to detect c89 so we can use int64_t and %lld on non-c89 builds */
 #define ASSERT_NUM64_EQUALS(value, expected)       ASSERT_COMPARE(value, ==, expected, int, "%d")


### PR DESCRIPTION
https://discord.com/channels/310192285306454017/962817919698501702/1071281247386615869

The SubSource flag was converting a float value calculated by a line into an integer to negate it before adding it to the accumulator. This caused a loss of the decimal part of the value being subtracted.