### PR TITLE
Jaguar CD hash addendum

### DIFF
--- a/test/rhash/test_hash.c
+++ b/test/rhash/test_hash.c
@@ -727,6 +727,7 @@ static void test_hash_atari_jaguar_cd_homebrew()
   /* cleanup */
   _rc_hash_jaguar_cd_homebrew_hash = NULL;
   free(image);
+  free(image2);
   init_mock_cdreader();
 
   /* validation */


### PR DESCRIPTION
Eliminates collisions for homebrew titles, which all seem to use the same bootloader.