### PR TITLE
attempt to report nginx-rejected request errors

### DIFF
--- a/src/rapi/rc_api_common.c
+++ b/src/rapi/rc_api_common.c
@@ -255,6 +255,27 @@ int rc_json_parse_response(rc_api_response_t* response, const char* json, rc_jso
 
   if (*json) {
     const char* end = json;
+
+    if (strncmp(json, "<html>", 6) == 0) {
+      const char* title_start = strstr(json, "<title>");
+      if (title_start) {
+        title_start += 7;
+        if (isdigit((int)*title_start)) {
+          const char* title_end = strstr(title_start + 7, "</title>");
+          if (title_end) {
+            char *dst = rc_buf_reserve(&response->buffer, (title_end - title_start) + 1);
+            response->error_message = dst;
+            memcpy(dst, title_start, title_end - title_start);
+            dst += (title_end - title_start);
+            *dst++ = '\0';
+            rc_buf_consume(&response->buffer, response->error_message, dst);
+            response->succeeded = 0;
+            return RC_INVALID_JSON;
+          }
+        }
+      }
+    }
+
     while (*end && *end != '\n' && end - json < 200)
       ++end;
 

--- a/test/rapi/test_rc_api_runtime.c
+++ b/test/rapi/test_rc_api_runtime.c
@@ -662,6 +662,29 @@ static void test_process_award_achievement_response_no_fields() {
   rc_api_destroy_award_achievement_response(&award_achievement_response);
 }
 
+static void test_process_award_achievement_response_429() {
+  rc_api_award_achievement_response_t award_achievement_response;
+  const char* server_response =
+      "<html>\n"
+      "<head><title>429 Too Many Requests</title></head>\n"
+      "<body>\n"
+      "<center><h1>429 Too Many Requests</h1></center>\n"
+      "<hr><center>nginx</center>\n"
+      "</body>\n"
+      "</html>";
+
+  memset(&award_achievement_response, 0, sizeof(award_achievement_response));
+
+  ASSERT_NUM_EQUALS(rc_api_process_award_achievement_response(&award_achievement_response, server_response), RC_INVALID_JSON);
+  ASSERT_NUM_EQUALS(award_achievement_response.response.succeeded, 0);
+  ASSERT_STR_EQUALS(award_achievement_response.response.error_message, "429 Too Many Requests");
+  ASSERT_UNUM_EQUALS(award_achievement_response.new_player_score, 0);
+  ASSERT_UNUM_EQUALS(award_achievement_response.awarded_achievement_id, 0);
+  ASSERT_UNUM_EQUALS(award_achievement_response.achievements_remaining, 0);
+
+  rc_api_destroy_award_achievement_response(&award_achievement_response);
+}
+
 static void test_init_submit_lboard_entry_request() {
   rc_api_submit_lboard_entry_request_t submit_lboard_entry_request;
   rc_api_request_t request;
@@ -865,6 +888,7 @@ void test_rapi_runtime(void) {
   TEST(test_process_award_achievement_response_invalid_credentials);
   TEST(test_process_award_achievement_response_text);
   TEST(test_process_award_achievement_response_no_fields);
+  TEST(test_process_award_achievement_response_429);
 
   /* submitlbentry */
   TEST(test_init_submit_lboard_entry_request);


### PR DESCRIPTION
For non-200 HTTP status codes, the server may return something other than JSON. If the integrating client calls a response processing function without checking the HTTP status code, attempt to detect and capture the message from the HTML response.