### PR TITLE
split RC_CLIENT_EVENT_ACHIEVEMENT_PROGRESS_INDICATOR_SHOW show event into show/update/hide

### DIFF
--- a/include/rc_client.h
+++ b/include/rc_client.h
@@ -494,13 +494,15 @@ enum {
   RC_CLIENT_EVENT_LEADERBOARD_SUBMITTED = 4, /* [leaderboard] attempt submitted */
   RC_CLIENT_EVENT_ACHIEVEMENT_CHALLENGE_INDICATOR_SHOW = 5, /* [achievement] challenge indicator should be shown */
   RC_CLIENT_EVENT_ACHIEVEMENT_CHALLENGE_INDICATOR_HIDE = 6, /* [achievement] challenge indicator should be hidden */
-  RC_CLIENT_EVENT_ACHIEVEMENT_PROGRESS_INDICATOR_SHOW = 7, /* progress indicator should be shown for [achievement] for two seconds, replacing any currently visible progress indicator */
-  RC_CLIENT_EVENT_LEADERBOARD_TRACKER_SHOW = 8, /* [leaderboard_tracker] should be shown */
-  RC_CLIENT_EVENT_LEADERBOARD_TRACKER_HIDE = 9, /* [leaderboard_tracker] should be hidden */
-  RC_CLIENT_EVENT_LEADERBOARD_TRACKER_UPDATE = 10, /* [leaderboard_tracker] updated */
-  RC_CLIENT_EVENT_RESET = 11, /* emulated system should be reset (as the result of enabling hardcore) */
-  RC_CLIENT_EVENT_GAME_COMPLETED = 12, /* all achievements for the game have been earned */
-  RC_CLIENT_EVENT_SERVER_ERROR = 13 /* an API response returned a [server_error] and will not be retried */
+  RC_CLIENT_EVENT_ACHIEVEMENT_PROGRESS_INDICATOR_SHOW = 7, /* progress indicator should be shown for [achievement] */
+  RC_CLIENT_EVENT_ACHIEVEMENT_PROGRESS_INDICATOR_HIDE = 8, /* progress indicator should be hidden */
+  RC_CLIENT_EVENT_ACHIEVEMENT_PROGRESS_INDICATOR_UPDATE = 9, /* progress indicator should be updated to reflect new badge/progress for [achievement] */
+  RC_CLIENT_EVENT_LEADERBOARD_TRACKER_SHOW = 10, /* [leaderboard_tracker] should be shown */
+  RC_CLIENT_EVENT_LEADERBOARD_TRACKER_HIDE = 11, /* [leaderboard_tracker] should be hidden */
+  RC_CLIENT_EVENT_LEADERBOARD_TRACKER_UPDATE = 12, /* [leaderboard_tracker] updated */
+  RC_CLIENT_EVENT_RESET = 13, /* emulated system should be reset (as the result of enabling hardcore) */
+  RC_CLIENT_EVENT_GAME_COMPLETED = 14, /* all achievements for the game have been earned */
+  RC_CLIENT_EVENT_SERVER_ERROR = 15 /* an API response returned a [server_error] and will not be retried */
 };
 
 typedef struct rc_client_server_error_t

--- a/src/rcheevos/rc_client_internal.h
+++ b/src/rcheevos/rc_client_internal.h
@@ -39,7 +39,7 @@ enum {
   RC_CLIENT_ACHIEVEMENT_PENDING_EVENT_TRIGGERED = (1 << 1),
   RC_CLIENT_ACHIEVEMENT_PENDING_EVENT_CHALLENGE_INDICATOR_SHOW = (1 << 2),
   RC_CLIENT_ACHIEVEMENT_PENDING_EVENT_CHALLENGE_INDICATOR_HIDE = (1 << 3),
-  RC_CLIENT_ACHIEVEMENT_PENDING_EVENT_PROGRESS_INDICATOR_SHOW = (1 << 4)
+  RC_CLIENT_ACHIEVEMENT_PENDING_EVENT_UPDATE = (1 << 4) /* not a real event, just triggers update */
 };
 
 typedef struct rc_client_achievement_info_t {
@@ -53,6 +53,21 @@ typedef struct rc_client_achievement_info_t {
 
   uint8_t pending_events;
 } rc_client_achievement_info_t;
+
+enum {
+  RC_CLIENT_PROGRESS_TRACKER_ACTION_NONE,
+  RC_CLIENT_PROGRESS_TRACKER_ACTION_SHOW,
+  RC_CLIENT_PROGRESS_TRACKER_ACTION_UPDATE,
+  RC_CLIENT_PROGRESS_TRACKER_ACTION_HIDE
+};
+
+typedef struct rc_client_progress_tracker_t {
+  rc_client_achievement_info_t* achievement;
+  float progress;
+
+  rc_client_scheduled_callback_data_t* hide_callback;
+  uint8_t action;
+} rc_client_progress_tracker_t;
 
 enum {
   RC_CLIENT_LEADERBOARD_TRACKER_PENDING_EVENT_NONE = 0,
@@ -106,7 +121,8 @@ enum {
 enum {
   RC_CLIENT_GAME_PENDING_EVENT_NONE = 0,
   RC_CLIENT_GAME_PENDING_EVENT_LEADERBOARD_TRACKER = (1 << 1),
-  RC_CLIENT_GAME_PENDING_EVENT_UPDATE_ACTIVE_ACHIEVEMENTS = (1 << 2)
+  RC_CLIENT_GAME_PENDING_EVENT_UPDATE_ACTIVE_ACHIEVEMENTS = (1 << 2),
+  RC_CLIENT_GAME_PENDING_EVENT_PROGRESS_TRACKER = (1 << 3)
 };
 
 typedef struct rc_client_subset_info_t {
@@ -144,6 +160,7 @@ typedef struct rc_client_media_hash_t {
 typedef struct rc_client_game_info_t {
   rc_client_game_t public_;
   rc_client_leaderboard_tracker_info_t* leaderboard_trackers;
+  rc_client_progress_tracker_t progress_tracker;
 
   rc_client_subset_info_t* subsets;
 

--- a/src/rcheevos/rc_client_internal.h
+++ b/src/rcheevos/rc_client_internal.h
@@ -21,11 +21,11 @@ typedef struct rc_client_callbacks_t {
 } rc_client_callbacks_t;
 
 struct rc_client_scheduled_callback_data_t;
-typedef void (*rc_client_scheduled_callback_t)(struct rc_client_scheduled_callback_data_t* callback_data, rc_client_t* client, time_t now);
+typedef void (*rc_client_scheduled_callback_t)(struct rc_client_scheduled_callback_data_t* callback_data, rc_client_t* client, clock_t now);
 
 typedef struct rc_client_scheduled_callback_data_t
 {
-  time_t when;
+  clock_t when;
   unsigned related_id;
   rc_client_scheduled_callback_t callback;
   void* data;


### PR DESCRIPTION
For more consistency (with challenge indicator and leaderboard trackers), and to allow forcibly hiding when resetting or loading a state.