### PR TITLE
Initialized byteswapped

### DIFF
--- a/src/rhash/hash.c
+++ b/src/rhash/hash.c
@@ -750,7 +750,7 @@ static int rc_hash_jaguar_cd(char hash[33], const char* path)
   char message[128];
   void* track_handle;
   md5_state_t md5;
-  int byteswapped;
+  int byteswapped = 0;
   unsigned size = 0;
   unsigned offset = 0;
   unsigned sector = 0;


### PR DESCRIPTION
While practically impossible, thanks to the return on line 795, in theory there is a code path that results in the byteswapped variable on line 810 of hash.c to be uninitialized when it is checked. The Dolphin cmake ninja compile path in particular throws a pedantic warning over it. This commit initializes it upon creation to a dummy value that will never get used but should be sufficient to satisfy any compilers.