### PR TITLE
Add rc_runtime_alloc

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,14 +183,23 @@ typedef struct rc_runtime_t {
 
   rc_value_t* variables;
   rc_value_t** next_variable;
+
+  char owns_self;
 }
 rc_runtime_t;
 ```
 
-The runtime must first be initialized.
+You can have rcheevos allocate a runtime for you. In this case, the returned runtime will be initialized and can be used immediately. Note that the allocation can fail, in which case NULL is returned.
+```c
+rc_runtime_t* rc_runtime_alloc(void);
+```
+
+You can also allocate the runtime yourself. In this case, the runtime must first be initialized.
 ```c
 void rc_runtime_init(rc_runtime_t* runtime);
 ```
+
+You cannot use `rc_runtime_init` if `rc_runtime_alloc` was used to create the runtime.
 
 Then individual achievements, leaderboards, and even rich presence can be loaded into the runtime. These functions return RC_OK, or one of the negative value error codes listed above.
 ```c
@@ -266,6 +275,13 @@ void rc_runtime_reset(rc_runtime_t* runtime);
 ```
 
 This ensures any active achievements/leaderboards are set back to their initial states and prevents unexpected triggers when the memory changes in atypical way.
+
+When you are finished using the runtime, you must destroy it to avoid memory leaks.
+```c
+void rc_runtime_destroy(rc_runtime_t* runtime);
+```
+
+If rcheevos allocated the runtime itself (via `rc_runtime_alloc`), then this call will also free the runtime itself.
 
 ## Server Communication
 

--- a/include/rc_runtime.h
+++ b/include/rc_runtime.h
@@ -88,9 +88,12 @@ typedef struct rc_runtime_t {
 
   rc_value_t* variables;
   rc_value_t** next_variable;
+
+  char owns_self;
 }
 rc_runtime_t;
 
+rc_runtime_t* rc_runtime_alloc(void);
 void rc_runtime_init(rc_runtime_t* runtime);
 void rc_runtime_destroy(rc_runtime_t* runtime);
 

--- a/src/rcheevos/runtime.c
+++ b/src/rcheevos/runtime.c
@@ -9,6 +9,17 @@
 
 #define RC_RICHPRESENCE_DISPLAY_BUFFER_SIZE 256
 
+rc_runtime_t* rc_runtime_alloc(void) {
+  rc_runtime_t* self = malloc(sizeof(rc_runtime_t));
+
+  if (self) {
+    rc_runtime_init(self);
+    self->owns_self = 1;
+  }
+
+  return self;
+}
+
 void rc_runtime_init(rc_runtime_t* self) {
   memset(self, 0, sizeof(rc_runtime_t));
   self->next_memref = &self->memrefs;
@@ -48,6 +59,10 @@ void rc_runtime_destroy(rc_runtime_t* self) {
 
   self->next_memref = 0;
   self->memrefs = 0;
+
+  if (self->owns_self) {
+    free(self);
+  }
 }
 
 static void rc_runtime_checksum(const char* memaddr, unsigned char* md5) {


### PR DESCRIPTION
This function will allocate a rc_runtime_t instance, initialize it, and return it. If the allocation fails, it will return NULL. rc_runtime_t has also been modified to add a boolean value to tell if the instance owns itself (i.e. was allocated in rc_runtime_alloc), and therefore should deallocate the instance in rc_runtime_destroy. Accordingly, this boolean is set to true in rc_runtime_alloc. Implicitly, it is set to false in rc_runtime_init, so users should not use rc_runtime_init when using the rc_runtime_alloc API, else memory will leak. This ensures that all current users will need to do no changes to their code, unless they explicitly want to use the new rc_runtime_alloc API.

The reasoning for adding this API is due to BizHawk's usage of this library. BizHawk is written in C#, which means its heap memory is managed and the garbage collector may move memory around. This presents issues with rc_runtime as it will store pointers to itself. Such pointers may become invalid due to the struct, being placed on the managed heap, being moved around. This presents a clean and performant solution to this issue while also likely helping for future similar cases.