### PR TITLE
add content_type to rc_api_request_t

### DIFF
--- a/include/rc_api_request.h
+++ b/include/rc_api_request.h
@@ -43,6 +43,8 @@ typedef struct rc_api_request_t {
   const char* url;
   /* Additional query args that should be sent via a POST command. If null, GET may be used */
   const char* post_data;
+  /* The HTTP Content-Type of the POST data. */
+  const char* content_type;
 
   /* Storage for the url and post_data */
   rc_api_buffer_t buffer;

--- a/src/rapi/rc_api_common.h
+++ b/src/rapi/rc_api_common.h
@@ -10,6 +10,8 @@
 extern "C" {
 #endif
 
+#define RC_CONTENT_TYPE_URLENCODED "application/x-www-form-urlencoded"
+
 typedef struct rc_api_url_builder_t {
   char* write;
   char* start;

--- a/src/rapi/rc_api_editor.c
+++ b/src/rapi/rc_api_editor.c
@@ -22,6 +22,7 @@ int rc_api_init_fetch_code_notes_request(rc_api_request_t* request, const rc_api
   rc_url_builder_append_unum_param(&builder, "g", api_params->game_id);
 
   request->post_data = rc_url_builder_finalize(&builder);
+  request->content_type = RC_CONTENT_TYPE_URLENCODED;
 
   return builder.result;
 }
@@ -123,6 +124,7 @@ int rc_api_init_update_code_note_request(rc_api_request_t* request, const rc_api
     rc_url_builder_append_str_param(&builder, "n", api_params->note);
 
   request->post_data = rc_url_builder_finalize(&builder);
+  request->content_type = RC_CONTENT_TYPE_URLENCODED;
 
   return builder.result;
 }
@@ -206,6 +208,7 @@ int rc_api_init_update_achievement_request(rc_api_request_t* request, const rc_a
   rc_url_builder_append_str_param(&builder, "h", buffer);
 
   request->post_data = rc_url_builder_finalize(&builder);
+  request->content_type = RC_CONTENT_TYPE_URLENCODED;
 
   return builder.result;
 }
@@ -297,6 +300,7 @@ int rc_api_init_update_leaderboard_request(rc_api_request_t* request, const rc_a
     rc_url_builder_append_str_param(&builder, "h", buffer);
 
     request->post_data = rc_url_builder_finalize(&builder);
+    request->content_type = RC_CONTENT_TYPE_URLENCODED;
 
     return builder.result;
 }
@@ -338,6 +342,7 @@ int rc_api_init_fetch_badge_range_request(rc_api_request_t* request, const rc_ap
   rc_url_builder_append_str_param(&builder, "r", "badgeiter");
 
   request->post_data = rc_url_builder_finalize(&builder);
+  request->content_type = RC_CONTENT_TYPE_URLENCODED;
 
   (void)api_params;
 
@@ -401,6 +406,7 @@ int rc_api_init_add_game_hash_request(rc_api_request_t* request, const rc_api_ad
     rc_url_builder_append_str_param(&builder, "d", api_params->hash_description);
 
   request->post_data = rc_url_builder_finalize(&builder);
+  request->content_type = RC_CONTENT_TYPE_URLENCODED;
 
   return builder.result;
 }

--- a/src/rapi/rc_api_info.c
+++ b/src/rapi/rc_api_info.c
@@ -27,6 +27,7 @@ int rc_api_init_fetch_achievement_info_request(rc_api_request_t* request, const 
     rc_url_builder_append_unum_param(&builder, "c", api_params->count);
 
     request->post_data = rc_url_builder_finalize(&builder);
+    request->content_type = RC_CONTENT_TYPE_URLENCODED;
   }
 
   return builder.result;
@@ -130,6 +131,7 @@ int rc_api_init_fetch_leaderboard_info_request(rc_api_request_t* request, const 
 
   rc_url_builder_append_unum_param(&builder, "c", api_params->count);
   request->post_data = rc_url_builder_finalize(&builder);
+  request->content_type = RC_CONTENT_TYPE_URLENCODED;
 
   return builder.result;
 }
@@ -270,6 +272,7 @@ int rc_api_init_fetch_games_list_request(rc_api_request_t* request, const rc_api
   rc_url_builder_append_unum_param(&builder, "c", api_params->console_id);
 
   request->post_data = rc_url_builder_finalize(&builder);
+  request->content_type = RC_CONTENT_TYPE_URLENCODED;
 
   return builder.result;
 }

--- a/src/rapi/rc_api_runtime.c
+++ b/src/rapi/rc_api_runtime.c
@@ -24,6 +24,7 @@ int rc_api_init_resolve_hash_request(rc_api_request_t* request, const rc_api_res
   rc_url_builder_append_str_param(&builder, "r", "gameid");
   rc_url_builder_append_str_param(&builder, "m", api_params->game_hash);
   request->post_data = rc_url_builder_finalize(&builder);
+  request->content_type = RC_CONTENT_TYPE_URLENCODED;
 
   return builder.result;
 }
@@ -65,6 +66,7 @@ int rc_api_init_fetch_game_data_request(rc_api_request_t* request, const rc_api_
   if (rc_api_url_build_dorequest(&builder, "patch", api_params->username, api_params->api_token)) {
     rc_url_builder_append_unum_param(&builder, "g", api_params->game_id);
     request->post_data = rc_url_builder_finalize(&builder);
+    request->content_type = RC_CONTENT_TYPE_URLENCODED;
   }
 
   return builder.result;
@@ -286,6 +288,7 @@ int rc_api_init_ping_request(rc_api_request_t* request, const rc_api_ping_reques
       rc_url_builder_append_str_param(&builder, "m", api_params->rich_presence);
 
     request->post_data = rc_url_builder_finalize(&builder);
+    request->content_type = RC_CONTENT_TYPE_URLENCODED;
   }
 
   return builder.result;
@@ -339,6 +342,7 @@ int rc_api_init_award_achievement_request(rc_api_request_t* request, const rc_ap
     rc_url_builder_append_str_param(&builder, "v", buffer);
 
     request->post_data = rc_url_builder_finalize(&builder);
+    request->content_type = RC_CONTENT_TYPE_URLENCODED;
   }
 
   return builder.result;
@@ -420,6 +424,7 @@ int rc_api_init_submit_lboard_entry_request(rc_api_request_t* request, const rc_
     rc_url_builder_append_str_param(&builder, "v", buffer);
 
     request->post_data = rc_url_builder_finalize(&builder);
+    request->content_type = RC_CONTENT_TYPE_URLENCODED;
   }
 
   return builder.result;

--- a/src/rapi/rc_api_user.c
+++ b/src/rapi/rc_api_user.c
@@ -27,6 +27,7 @@ int rc_api_init_login_request(rc_api_request_t* request, const rc_api_login_requ
     return RC_INVALID_STATE;
 
   request->post_data = rc_url_builder_finalize(&builder);
+  request->content_type = RC_CONTENT_TYPE_URLENCODED;
 
   return builder.result;
 }
@@ -92,6 +93,7 @@ int rc_api_init_start_session_request(rc_api_request_t* request, const rc_api_st
     rc_url_builder_append_unum_param(&builder, "m", api_params->game_id);
     rc_url_builder_append_str_param(&builder, "l", RCHEEVOS_VERSION_STRING);
     request->post_data = rc_url_builder_finalize(&builder);
+    request->content_type = RC_CONTENT_TYPE_URLENCODED;
   }
 
   return builder.result;
@@ -125,6 +127,7 @@ int rc_api_init_fetch_user_unlocks_request(rc_api_request_t* request, const rc_a
     rc_url_builder_append_unum_param(&builder, "g", api_params->game_id);
     rc_url_builder_append_unum_param(&builder, "h", api_params->hardcore ? 1 : 0);
     request->post_data = rc_url_builder_finalize(&builder);
+    request->content_type = RC_CONTENT_TYPE_URLENCODED;
   }
 
   return builder.result;

--- a/test/rapi/test_rc_api_editor.c
+++ b/test/rapi/test_rc_api_editor.c
@@ -1,6 +1,7 @@
 #include "rc_api_editor.h"
 #include "rc_api_runtime.h"
 
+#include "../src/rapi/rc_api_common.h"
 #include "../test_framework.h"
 #include "rc_compat.h"
 #include "rc_consoles.h"
@@ -18,6 +19,7 @@ static void test_init_fetch_code_notes_request()
   ASSERT_NUM_EQUALS(rc_api_init_fetch_code_notes_request(&request, &fetch_code_notes_request), RC_OK);
   ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
   ASSERT_STR_EQUALS(request.post_data, "r=codenotes2&g=1234");
+  ASSERT_STR_EQUALS(request.content_type, RC_CONTENT_TYPE_URLENCODED);
 
   rc_api_destroy_request(&request);
 }
@@ -144,6 +146,7 @@ static void test_init_update_code_note_request()
   ASSERT_NUM_EQUALS(rc_api_init_update_code_note_request(&request, &update_code_note_request), RC_OK);
   ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
   ASSERT_STR_EQUALS(request.post_data, "r=submitcodenote&u=Dev&t=API_TOKEN&g=1234&m=7168&n=flags%0a1%3dfirst%0a2%3dsecond");
+  ASSERT_STR_EQUALS(request.content_type, RC_CONTENT_TYPE_URLENCODED);
 
   rc_api_destroy_request(&request);
 }
@@ -179,6 +182,7 @@ static void test_init_update_code_note_request_no_note()
   ASSERT_NUM_EQUALS(rc_api_init_update_code_note_request(&request, &update_code_note_request), RC_OK);
   ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
   ASSERT_STR_EQUALS(request.post_data, "r=submitcodenote&u=Dev&t=API_TOKEN&g=1234&m=7168");
+  ASSERT_STR_EQUALS(request.content_type, RC_CONTENT_TYPE_URLENCODED);
 
   rc_api_destroy_request(&request);
 }
@@ -198,6 +202,7 @@ static void test_init_update_code_note_request_empty_note()
   ASSERT_NUM_EQUALS(rc_api_init_update_code_note_request(&request, &update_code_note_request), RC_OK);
   ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
   ASSERT_STR_EQUALS(request.post_data, "r=submitcodenote&u=Dev&t=API_TOKEN&g=1234&m=7168");
+  ASSERT_STR_EQUALS(request.content_type, RC_CONTENT_TYPE_URLENCODED);
 
   rc_api_destroy_request(&request);
 }
@@ -248,6 +253,7 @@ static void test_init_update_achievement_request()
   ASSERT_NUM_EQUALS(rc_api_init_update_achievement_request(&request, &update_achievement_request), RC_OK);
   ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
   ASSERT_STR_EQUALS(request.post_data, "r=uploadachievement&u=Dev&t=API_TOKEN&a=5555&g=1234&n=Title&d=Description&m=0xH1234%3d1&z=5&f=3&b=123456&h=7cd9d3f0bfdf84734968353b5a430cfd");
+  ASSERT_STR_EQUALS(request.content_type, RC_CONTENT_TYPE_URLENCODED);
 
   rc_api_destroy_request(&request);
 }
@@ -271,6 +277,7 @@ static void test_init_update_achievement_request_new()
   ASSERT_NUM_EQUALS(rc_api_init_update_achievement_request(&request, &update_achievement_request), RC_OK);
   ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
   ASSERT_STR_EQUALS(request.post_data, "r=uploadachievement&u=Dev&t=API_TOKEN&g=1234&n=Title&d=Description&m=0xH1234%3d1&z=5&f=5&b=123456&h=10dd1fd6e0201f634b1b7536d4860ccb");
+  ASSERT_STR_EQUALS(request.content_type, RC_CONTENT_TYPE_URLENCODED);
 
   rc_api_destroy_request(&request);
 }
@@ -360,6 +367,7 @@ static void test_init_update_leaderboard_request()
   ASSERT_NUM_EQUALS(rc_api_init_update_leaderboard_request(&request, &update_leaderboard_request), RC_OK);
   ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
   ASSERT_STR_EQUALS(request.post_data, "r=uploadleaderboard&u=Dev&t=API_TOKEN&i=5555&g=1234&n=Title&d=Description&s=0xH1234%3d1&b=0xH1234%3d2&c=0xH1234%3d3&l=0xH2345&w=1&f=SCORE&h=bbdb85cb1eb82773d5740c2d5d515ec0");
+  ASSERT_STR_EQUALS(request.content_type, RC_CONTENT_TYPE_URLENCODED);
 
   rc_api_destroy_request(&request);
 }
@@ -385,6 +393,7 @@ static void test_init_update_leaderboard_request_new()
   ASSERT_NUM_EQUALS(rc_api_init_update_leaderboard_request(&request, &update_leaderboard_request), RC_OK);
   ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
   ASSERT_STR_EQUALS(request.post_data, "r=uploadleaderboard&u=Dev&t=API_TOKEN&g=1234&n=Title&d=Description&s=0xH1234%3d1&b=0xH1234%3d2&c=0xH1234%3d3&l=0xH2345&w=1&f=SCORE&h=739e28608a9e93d7351103d2f43fc6dc");
+  ASSERT_STR_EQUALS(request.content_type, RC_CONTENT_TYPE_URLENCODED);
 
   rc_api_destroy_request(&request);
 }
@@ -433,6 +442,7 @@ static void test_init_update_leaderboard_request_no_description()
   ASSERT_NUM_EQUALS(rc_api_init_update_leaderboard_request(&request, &update_leaderboard_request), RC_OK);
   ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
   ASSERT_STR_EQUALS(request.post_data, "r=uploadleaderboard&u=Dev&t=API_TOKEN&i=5555&g=1234&n=Title&d=&s=0xH1234%3d1&b=0xH1234%3d2&c=0xH1234%3d3&l=0xH2345&w=1&f=SCORE&h=bbdb85cb1eb82773d5740c2d5d515ec0");
+  ASSERT_STR_EQUALS(request.content_type, RC_CONTENT_TYPE_URLENCODED);
 
   rc_api_destroy_request(&request);
 }
@@ -489,6 +499,7 @@ static void test_init_fetch_badge_range_request()
   ASSERT_NUM_EQUALS(rc_api_init_fetch_badge_range_request(&request, &fetch_badge_range_request), RC_OK);
   ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
   ASSERT_STR_EQUALS(request.post_data, "r=badgeiter");
+  ASSERT_STR_EQUALS(request.content_type, RC_CONTENT_TYPE_URLENCODED);
 
   rc_api_destroy_request(&request);
 }
@@ -525,6 +536,7 @@ static void test_init_add_game_hash_request()
   ASSERT_NUM_EQUALS(rc_api_init_add_game_hash_request(&request, &add_game_hash_request), RC_OK);
   ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
   ASSERT_STR_EQUALS(request.post_data, "r=submitgametitle&u=Dev&t=API_TOKEN&c=7&m=NEW_HASH&i=Game+Name&g=1234&d=Game+Name+%5bNo+Intro%5d.nes");
+  ASSERT_STR_EQUALS(request.content_type, RC_CONTENT_TYPE_URLENCODED);
 
   rc_api_destroy_request(&request);
 }
@@ -545,6 +557,7 @@ static void test_init_add_game_hash_request_no_game_id()
   ASSERT_NUM_EQUALS(rc_api_init_add_game_hash_request(&request, &add_game_hash_request), RC_OK);
   ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
   ASSERT_STR_EQUALS(request.post_data, "r=submitgametitle&u=Dev&t=API_TOKEN&c=7&m=NEW_HASH&i=Game+Name&d=Game+Name+%5bNo+Intro%5d.nes");
+  ASSERT_STR_EQUALS(request.content_type, RC_CONTENT_TYPE_URLENCODED);
 
   rc_api_destroy_request(&request);
 }
@@ -585,6 +598,7 @@ static void test_init_add_game_hash_request_no_title()
   ASSERT_NUM_EQUALS(rc_api_init_add_game_hash_request(&request, &add_game_hash_request), RC_OK);
   ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
   ASSERT_STR_EQUALS(request.post_data, "r=submitgametitle&u=Dev&t=API_TOKEN&c=7&m=NEW_HASH&g=1234&d=Game+Name+%5bNo+Intro%5d.nes");
+  ASSERT_STR_EQUALS(request.content_type, RC_CONTENT_TYPE_URLENCODED);
 
   rc_api_destroy_request(&request);
 }

--- a/test/rapi/test_rc_api_info.c
+++ b/test/rapi/test_rc_api_info.c
@@ -1,5 +1,6 @@
 #include "rc_api_info.h"
 
+#include "../src/rapi/rc_api_common.h"
 #include "../test_framework.h"
 #include "rc_compat.h"
 
@@ -19,6 +20,7 @@ static void test_init_fetch_achievement_info_request() {
   ASSERT_NUM_EQUALS(rc_api_init_fetch_achievement_info_request(&request, &fetch_achievement_info_request), RC_OK);
   ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
   ASSERT_STR_EQUALS(request.post_data, "r=achievementwondata&u=Username&t=API_TOKEN&a=1234&o=99&c=50");
+  ASSERT_STR_EQUALS(request.content_type, RC_CONTENT_TYPE_URLENCODED);
 
   rc_api_destroy_request(&request);
 }
@@ -36,6 +38,7 @@ static void test_init_fetch_achievement_info_request_no_first() {
   ASSERT_NUM_EQUALS(rc_api_init_fetch_achievement_info_request(&request, &fetch_achievement_info_request), RC_OK);
   ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
   ASSERT_STR_EQUALS(request.post_data, "r=achievementwondata&u=Username&t=API_TOKEN&a=1234&c=50");
+  ASSERT_STR_EQUALS(request.content_type, RC_CONTENT_TYPE_URLENCODED);
 
   rc_api_destroy_request(&request);
 }
@@ -54,6 +57,7 @@ static void test_init_fetch_achievement_info_request_one_first() {
   ASSERT_NUM_EQUALS(rc_api_init_fetch_achievement_info_request(&request, &fetch_achievement_info_request), RC_OK);
   ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
   ASSERT_STR_EQUALS(request.post_data, "r=achievementwondata&u=Username&t=API_TOKEN&a=1234&c=50");
+  ASSERT_STR_EQUALS(request.content_type, RC_CONTENT_TYPE_URLENCODED);
 
   rc_api_destroy_request(&request);
 }
@@ -72,6 +76,7 @@ static void test_init_fetch_achievement_info_request_friends_only() {
   ASSERT_NUM_EQUALS(rc_api_init_fetch_achievement_info_request(&request, &fetch_achievement_info_request), RC_OK);
   ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
   ASSERT_STR_EQUALS(request.post_data, "r=achievementwondata&u=Username&t=API_TOKEN&a=1234&f=1&c=50");
+  ASSERT_STR_EQUALS(request.content_type, RC_CONTENT_TYPE_URLENCODED);
 
   rc_api_destroy_request(&request);
 }
@@ -118,6 +123,7 @@ static void test_init_fetch_leaderboard_info_request() {
   ASSERT_NUM_EQUALS(rc_api_init_fetch_leaderboard_info_request(&request, &fetch_leaderboard_info_request), RC_OK);
   ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
   ASSERT_STR_EQUALS(request.post_data, "r=lbinfo&i=1234&o=100&c=50");
+  ASSERT_STR_EQUALS(request.content_type, RC_CONTENT_TYPE_URLENCODED);
 
   rc_api_destroy_request(&request);
 }
@@ -133,6 +139,7 @@ static void test_init_fetch_leaderboard_info_request_no_first() {
   ASSERT_NUM_EQUALS(rc_api_init_fetch_leaderboard_info_request(&request, &fetch_leaderboard_info_request), RC_OK);
   ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
   ASSERT_STR_EQUALS(request.post_data, "r=lbinfo&i=1234&c=50");
+  ASSERT_STR_EQUALS(request.content_type, RC_CONTENT_TYPE_URLENCODED);
 
   rc_api_destroy_request(&request);
 }
@@ -149,6 +156,7 @@ static void test_init_fetch_leaderboard_info_request_for_user() {
   ASSERT_NUM_EQUALS(rc_api_init_fetch_leaderboard_info_request(&request, &fetch_leaderboard_info_request), RC_OK);
   ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
   ASSERT_STR_EQUALS(request.post_data, "r=lbinfo&i=1234&u=Username&c=20");
+  ASSERT_STR_EQUALS(request.content_type, RC_CONTENT_TYPE_URLENCODED);
 
   rc_api_destroy_request(&request);
 }
@@ -166,6 +174,7 @@ static void test_init_fetch_leaderboard_info_request_for_user_with_offset() {
   ASSERT_NUM_EQUALS(rc_api_init_fetch_leaderboard_info_request(&request, &fetch_leaderboard_info_request), RC_OK);
   ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
   ASSERT_STR_EQUALS(request.post_data, "r=lbinfo&i=1234&u=Username&c=20");
+  ASSERT_STR_EQUALS(request.content_type, RC_CONTENT_TYPE_URLENCODED);
 
   rc_api_destroy_request(&request);
 }
@@ -266,6 +275,7 @@ static void test_init_fetch_games_list_request() {
   ASSERT_NUM_EQUALS(rc_api_init_fetch_games_list_request(&request, &fetch_games_list_request), RC_OK);
   ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
   ASSERT_STR_EQUALS(request.post_data, "r=gameslist&c=12");
+  ASSERT_STR_EQUALS(request.content_type, RC_CONTENT_TYPE_URLENCODED);
 
   rc_api_destroy_request(&request);
 }

--- a/test/rapi/test_rc_api_runtime.c
+++ b/test/rapi/test_rc_api_runtime.c
@@ -2,6 +2,7 @@
 
 #include "rc_runtime_types.h"
 
+#include "../src/rapi/rc_api_common.h"
 #include "../test_framework.h"
 
 #define DOREQUEST_URL "https://retroachievements.org/dorequest.php"
@@ -18,6 +19,7 @@ static void test_init_resolve_hash_request() {
   ASSERT_NUM_EQUALS(rc_api_init_resolve_hash_request(&request, &resolve_hash_request), RC_OK);
   ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
   ASSERT_STR_EQUALS(request.post_data, "r=gameid&m=ABCDEF0123456789");
+  ASSERT_STR_EQUALS(request.content_type, RC_CONTENT_TYPE_URLENCODED);
 
   rc_api_destroy_request(&request);
 }
@@ -32,6 +34,7 @@ static void test_init_resolve_hash_request_no_credentials() {
   ASSERT_NUM_EQUALS(rc_api_init_resolve_hash_request(&request, &resolve_hash_request), RC_OK);
   ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
   ASSERT_STR_EQUALS(request.post_data, "r=gameid&m=ABCDEF0123456789");
+  ASSERT_STR_EQUALS(request.content_type, RC_CONTENT_TYPE_URLENCODED);
 
   rc_api_destroy_request(&request);
 }
@@ -99,6 +102,7 @@ static void test_init_fetch_game_data_request() {
   ASSERT_NUM_EQUALS(rc_api_init_fetch_game_data_request(&request, &fetch_game_data_request), RC_OK);
   ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
   ASSERT_STR_EQUALS(request.post_data, "r=patch&u=Username&t=API_TOKEN&g=1234");
+  ASSERT_STR_EQUALS(request.content_type, RC_CONTENT_TYPE_URLENCODED);
 
   rc_api_destroy_request(&request);
 }
@@ -385,6 +389,7 @@ static void test_init_ping_request() {
   ASSERT_NUM_EQUALS(rc_api_init_ping_request(&request, &ping_request), RC_OK);
   ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
   ASSERT_STR_EQUALS(request.post_data, "r=ping&u=Username&t=API_TOKEN&g=1234");
+  ASSERT_STR_EQUALS(request.content_type, RC_CONTENT_TYPE_URLENCODED);
 
   rc_api_destroy_request(&request);
 }
@@ -415,6 +420,7 @@ static void test_init_ping_request_rich_presence() {
   ASSERT_NUM_EQUALS(rc_api_init_ping_request(&request, &ping_request), RC_OK);
   ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
   ASSERT_STR_EQUALS(request.post_data, "r=ping&u=Username&t=API_TOKEN&g=1234&m=Level+1%2c+70%25+complete");
+  ASSERT_STR_EQUALS(request.content_type, RC_CONTENT_TYPE_URLENCODED);
 
   rc_api_destroy_request(&request);
 }
@@ -432,6 +438,7 @@ static void test_init_ping_request_rich_presence_unicode() {
   ASSERT_NUM_EQUALS(rc_api_init_ping_request(&request, &ping_request), RC_OK);
   ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
   ASSERT_STR_EQUALS(request.post_data, "r=ping&u=Username&t=API_TOKEN&g=1446&m=%f0%9f%9a%b6%3a3%2c+1st+Quest");
+  ASSERT_STR_EQUALS(request.content_type, RC_CONTENT_TYPE_URLENCODED);
 
   rc_api_destroy_request(&request);
 }
@@ -449,6 +456,7 @@ static void test_init_ping_request_rich_presence_empty() {
   ASSERT_NUM_EQUALS(rc_api_init_ping_request(&request, &ping_request), RC_OK);
   ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
   ASSERT_STR_EQUALS(request.post_data, "r=ping&u=Username&t=API_TOKEN&g=1234");
+  ASSERT_STR_EQUALS(request.content_type, RC_CONTENT_TYPE_URLENCODED);
 
   rc_api_destroy_request(&request);
 }
@@ -480,6 +488,7 @@ static void test_init_award_achievement_request_hardcore() {
   ASSERT_NUM_EQUALS(rc_api_init_award_achievement_request(&request, &award_achievement_request), RC_OK);
   ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
   ASSERT_STR_EQUALS(request.post_data, "r=awardachievement&u=Username&t=API_TOKEN&a=1234&h=1&m=ABCDEF0123456789&v=b8aefaad6f9659e2164bc60da0c3b64d");
+  ASSERT_STR_EQUALS(request.content_type, RC_CONTENT_TYPE_URLENCODED);
 
   rc_api_destroy_request(&request);
 }
@@ -498,6 +507,7 @@ static void test_init_award_achievement_request_non_hardcore() {
   ASSERT_NUM_EQUALS(rc_api_init_award_achievement_request(&request, &award_achievement_request), RC_OK);
   ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
   ASSERT_STR_EQUALS(request.post_data, "r=awardachievement&u=Username&t=API_TOKEN&a=1234&h=0&m=ABABCBCBDEDEFFFF&v=ed81d6ecf825f8cbe3ae1edace098892");
+  ASSERT_STR_EQUALS(request.content_type, RC_CONTENT_TYPE_URLENCODED);
 
   rc_api_destroy_request(&request);
 }
@@ -515,6 +525,7 @@ static void test_init_award_achievement_request_no_hash() {
   ASSERT_NUM_EQUALS(rc_api_init_award_achievement_request(&request, &award_achievement_request), RC_OK);
   ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
   ASSERT_STR_EQUALS(request.post_data, "r=awardachievement&u=Username&t=API_TOKEN&a=5432&h=1&v=31048257ab1788386e71ab0c222aa5c8");
+  ASSERT_STR_EQUALS(request.content_type, RC_CONTENT_TYPE_URLENCODED);
 
   rc_api_destroy_request(&request);
 }
@@ -725,6 +736,7 @@ static void test_init_submit_lboard_entry_request() {
   ASSERT_NUM_EQUALS(rc_api_init_submit_lboard_entry_request(&request, &submit_lboard_entry_request), RC_OK);
   ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
   ASSERT_STR_EQUALS(request.post_data, "r=submitlbentry&u=Username&t=API_TOKEN&i=1234&s=10999&m=ABCDEF0123456789&v=e13c9132ee651256f9d2ee8f06f75d76");
+  ASSERT_STR_EQUALS(request.content_type, RC_CONTENT_TYPE_URLENCODED);
 
   rc_api_destroy_request(&request);
 }
@@ -743,6 +755,7 @@ static void test_init_submit_lboard_entry_request_zero_value() {
   ASSERT_NUM_EQUALS(rc_api_init_submit_lboard_entry_request(&request, &submit_lboard_entry_request), RC_OK);
   ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
   ASSERT_STR_EQUALS(request.post_data, "r=submitlbentry&u=Username&t=API_TOKEN&i=1111&s=0&m=ABCDEF0123456789&v=9c2ac665157d68b8a26e83bb71dd8aaf");
+  ASSERT_STR_EQUALS(request.content_type, RC_CONTENT_TYPE_URLENCODED);
 
   rc_api_destroy_request(&request);
 }
@@ -761,6 +774,7 @@ static void test_init_submit_lboard_entry_request_negative_value() {
   ASSERT_NUM_EQUALS(rc_api_init_submit_lboard_entry_request(&request, &submit_lboard_entry_request), RC_OK);
   ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
   ASSERT_STR_EQUALS(request.post_data, "r=submitlbentry&u=Username&t=API_TOKEN&i=1111&s=-234781&m=ABCDEF0123456789&v=fbe290266f2d121a7a37942e1e90f453");
+  ASSERT_STR_EQUALS(request.content_type, RC_CONTENT_TYPE_URLENCODED);
 
   rc_api_destroy_request(&request);
 }

--- a/test/rapi/test_rc_api_user.c
+++ b/test/rapi/test_rc_api_user.c
@@ -1,5 +1,6 @@
 #include "rc_api_user.h"
 
+#include "../src/rapi/rc_api_common.h"
 #include "../test_framework.h"
 #include "rc_compat.h"
 #include "rc_version.h"
@@ -19,6 +20,7 @@ static void test_init_start_session_request()
   ASSERT_NUM_EQUALS(rc_api_init_start_session_request(&request, &start_session_request), RC_OK);
   ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
   ASSERT_STR_EQUALS(request.post_data,  "r=postactivity&u=Username&t=API_TOKEN&a=3&m=1234&l=" RCHEEVOS_VERSION_STRING);
+  ASSERT_STR_EQUALS(request.content_type, RC_CONTENT_TYPE_URLENCODED);
 
   rc_api_destroy_request(&request);
 }
@@ -77,6 +79,7 @@ static void test_init_login_request_password()
   ASSERT_NUM_EQUALS(rc_api_init_login_request(&request, &login_request), RC_OK);
   ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
   ASSERT_STR_EQUALS(request.post_data, "r=login&u=Username&p=Pa%24%24w0rd%21");
+  ASSERT_STR_EQUALS(request.content_type, RC_CONTENT_TYPE_URLENCODED);
 
   rc_api_destroy_request(&request);
 }
@@ -100,6 +103,7 @@ static void test_init_login_request_password_long()
   ASSERT_NUM_EQUALS(rc_api_init_login_request(&request, &login_request), RC_OK);
   ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
   ASSERT_STR_EQUALS(request.post_data, buffer);
+  ASSERT_STR_EQUALS(request.content_type, RC_CONTENT_TYPE_URLENCODED);
 
   rc_api_destroy_request(&request);
 }
@@ -116,6 +120,7 @@ static void test_init_login_request_token()
   ASSERT_NUM_EQUALS(rc_api_init_login_request(&request, &login_request), RC_OK);
   ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
   ASSERT_STR_EQUALS(request.post_data, "r=login&u=Username&t=ABCDEFGHIJKLMNOP");
+  ASSERT_STR_EQUALS(request.content_type, RC_CONTENT_TYPE_URLENCODED);
 
   rc_api_destroy_request(&request);
 }
@@ -133,6 +138,7 @@ static void test_init_login_request_password_and_token()
   ASSERT_NUM_EQUALS(rc_api_init_login_request(&request, &login_request), RC_OK);
   ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
   ASSERT_STR_EQUALS(request.post_data, "r=login&u=Username&p=Pa%24%24w0rd%21");
+  ASSERT_STR_EQUALS(request.content_type, RC_CONTENT_TYPE_URLENCODED);
 
   rc_api_destroy_request(&request);
 }
@@ -163,6 +169,7 @@ static void test_init_login_request_alternate_host()
   ASSERT_NUM_EQUALS(rc_api_init_login_request(&request, &login_request), RC_OK);
   ASSERT_STR_EQUALS(request.url, "http://localhost/dorequest.php");
   ASSERT_STR_EQUALS(request.post_data, "r=login&u=Username&p=Pa%24%24w0rd%21");
+  ASSERT_STR_EQUALS(request.content_type, RC_CONTENT_TYPE_URLENCODED);
 
   rc_api_set_host(NULL);
   rc_api_destroy_request(&request);
@@ -402,6 +409,7 @@ static void test_init_fetch_user_unlocks_request_non_hardcore()
   ASSERT_NUM_EQUALS(rc_api_init_fetch_user_unlocks_request(&request, &fetch_user_unlocks_request), RC_OK);
   ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
   ASSERT_STR_EQUALS(request.post_data, "r=unlocks&u=Username&t=API_TOKEN&g=1234&h=0");
+  ASSERT_STR_EQUALS(request.content_type, RC_CONTENT_TYPE_URLENCODED);
 
   rc_api_destroy_request(&request);
 }
@@ -420,6 +428,7 @@ static void test_init_fetch_user_unlocks_request_hardcore()
   ASSERT_NUM_EQUALS(rc_api_init_fetch_user_unlocks_request(&request, &fetch_user_unlocks_request), RC_OK);
   ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
   ASSERT_STR_EQUALS(request.post_data, "r=unlocks&u=Username&t=API_TOKEN&g=2345&h=1");
+  ASSERT_STR_EQUALS(request.content_type, RC_CONTENT_TYPE_URLENCODED);
 
   rc_api_destroy_request(&request);
 }


### PR DESCRIPTION
Instead of requiring clients to know they need to send a `Content-Type: application/x-www-form-urlencoded` header along with the POST payload, explicitly provide that information in the `rc_api_request_t` object.
