### PR TITLE
don't report redundancy when alt is more restrictive than core

### DIFF
--- a/src/rcheevos/rc_validate.c
+++ b/src/rcheevos/rc_validate.c
@@ -648,6 +648,13 @@ static int rc_validate_conflicting_conditions(const rc_condset_t* conditions, co
           break;
 
         case RC_OVERLAP_REDUNDANT:
+          if (prefix != compare_prefix && strcmp(compare_prefix, "Core") == 0)
+          {
+            /* if the alt condition is more restrictive than the core condition, ignore it */
+            if (rc_validate_comparison_overlap(comparison2, value2, comparison1, value1) != RC_OVERLAP_REDUNDANT)
+              continue;
+          }
+
           if (compare_condition->type == RC_CONDITION_PAUSE_IF || condition->type == RC_CONDITION_PAUSE_IF)
           {
             /* ignore PauseIf redundancies between groups */

--- a/test/rcheevos/test_rc_validate.c
+++ b/test/rcheevos/test_rc_validate.c
@@ -275,6 +275,9 @@ void test_redundant_conditions() {
   TEST_PARAMS2(test_validate_trigger, "T:0xH0000!=0_T:0xH0000=6", "Condition 1: Redundant with Condition 2");
   TEST_PARAMS2(test_validate_trigger, "0xH0000!=0_T:0xH0000=6", ""); /* trigger not redundant with non-trigger */
   TEST_PARAMS2(test_validate_trigger, "0xH0000=1_Q:0xH0000=1", "Condition 1: Redundant with Condition 2");
+  TEST_PARAMS2(test_validate_trigger, "0xH0000=1S0xH0000!=0S0xH0001=2", "Alt1 Condition 1: Redundant with Core Condition 1");
+  TEST_PARAMS2(test_validate_trigger, "0xH0000!=0S0xH0000=1S0xH0001=2", ""); /* more restrictive alt 1 is not redundant with core */
+  TEST_PARAMS2(test_validate_trigger, "0xH0000!=0S0xH0000!=0S0xH0001=2", "Alt1 Condition 1: Redundant with Core Condition 1");
 }
 
 void test_rc_validate(void) {


### PR DESCRIPTION
Prevents redundancy warning when core says "0x1234 != 0" and alt says "0x1234 = 4". While "0x1234=4" would cover both cases, the core clause may still be necessary for other alts.