### PR TITLE
add rc_libretro_memory_find_avail

### DIFF
--- a/src/rcheevos/rc_libretro.c
+++ b/src/rcheevos/rc_libretro.c
@@ -288,7 +288,7 @@ int rc_libretro_is_system_allowed(const char* library_name, int console_id) {
   return 1;
 }
 
-unsigned char* rc_libretro_memory_find(const rc_libretro_memory_regions_t* regions, unsigned address) {
+unsigned char* rc_libretro_memory_find_avail(const rc_libretro_memory_regions_t* regions, unsigned address, unsigned* avail) {
   unsigned i;
 
   for (i = 0; i < regions->count; ++i) {
@@ -297,13 +297,23 @@ unsigned char* rc_libretro_memory_find(const rc_libretro_memory_regions_t* regio
       if (regions->data[i] == NULL)
         break;
 
+      if (avail)
+        *avail = (unsigned)(size - address);
+
       return &regions->data[i][address];
     }
 
     address -= (unsigned)size;
   }
 
+  if (avail)
+    *avail = 0;
+
   return NULL;
+}
+
+unsigned char* rc_libretro_memory_find(const rc_libretro_memory_regions_t* regions, unsigned address) {
+  return rc_libretro_memory_find_avail(regions, address, NULL);
 }
 
 void rc_libretro_init_verbose_message_callback(rc_libretro_message_callback callback) {

--- a/src/rcheevos/rc_libretro.h
+++ b/src/rcheevos/rc_libretro.h
@@ -53,6 +53,7 @@ int rc_libretro_memory_init(rc_libretro_memory_regions_t* regions, const struct 
 void rc_libretro_memory_destroy(rc_libretro_memory_regions_t* regions);
 
 unsigned char* rc_libretro_memory_find(const rc_libretro_memory_regions_t* regions, unsigned address);
+unsigned char* rc_libretro_memory_find_avail(const rc_libretro_memory_regions_t* regions, unsigned address, unsigned* avail);
 
 /*****************************************************************************\
 | Disk Identification                                                         |

--- a/test/rcheevos/test_rc_libretro.c
+++ b/test/rcheevos/test_rc_libretro.c
@@ -48,6 +48,7 @@ static void test_disallowed_system(const char* library_name, int console_id) {
 
 static void test_memory_init_without_regions() {
   rc_libretro_memory_regions_t regions;
+  unsigned avail;
   unsigned char buffer1[16], buffer2[8];
   retro_memory_data[RETRO_MEMORY_SYSTEM_RAM] = buffer1;
   retro_memory_size[RETRO_MEMORY_SYSTEM_RAM] = sizeof(buffer1);
@@ -61,6 +62,15 @@ static void test_memory_init_without_regions() {
   ASSERT_PTR_EQUALS(rc_libretro_memory_find(&regions, 2), &buffer1[2]);
   ASSERT_PTR_EQUALS(rc_libretro_memory_find(&regions, sizeof(buffer1) + 2), &buffer2[2]);
   ASSERT_PTR_NULL(rc_libretro_memory_find(&regions, sizeof(buffer1) + sizeof(buffer2) + 2));
+
+  ASSERT_PTR_EQUALS(rc_libretro_memory_find_avail(&regions, 2, &avail), &buffer1[2]);
+  ASSERT_NUM_EQUALS(avail, sizeof(buffer1) - 2);
+  ASSERT_PTR_EQUALS(rc_libretro_memory_find_avail(&regions, sizeof(buffer1) - 1, &avail), &buffer1[sizeof(buffer1) - 1]);
+  ASSERT_NUM_EQUALS(avail, 1);
+  ASSERT_PTR_EQUALS(rc_libretro_memory_find_avail(&regions, sizeof(buffer1) + 2, &avail), &buffer2[2]);
+  ASSERT_NUM_EQUALS(avail, sizeof(buffer2) - 2);
+  ASSERT_PTR_NULL(rc_libretro_memory_find_avail(&regions, sizeof(buffer1) + sizeof(buffer2) + 2, &avail));
+  ASSERT_NUM_EQUALS(avail, 0);
 }
 
 static void test_memory_init_without_regions_system_ram_only() {
@@ -128,6 +138,7 @@ static void test_memory_init_from_unmapped_memory() {
 
 static void test_memory_init_from_unmapped_memory_null_filler() {
   rc_libretro_memory_regions_t regions;
+  unsigned avail;
   unsigned char buffer1[16], buffer2[8];
   retro_memory_data[RETRO_MEMORY_SYSTEM_RAM] = buffer1;
   retro_memory_size[RETRO_MEMORY_SYSTEM_RAM] = sizeof(buffer1);
@@ -143,6 +154,15 @@ static void test_memory_init_from_unmapped_memory_null_filler() {
   ASSERT_PTR_EQUALS(rc_libretro_memory_find(&regions, 0x10002), &buffer2[2]);
   ASSERT_PTR_NULL(rc_libretro_memory_find(&regions, 0x1000A));
   ASSERT_PTR_NULL(rc_libretro_memory_find(&regions, 0x20002));
+
+  ASSERT_PTR_EQUALS(rc_libretro_memory_find_avail(&regions, 0x00002, &avail), &buffer1[2]);
+  ASSERT_NUM_EQUALS(avail, sizeof(buffer1) - 2);
+  ASSERT_PTR_NULL(rc_libretro_memory_find_avail(&regions, 0x00012, &avail));
+  ASSERT_NUM_EQUALS(avail, 0);
+  ASSERT_PTR_EQUALS(rc_libretro_memory_find_avail(&regions, 0x10002, &avail), &buffer2[2]);
+  ASSERT_NUM_EQUALS(avail, sizeof(buffer2) - 2);
+  ASSERT_PTR_NULL(rc_libretro_memory_find_avail(&regions, 0x1000A, &avail));
+  ASSERT_NUM_EQUALS(avail, 0);
 }
 
 static void test_memory_init_from_unmapped_memory_no_save_ram() {


### PR DESCRIPTION
https://discord.com/channels/310192285306454017/310195854642249728/1089900374539894875

The calculation of a pointer is causing a 32-bit read to read past the end of a buffer exposed by the core. The PSP system has 0x200000 bytes of memory, so the last available address that can be read is 0x1fffff. During the opening cutscene, a pointer evaluates to 0x1ffffe, which is a valid address, but attempting to read four bytes at 0x1ffffe causes two bytes to be read outside the buffer. Depending on where the buffer is allocated, this can cause issues. In the reported case, the emulator crashes.

This PR introduces a new parameter to the `rc_libretro_memory_find` function (via a new function as c89 doesn't support overloaded function names), allowing RetroArch to ensure there's enough memory available before attempting to read it. Changes on the RetroArch side of things will have to wait until this is merged and available in the RetroArch codebase.