### PR TITLE
update rc_api functions to accept length and status code

### DIFF
--- a/include/rc_api_editor.h
+++ b/include/rc_api_editor.h
@@ -44,6 +44,7 @@ rc_api_fetch_code_notes_response_t;
 
 int rc_api_init_fetch_code_notes_request(rc_api_request_t* request, const rc_api_fetch_code_notes_request_t* api_params);
 int rc_api_process_fetch_code_notes_response(rc_api_fetch_code_notes_response_t* response, const char* server_response);
+int rc_api_process_fetch_code_notes_server_response(rc_api_fetch_code_notes_response_t* response, const rc_api_server_response_t* server_response);
 void rc_api_destroy_fetch_code_notes_response(rc_api_fetch_code_notes_response_t* response);
 
 /* --- Update Code Note --- */
@@ -76,6 +77,7 @@ rc_api_update_code_note_response_t;
 
 int rc_api_init_update_code_note_request(rc_api_request_t* request, const rc_api_update_code_note_request_t* api_params);
 int rc_api_process_update_code_note_response(rc_api_update_code_note_response_t* response, const char* server_response);
+int rc_api_process_update_code_note_server_response(rc_api_update_code_note_response_t* response, const rc_api_server_response_t* server_response);
 void rc_api_destroy_update_code_note_response(rc_api_update_code_note_response_t* response);
 
 /* --- Update Achievement --- */
@@ -121,6 +123,7 @@ rc_api_update_achievement_response_t;
 
 int rc_api_init_update_achievement_request(rc_api_request_t* request, const rc_api_update_achievement_request_t* api_params);
 int rc_api_process_update_achievement_response(rc_api_update_achievement_response_t* response, const char* server_response);
+int rc_api_process_update_achievement_server_response(rc_api_update_achievement_response_t* response, const rc_api_server_response_t* server_response);
 void rc_api_destroy_update_achievement_response(rc_api_update_achievement_response_t* response);
 
 /* --- Update Leaderboard --- */
@@ -170,6 +173,7 @@ rc_api_update_leaderboard_response_t;
 
 int rc_api_init_update_leaderboard_request(rc_api_request_t* request, const rc_api_update_leaderboard_request_t* api_params);
 int rc_api_process_update_leaderboard_response(rc_api_update_leaderboard_response_t* response, const char* server_response);
+int rc_api_process_update_leaderboard_server_response(rc_api_update_leaderboard_response_t* response, const rc_api_server_response_t* server_response);
 void rc_api_destroy_update_leaderboard_response(rc_api_update_leaderboard_response_t* response);
 
 /* --- Fetch Badge Range --- */
@@ -199,6 +203,7 @@ rc_api_fetch_badge_range_response_t;
 
 int rc_api_init_fetch_badge_range_request(rc_api_request_t* request, const rc_api_fetch_badge_range_request_t* api_params);
 int rc_api_process_fetch_badge_range_response(rc_api_fetch_badge_range_response_t* response, const char* server_response);
+int rc_api_process_fetch_badge_range_server_response(rc_api_fetch_badge_range_response_t* response, const rc_api_server_response_t* server_response);
 void rc_api_destroy_fetch_badge_range_response(rc_api_fetch_badge_range_response_t* response);
 
 /* --- Add Game Hash --- */
@@ -238,6 +243,7 @@ rc_api_add_game_hash_response_t;
 
 int rc_api_init_add_game_hash_request(rc_api_request_t* request, const rc_api_add_game_hash_request_t* api_params);
 int rc_api_process_add_game_hash_response(rc_api_add_game_hash_response_t* response, const char* server_response);
+int rc_api_process_add_game_hash_server_response(rc_api_add_game_hash_response_t* response, const rc_api_server_response_t* server_response);
 void rc_api_destroy_add_game_hash_response(rc_api_add_game_hash_response_t* response);
 
 #ifdef __cplusplus

--- a/include/rc_api_info.h
+++ b/include/rc_api_info.h
@@ -64,6 +64,7 @@ rc_api_fetch_achievement_info_response_t;
 
 int rc_api_init_fetch_achievement_info_request(rc_api_request_t* request, const rc_api_fetch_achievement_info_request_t* api_params);
 int rc_api_process_fetch_achievement_info_response(rc_api_fetch_achievement_info_response_t* response, const char* server_response);
+int rc_api_process_fetch_achievement_info_server_response(rc_api_fetch_achievement_info_response_t* response, const rc_api_server_response_t* server_response);
 void rc_api_destroy_fetch_achievement_info_response(rc_api_fetch_achievement_info_response_t* response);
 
 /* --- Fetch Leaderboard Info --- */
@@ -135,6 +136,7 @@ rc_api_fetch_leaderboard_info_response_t;
 
 int rc_api_init_fetch_leaderboard_info_request(rc_api_request_t* request, const rc_api_fetch_leaderboard_info_request_t* api_params);
 int rc_api_process_fetch_leaderboard_info_response(rc_api_fetch_leaderboard_info_response_t* response, const char* server_response);
+int rc_api_process_fetch_leaderboard_info_server_response(rc_api_fetch_leaderboard_info_response_t* response, const rc_api_server_response_t* server_response);
 void rc_api_destroy_fetch_leaderboard_info_response(rc_api_fetch_leaderboard_info_response_t* response);
 
 /* --- Fetch Games List --- */
@@ -173,6 +175,7 @@ rc_api_fetch_games_list_response_t;
 
 int rc_api_init_fetch_games_list_request(rc_api_request_t* request, const rc_api_fetch_games_list_request_t* api_params);
 int rc_api_process_fetch_games_list_response(rc_api_fetch_games_list_response_t* response, const char* server_response);
+int rc_api_process_fetch_games_list_server_response(rc_api_fetch_games_list_response_t* response, const rc_api_server_response_t* server_response);
 void rc_api_destroy_fetch_games_list_response(rc_api_fetch_games_list_response_t* response);
 
 #ifdef __cplusplus

--- a/include/rc_api_runtime.h
+++ b/include/rc_api_runtime.h
@@ -59,6 +59,7 @@ rc_api_resolve_hash_response_t;
 
 int rc_api_init_resolve_hash_request(rc_api_request_t* request, const rc_api_resolve_hash_request_t* api_params);
 int rc_api_process_resolve_hash_response(rc_api_resolve_hash_response_t* response, const char* server_response);
+int rc_api_process_resolve_hash_server_response(rc_api_resolve_hash_response_t* response, const rc_api_server_response_t* server_response);
 void rc_api_destroy_resolve_hash_response(rc_api_resolve_hash_response_t* response);
 
 /* --- Fetch Game Data --- */
@@ -155,6 +156,7 @@ rc_api_fetch_game_data_response_t;
 
 int rc_api_init_fetch_game_data_request(rc_api_request_t* request, const rc_api_fetch_game_data_request_t* api_params);
 int rc_api_process_fetch_game_data_response(rc_api_fetch_game_data_response_t* response, const char* server_response);
+int rc_api_process_fetch_game_data_server_response(rc_api_fetch_game_data_response_t* response, const rc_api_server_response_t* server_response);
 void rc_api_destroy_fetch_game_data_response(rc_api_fetch_game_data_response_t* response);
 
 /* --- Ping --- */
@@ -185,6 +187,7 @@ rc_api_ping_response_t;
 
 int rc_api_init_ping_request(rc_api_request_t* request, const rc_api_ping_request_t* api_params);
 int rc_api_process_ping_response(rc_api_ping_response_t* response, const char* server_response);
+int rc_api_process_ping_server_response(rc_api_ping_response_t* response, const rc_api_server_response_t* server_response);
 void rc_api_destroy_ping_response(rc_api_ping_response_t* response);
 
 /* --- Award Achievement --- */
@@ -227,6 +230,7 @@ rc_api_award_achievement_response_t;
 
 int rc_api_init_award_achievement_request(rc_api_request_t* request, const rc_api_award_achievement_request_t* api_params);
 int rc_api_process_award_achievement_response(rc_api_award_achievement_response_t* response, const char* server_response);
+int rc_api_process_award_achievement_server_response(rc_api_award_achievement_response_t* response, const rc_api_server_response_t* server_response);
 void rc_api_destroy_award_achievement_response(rc_api_award_achievement_response_t* response);
 
 /* --- Submit Leaderboard Entry --- */
@@ -284,6 +288,7 @@ rc_api_submit_lboard_entry_response_t;
 
 int rc_api_init_submit_lboard_entry_request(rc_api_request_t* request, const rc_api_submit_lboard_entry_request_t* api_params);
 int rc_api_process_submit_lboard_entry_response(rc_api_submit_lboard_entry_response_t* response, const char* server_response);
+int rc_api_process_submit_lboard_entry_server_response(rc_api_submit_lboard_entry_response_t* response, const rc_api_server_response_t* server_response);
 void rc_api_destroy_submit_lboard_entry_response(rc_api_submit_lboard_entry_response_t* response);
 
 #ifdef __cplusplus

--- a/include/rc_api_user.h
+++ b/include/rc_api_user.h
@@ -47,6 +47,7 @@ rc_api_login_response_t;
 
 int rc_api_init_login_request(rc_api_request_t* request, const rc_api_login_request_t* api_params);
 int rc_api_process_login_response(rc_api_login_response_t* response, const char* server_response);
+int rc_api_process_login_server_response(rc_api_login_response_t* response, const rc_api_server_response_t* server_response);
 void rc_api_destroy_login_response(rc_api_login_response_t* response);
 
 /* --- Start Session --- */
@@ -75,6 +76,7 @@ rc_api_start_session_response_t;
 
 int rc_api_init_start_session_request(rc_api_request_t* request, const rc_api_start_session_request_t* api_params);
 int rc_api_process_start_session_response(rc_api_start_session_response_t* response, const char* server_response);
+int rc_api_process_start_session_server_response(rc_api_start_session_response_t* response, const rc_api_server_response_t* server_response);
 void rc_api_destroy_start_session_response(rc_api_start_session_response_t* response);
 
 /* --- Fetch User Unlocks --- */
@@ -110,6 +112,7 @@ rc_api_fetch_user_unlocks_response_t;
 
 int rc_api_init_fetch_user_unlocks_request(rc_api_request_t* request, const rc_api_fetch_user_unlocks_request_t* api_params);
 int rc_api_process_fetch_user_unlocks_response(rc_api_fetch_user_unlocks_response_t* response, const char* server_response);
+int rc_api_process_fetch_user_unlocks_server_response(rc_api_fetch_user_unlocks_response_t* response, const rc_api_server_response_t* server_response);
 void rc_api_destroy_fetch_user_unlocks_response(rc_api_fetch_user_unlocks_response_t* response);
 
 #ifdef __cplusplus

--- a/src/rapi/rc_api_common.c
+++ b/src/rapi/rc_api_common.c
@@ -255,22 +255,20 @@ static int rc_json_extract_html_error(rc_api_response_t* response, const rc_api_
   const char* json = server_response->body;
   const char* end = json;
 
-  if (strncmp(json, "<html>", 6) == 0) {
-    const char* title_start = strstr(json, "<title>");
-    if (title_start) {
-      title_start += 7;
-      if (isdigit((int)*title_start)) {
-        const char* title_end = strstr(title_start + 7, "</title>");
-        if (title_end) {
-          char* dst = rc_buf_reserve(&response->buffer, (title_end - title_start) + 1);
-          response->error_message = dst;
-          memcpy(dst, title_start, title_end - title_start);
-          dst += (title_end - title_start);
-          *dst++ = '\0';
-          rc_buf_consume(&response->buffer, response->error_message, dst);
-          response->succeeded = 0;
-          return RC_INVALID_JSON;
-        }
+  const char* title_start = strstr(json, "<title>");
+  if (title_start) {
+    title_start += 7;
+    if (isdigit((int)*title_start)) {
+      const char* title_end = strstr(title_start + 7, "</title>");
+      if (title_end) {
+        char* dst = rc_buf_reserve(&response->buffer, (title_end - title_start) + 1);
+        response->error_message = dst;
+        memcpy(dst, title_start, title_end - title_start);
+        dst += (title_end - title_start);
+        *dst++ = '\0';
+        rc_buf_consume(&response->buffer, response->error_message, dst);
+        response->succeeded = 0;
+        return RC_INVALID_JSON;
       }
     }
   }

--- a/src/rapi/rc_api_common.c
+++ b/src/rapi/rc_api_common.c
@@ -251,15 +251,7 @@ int rc_json_get_object_string_length(const char* json) {
   return (int)(iterator.json - json_start);
 }
 
-int rc_json_parse_response(rc_api_response_t* response, const char* json, rc_json_field_t* fields, size_t field_count) {
-  rc_api_server_response_t server_response;
-  memset(&server_response, 0, sizeof(server_response));
-  server_response.body = json;
-  server_response.body_length = rc_json_get_object_string_length(json);
-  return rc_json_parse_server_response(response, &server_response, fields, field_count);
-}
-
-int rc_json_extract_html_error(rc_api_response_t* response, const rc_api_server_response_t* server_response) {
+static int rc_json_extract_html_error(rc_api_response_t* response, const rc_api_server_response_t* server_response) {
   const char* json = server_response->body;
   const char* end = json;
 

--- a/src/rapi/rc_api_common.c
+++ b/src/rapi/rc_api_common.c
@@ -20,157 +20,174 @@ static char* g_imagehost = NULL;
 
 /* --- rc_json --- */
 
-static int rc_json_parse_object(const char** json_ptr, rc_json_field_t* fields, size_t field_count, unsigned* fields_seen);
-static int rc_json_parse_array(const char** json_ptr, rc_json_field_t* field);
+static int rc_json_parse_object(rc_json_iterator_t* iterator, rc_json_field_t* fields, size_t field_count, unsigned* fields_seen);
+static int rc_json_parse_array(rc_json_iterator_t* iterator, rc_json_field_t* field);
 
-static int rc_json_parse_field(const char** json_ptr, rc_json_field_t* field) {
+static int rc_json_match_char(rc_json_iterator_t* iterator, char c)
+{
+  if (iterator->json < iterator->end && *iterator->json == c) {
+    ++iterator->json;
+    return 1;
+  }
+
+  return 0;
+}
+
+static void rc_json_skip_whitespace(rc_json_iterator_t* iterator)
+{
+  while (iterator->json < iterator->end && isspace((unsigned char)*iterator->json))
+    ++iterator->json;
+}
+
+static int rc_json_find_closing_quote(rc_json_iterator_t* iterator)
+{
+  while (iterator->json < iterator->end) {
+    if (*iterator->json == '"')
+      return 1;
+
+    if (*iterator->json == '\\') {
+      ++iterator->json;
+      if (iterator->json == iterator->end)
+        return 0;
+    }
+
+    if (*iterator->json == '\0')
+      return 0;
+
+    ++iterator->json;
+  }
+
+  return 0;
+}
+
+static int rc_json_parse_field(rc_json_iterator_t* iterator, rc_json_field_t* field) {
   int result;
 
-  field->value_start = *json_ptr;
+  if (iterator->json >= iterator->end)
+    return RC_INVALID_JSON;
 
-  switch (**json_ptr)
+  field->value_start = iterator->json;
+
+  switch (*iterator->json)
   {
     case '"': /* quoted string */
-      ++(*json_ptr);
-      while (**json_ptr != '"') {
-        if (**json_ptr == '\\')
-          ++(*json_ptr);
-
-        if (**json_ptr == '\0')
-          return RC_INVALID_JSON;
-
-        ++(*json_ptr);
-      }
-      ++(*json_ptr);
+      ++iterator->json;
+      if (!rc_json_find_closing_quote(iterator))
+        return RC_INVALID_JSON;
+      ++iterator->json;
       break;
 
     case '-':
     case '+': /* signed number */
-      ++(*json_ptr);
+      ++iterator->json;
       /* fallthrough to number */
     case '0': case '1': case '2': case '3': case '4':
     case '5': case '6': case '7': case '8': case '9': /* number */
-      do {
-        ++(*json_ptr);
-      } while (**json_ptr >= '0' && **json_ptr <= '9');
-      if (**json_ptr == '.') {
-        do {
-          ++(*json_ptr);
-        } while (**json_ptr >= '0' && **json_ptr <= '9');
+      while (iterator->json < iterator->end && *iterator->json >= '0' && *iterator->json <= '9')
+        ++iterator->json;
+
+      if (rc_json_match_char(iterator, '.')) {
+        while (iterator->json < iterator->end && *iterator->json >= '0' && *iterator->json <= '9')
+          ++iterator->json;
       }
       break;
 
     case '[': /* array */
-      result = rc_json_parse_array(json_ptr, field);
+      result = rc_json_parse_array(iterator, field);
       if (result != RC_OK)
-          return result;
+        return result;
 
       break;
 
     case '{': /* object */
-      result = rc_json_parse_object(json_ptr, NULL, 0, &field->array_size);
+      result = rc_json_parse_object(iterator, NULL, 0, &field->array_size);
       if (result != RC_OK)
         return result;
 
       break;
 
     default: /* non-quoted text [true,false,null] */
-      if (!isalpha((unsigned char)**json_ptr))
+      if (!isalpha((unsigned char)*iterator->json))
         return RC_INVALID_JSON;
 
-      do {
-        ++(*json_ptr);
-      } while (isalnum((unsigned char)**json_ptr));
+      while (iterator->json < iterator->end && isalnum((unsigned char)*iterator->json))
+        ++iterator->json;
       break;
   }
 
-  field->value_end = *json_ptr;
+  field->value_end = iterator->json;
   return RC_OK;
 }
 
-static int rc_json_parse_array(const char** json_ptr, rc_json_field_t* field) {
+static int rc_json_parse_array(rc_json_iterator_t* iterator, rc_json_field_t* field) {
   rc_json_field_t unused_field;
-  const char* json = *json_ptr;
   int result;
 
-  if (*json != '[')
+  if (!rc_json_match_char(iterator, '['))
     return RC_INVALID_JSON;
-  ++json;
 
   field->array_size = 0;
-  if (*json != ']') {
-    do
-    {
-      while (isspace((unsigned char)*json))
-        ++json;
 
-      result = rc_json_parse_field(&json, &unused_field);
-      if (result != RC_OK)
-        return result;
+  if (rc_json_match_char(iterator, ']')) /* empty array */
+    return RC_OK;
 
-      ++field->array_size;
+  do
+  {
+    rc_json_skip_whitespace(iterator);
 
-      while (isspace((unsigned char)*json))
-        ++json;
+    result = rc_json_parse_field(iterator, &unused_field);
+    if (result != RC_OK)
+      return result;
 
-      if (*json != ',')
-        break;
+    ++field->array_size;
 
-      ++json;
-    } while (1);
+    rc_json_skip_whitespace(iterator);
+  } while (rc_json_match_char(iterator, ','));
 
-    if (*json != ']')
-      return RC_INVALID_JSON;
-  }
+  if (!rc_json_match_char(iterator, ']'))
+    return RC_INVALID_JSON;
 
-  *json_ptr = ++json;
   return RC_OK;
 }
 
-static int rc_json_get_next_field(rc_json_object_field_iterator_t* iterator) {
-  const char* json = iterator->json;
+static int rc_json_get_next_field(rc_json_iterator_t* iterator, rc_json_field_t* field) {
+  rc_json_skip_whitespace(iterator);
 
-  while (isspace((unsigned char)*json))
-    ++json;
-
-  if (*json != '"')
+  if (!rc_json_match_char(iterator, '"'))
     return RC_INVALID_JSON;
 
-  iterator->field.name = ++json;
-  while (*json != '"') {
-    if (!*json)
+  field->name = iterator->json;
+  while (iterator->json < iterator->end && *iterator->json != '"') {
+    if (!*iterator->json)
       return RC_INVALID_JSON;
-    ++json;
+    ++iterator->json;
   }
-  iterator->name_len = json - iterator->field.name;
-  ++json;
 
-  while (isspace((unsigned char)*json))
-    ++json;
-
-  if (*json != ':')
+  if (iterator->json == iterator->end)
     return RC_INVALID_JSON;
 
-  ++json;
+  field->name_len = iterator->json - field->name;
+  ++iterator->json;
 
-  while (isspace((unsigned char)*json))
-    ++json;
+  rc_json_skip_whitespace(iterator);
 
-  if (rc_json_parse_field(&json, &iterator->field) < 0)
+  if (!rc_json_match_char(iterator, ':'))
     return RC_INVALID_JSON;
 
-  while (isspace((unsigned char)*json))
-    ++json;
+  rc_json_skip_whitespace(iterator);
 
-  iterator->json = json;
+  if (rc_json_parse_field(iterator, field) < 0)
+    return RC_INVALID_JSON;
+
+  rc_json_skip_whitespace(iterator);
+
   return RC_OK;
 }
 
-static int rc_json_parse_object(const char** json_ptr, rc_json_field_t* fields, size_t field_count, unsigned* fields_seen) {
-  rc_json_object_field_iterator_t iterator;
-  const char* json = *json_ptr;
+static int rc_json_parse_object(rc_json_iterator_t* iterator, rc_json_field_t* fields, size_t field_count, unsigned* fields_seen) {
   size_t i;
   unsigned num_fields = 0;
+  rc_json_field_t field;
   int result;
 
   if (fields_seen)
@@ -179,60 +196,115 @@ static int rc_json_parse_object(const char** json_ptr, rc_json_field_t* fields, 
   for (i = 0; i < field_count; ++i)
     fields[i].value_start = fields[i].value_end = NULL;
 
-  if (*json != '{')
+  if (!rc_json_match_char(iterator, '{'))
     return RC_INVALID_JSON;
-  ++json;
 
-  if (*json == '}') {
-    *json_ptr = ++json;
+  if (rc_json_match_char(iterator, '}')) /* empty object */
     return RC_OK;
-  }
-
-  memset(&iterator, 0, sizeof(iterator));
-  iterator.json = json;
 
   do
   {
-    result = rc_json_get_next_field(&iterator);
+    result = rc_json_get_next_field(iterator, &field);
     if (result != RC_OK)
       return result;
 
     for (i = 0; i < field_count; ++i) {
-      if (!fields[i].value_start && strncmp(fields[i].name, iterator.field.name, iterator.name_len) == 0 &&
-          fields[i].name[iterator.name_len] == '\0') {
-        fields[i].value_start = iterator.field.value_start;
-        fields[i].value_end = iterator.field.value_end;
-        fields[i].array_size = iterator.field.array_size;
+      if (!fields[i].value_start && fields[i].name_len == field.name_len &&
+          memcmp(fields[i].name, field.name, field.name_len) == 0) {
+        fields[i].value_start = field.value_start;
+        fields[i].value_end = field.value_end;
+        fields[i].array_size = field.array_size;
         break;
       }
     }
 
     ++num_fields;
-    if (*iterator.json != ',')
-      break;
 
-    ++iterator.json;
-  } while (1);
+  } while (rc_json_match_char(iterator, ','));
 
-  if (*iterator.json != '}')
+  if (!rc_json_match_char(iterator, '}'))
     return RC_INVALID_JSON;
 
   if (fields_seen)
     *fields_seen = num_fields;
 
-  *json_ptr = ++iterator.json;
   return RC_OK;
 }
 
-int rc_json_get_next_object_field(rc_json_object_field_iterator_t* iterator) {
-  if (*iterator->json != ',' && *iterator->json != '{')
+int rc_json_get_next_object_field(rc_json_iterator_t* iterator, rc_json_field_t* field) {
+  if (!rc_json_match_char(iterator, ',') && !rc_json_match_char(iterator, '{'))
     return 0;
 
-  ++iterator->json;
-  return (rc_json_get_next_field(iterator) == RC_OK);
+  return (rc_json_get_next_field(iterator, field) == RC_OK);
+}
+
+int rc_json_get_object_string_length(const char* json) {
+  const char* json_start = json;
+
+  rc_json_iterator_t iterator;
+  memset(&iterator, 0, sizeof(iterator));
+  iterator.json = json;
+  iterator.end = json + (1024 * 1024 * 1024); /* arbitrary 1GB limit on JSON response */
+
+  rc_json_parse_object(&iterator, NULL, 0, NULL);
+
+  return (int)(iterator.json - json_start);
 }
 
 int rc_json_parse_response(rc_api_response_t* response, const char* json, rc_json_field_t* fields, size_t field_count) {
+  rc_api_server_response_t server_response;
+  memset(&server_response, 0, sizeof(server_response));
+  server_response.body = json;
+  server_response.body_length = rc_json_get_object_string_length(json);
+  return rc_json_parse_server_response(response, &server_response, fields, field_count);
+}
+
+int rc_json_extract_html_error(rc_api_response_t* response, const rc_api_server_response_t* server_response) {
+  const char* json = server_response->body;
+  const char* end = json;
+
+  if (strncmp(json, "<html>", 6) == 0) {
+    const char* title_start = strstr(json, "<title>");
+    if (title_start) {
+      title_start += 7;
+      if (isdigit((int)*title_start)) {
+        const char* title_end = strstr(title_start + 7, "</title>");
+        if (title_end) {
+          char* dst = rc_buf_reserve(&response->buffer, (title_end - title_start) + 1);
+          response->error_message = dst;
+          memcpy(dst, title_start, title_end - title_start);
+          dst += (title_end - title_start);
+          *dst++ = '\0';
+          rc_buf_consume(&response->buffer, response->error_message, dst);
+          response->succeeded = 0;
+          return RC_INVALID_JSON;
+        }
+      }
+    }
+  }
+
+  while (*end && *end != '\n' && end - json < 200)
+    ++end;
+
+  if (end > json && end[-1] == '\r')
+    --end;
+
+  if (end > json) {
+    char* dst = rc_buf_reserve(&response->buffer, (end - json) + 1);
+    response->error_message = dst;
+    memcpy(dst, json, end - json);
+    dst += (end - json);
+    *dst++ = '\0';
+    rc_buf_consume(&response->buffer, response->error_message, dst);
+  }
+
+  response->succeeded = 0;
+  return RC_INVALID_JSON;
+}
+
+int rc_json_parse_server_response(rc_api_response_t* response, const rc_api_server_response_t* server_response, rc_json_field_t* fields, size_t field_count) {
+  int result;
+
 #ifndef NDEBUG
   if (field_count < 2)
     return RC_INVALID_STATE;
@@ -242,63 +314,28 @@ int rc_json_parse_response(rc_api_response_t* response, const char* json, rc_jso
     return RC_INVALID_STATE;
 #endif
 
-  if (!json || !*json) {
+  response->error_message = NULL;
+
+  if (!server_response || !server_response->body || !*server_response->body) {
     response->succeeded = 0;
     return RC_NO_RESPONSE;
   }
 
-  if (*json == '{') {
-    int result = rc_json_parse_object(&json, fields, field_count, NULL);
+  if (*server_response->body != '{') {
+    result = rc_json_extract_html_error(response, server_response);
+  }
+  else {
+    rc_json_iterator_t iterator;
+    memset(&iterator, 0, sizeof(iterator));
+    iterator.json = server_response->body;
+    iterator.end = server_response->body + server_response->body_length;
+    result = rc_json_parse_object(&iterator, fields, field_count, NULL);
 
     rc_json_get_optional_string(&response->error_message, response, &fields[1], "Error", NULL);
     rc_json_get_optional_bool(&response->succeeded, &fields[0], "Success", 1);
-
-    return result;
   }
 
-  response->error_message = NULL;
-
-  if (*json) {
-    const char* end = json;
-
-    if (strncmp(json, "<html>", 6) == 0) {
-      const char* title_start = strstr(json, "<title>");
-      if (title_start) {
-        title_start += 7;
-        if (isdigit((int)*title_start)) {
-          const char* title_end = strstr(title_start + 7, "</title>");
-          if (title_end) {
-            char *dst = rc_buf_reserve(&response->buffer, (title_end - title_start) + 1);
-            response->error_message = dst;
-            memcpy(dst, title_start, title_end - title_start);
-            dst += (title_end - title_start);
-            *dst++ = '\0';
-            rc_buf_consume(&response->buffer, response->error_message, dst);
-            response->succeeded = 0;
-            return RC_INVALID_JSON;
-          }
-        }
-      }
-    }
-
-    while (*end && *end != '\n' && end - json < 200)
-      ++end;
-
-    if (end > json && end[-1] == '\r')
-      --end;
-
-    if (end > json) {
-      char* dst = rc_buf_reserve(&response->buffer, (end - json) + 1);
-      response->error_message = dst;
-      memcpy(dst, json, end - json);
-      dst += (end - json);
-      *dst++ = '\0';
-      rc_buf_consume(&response->buffer, response->error_message, dst);
-    }
-  }
-
-  response->succeeded = 0;
-  return RC_INVALID_JSON;
+  return result;
 }
 
 static int rc_json_missing_field(rc_api_response_t* response, const rc_json_field_t* field) {
@@ -321,7 +358,8 @@ static int rc_json_missing_field(rc_api_response_t* response, const rc_json_fiel
 }
 
 int rc_json_get_required_object(rc_json_field_t* fields, size_t field_count, rc_api_response_t* response, rc_json_field_t* field, const char* field_name) {
-  const char* json = field->value_start;
+  rc_json_iterator_t iterator;
+
 #ifndef NDEBUG
   if (strcmp(field->name, field_name) != 0)
     return 0;
@@ -329,36 +367,39 @@ int rc_json_get_required_object(rc_json_field_t* fields, size_t field_count, rc_
   (void)field_name;
 #endif
 
-  if (!json)
+  if (!field->value_start)
     return rc_json_missing_field(response, field);
 
-  return (rc_json_parse_object(&json, fields, field_count, &field->array_size) == RC_OK);
+  memset(&iterator, 0, sizeof(iterator));
+  iterator.json = field->value_start;
+  iterator.end = field->value_end;
+  return (rc_json_parse_object(&iterator, fields, field_count, &field->array_size) == RC_OK);
 }
 
-static int rc_json_get_array_entry_value(rc_json_field_t* field, rc_json_field_t* iterator) {
-  if (!iterator->array_size)
+static int rc_json_get_array_entry_value(rc_json_field_t* field, rc_json_iterator_t* iterator) {
+  rc_json_skip_whitespace(iterator);
+
+  if (iterator->json >= iterator->end)
     return 0;
 
-  while (isspace((unsigned char)*iterator->value_start))
-    ++iterator->value_start;
+  if (rc_json_parse_field(iterator, field) != RC_OK)
+    return 0;
 
-  rc_json_parse_field(&iterator->value_start, field);
+  rc_json_skip_whitespace(iterator);
 
-  while (isspace((unsigned char)*iterator->value_start))
-    ++iterator->value_start;
+  if (!rc_json_match_char(iterator, ','))
+    rc_json_match_char(iterator, ']');
 
-  ++iterator->value_start; /* skip , or ] */
-
-  --iterator->array_size;
   return 1;
 }
 
 int rc_json_get_required_unum_array(unsigned** entries, unsigned* num_entries, rc_api_response_t* response, const rc_json_field_t* field, const char* field_name) {
-  rc_json_field_t iterator;
+  rc_json_iterator_t iterator;
+  rc_json_field_t array;
   rc_json_field_t value;
   unsigned* entry;
 
-  if (!rc_json_get_required_array(num_entries, &iterator, response, field, field_name))
+  if (!rc_json_get_required_array(num_entries, &array, response, field, field_name))
     return RC_MISSING_VALUE;
 
   if (*num_entries) {
@@ -367,6 +408,10 @@ int rc_json_get_required_unum_array(unsigned** entries, unsigned* num_entries, r
       return RC_OUT_OF_MEMORY;
 
     value.name = field_name;
+
+    memset(&iterator, 0, sizeof(iterator));
+    iterator.json = array.value_start;
+    iterator.end = array.value_end;
 
     entry = *entries;
     while (rc_json_get_array_entry_value(&value, &iterator)) {
@@ -383,7 +428,7 @@ int rc_json_get_required_unum_array(unsigned** entries, unsigned* num_entries, r
   return RC_OK;
 }
 
-int rc_json_get_required_array(unsigned* num_entries, rc_json_field_t* iterator, rc_api_response_t* response, const rc_json_field_t* field, const char* field_name) {
+int rc_json_get_required_array(unsigned* num_entries, rc_json_field_t* array_field, rc_api_response_t* response, const rc_json_field_t* field, const char* field_name) {
 #ifndef NDEBUG
   if (strcmp(field->name, field_name) != 0)
     return 0;
@@ -396,28 +441,27 @@ int rc_json_get_required_array(unsigned* num_entries, rc_json_field_t* iterator,
     return rc_json_missing_field(response, field);
   }
 
-  memcpy(iterator, field, sizeof(*iterator));
-  ++iterator->value_start; /* skip [ */
+  memcpy(array_field, field, sizeof(*array_field));
+  ++array_field->value_start; /* skip [ */
 
   *num_entries = field->array_size;
   return 1;
 }
 
-int rc_json_get_array_entry_object(rc_json_field_t* fields, size_t field_count, rc_json_field_t* iterator) {
-  if (!iterator->array_size)
+int rc_json_get_array_entry_object(rc_json_field_t* fields, size_t field_count, rc_json_iterator_t* iterator) {
+  rc_json_skip_whitespace(iterator);
+
+  if (iterator->json >= iterator->end)
     return 0;
 
-  while (isspace((unsigned char)*iterator->value_start))
-    ++iterator->value_start;
+  if (rc_json_parse_object(iterator, fields, field_count, NULL) != RC_OK)
+    return 0;
 
-  rc_json_parse_object(&iterator->value_start, fields, field_count, NULL);
+  rc_json_skip_whitespace(iterator);
 
-  while (isspace((unsigned char)*iterator->value_start))
-    ++iterator->value_start;
+  if (!rc_json_match_char(iterator, ','))
+    rc_json_match_char(iterator, ']');
 
-  ++iterator->value_start; /* skip , or ] */
-
-  --iterator->array_size;
   return 1;
 }
 

--- a/src/rapi/rc_api_common.h
+++ b/src/rapi/rc_api_common.h
@@ -43,7 +43,6 @@ typedef struct rc_json_iterator_t {
 }
 rc_json_iterator_t;
 
-int rc_json_parse_response(rc_api_response_t* response, const char* json, rc_json_field_t* fields, size_t field_count);
 int rc_json_parse_server_response(rc_api_response_t* response, const rc_api_server_response_t* server_response, rc_json_field_t* fields, size_t field_count);
 int rc_json_get_string(const char** out, rc_api_buffer_t* buffer, const rc_json_field_t* field, const char* field_name);
 int rc_json_get_num(int* out, const rc_json_field_t* field, const char* field_name);

--- a/src/rapi/rc_api_common.h
+++ b/src/rapi/rc_api_common.h
@@ -26,24 +26,25 @@ void rc_url_builder_init(rc_api_url_builder_t* builder, rc_api_buffer_t* buffer,
 void rc_url_builder_append(rc_api_url_builder_t* builder, const char* data, size_t len);
 const char* rc_url_builder_finalize(rc_api_url_builder_t* builder);
 
-#define RC_JSON_NEW_FIELD(n) {n,0,0,0}
+#define RC_JSON_NEW_FIELD(n) {NULL,NULL,n,sizeof(n)-1,0}
 
 typedef struct rc_json_field_t {
-  const char* name;
   const char* value_start;
   const char* value_end;
+  const char* name;
+  size_t name_len;
   unsigned array_size;
 }
 rc_json_field_t;
 
-typedef struct rc_json_object_field_iterator_t {
-  rc_json_field_t field;
+typedef struct rc_json_iterator_t {
   const char* json;
-  size_t name_len;
+  const char* end;
 }
-rc_json_object_field_iterator_t;
+rc_json_iterator_t;
 
 int rc_json_parse_response(rc_api_response_t* response, const char* json, rc_json_field_t* fields, size_t field_count);
+int rc_json_parse_server_response(rc_api_response_t* response, const rc_api_server_response_t* server_response, rc_json_field_t* fields, size_t field_count);
 int rc_json_get_string(const char** out, rc_api_buffer_t* buffer, const rc_json_field_t* field, const char* field_name);
 int rc_json_get_num(int* out, const rc_json_field_t* field, const char* field_name);
 int rc_json_get_unum(unsigned* out, const rc_json_field_t* field, const char* field_name);
@@ -60,9 +61,10 @@ int rc_json_get_required_bool(int* out, rc_api_response_t* response, const rc_js
 int rc_json_get_required_datetime(time_t* out, rc_api_response_t* response, const rc_json_field_t* field, const char* field_name);
 int rc_json_get_required_object(rc_json_field_t* fields, size_t field_count, rc_api_response_t* response, rc_json_field_t* field, const char* field_name);
 int rc_json_get_required_unum_array(unsigned** entries, unsigned* num_entries, rc_api_response_t* response, const rc_json_field_t* field, const char* field_name);
-int rc_json_get_required_array(unsigned* num_entries, rc_json_field_t* iterator, rc_api_response_t* response, const rc_json_field_t* field, const char* field_name);
-int rc_json_get_array_entry_object(rc_json_field_t* fields, size_t field_count, rc_json_field_t* iterator);
-int rc_json_get_next_object_field(rc_json_object_field_iterator_t* iterator);
+int rc_json_get_required_array(unsigned* num_entries, rc_json_field_t* array_field, rc_api_response_t* response, const rc_json_field_t* field, const char* field_name);
+int rc_json_get_array_entry_object(rc_json_field_t* fields, size_t field_count, rc_json_iterator_t* iterator);
+int rc_json_get_next_object_field(rc_json_iterator_t* iterator, rc_json_field_t* field);
+int rc_json_get_object_string_length(const char* json);
 
 void rc_buf_init(rc_api_buffer_t* buffer);
 void rc_buf_destroy(rc_api_buffer_t* buffer);

--- a/src/rapi/rc_api_editor.c
+++ b/src/rapi/rc_api_editor.c
@@ -28,6 +28,16 @@ int rc_api_init_fetch_code_notes_request(rc_api_request_t* request, const rc_api
 }
 
 int rc_api_process_fetch_code_notes_response(rc_api_fetch_code_notes_response_t* response, const char* server_response) {
+  rc_api_server_response_t response_obj;
+
+  memset(&response_obj, 0, sizeof(response_obj));
+  response_obj.body = server_response;
+  response_obj.body_length = rc_json_get_object_string_length(server_response);
+
+  return rc_api_process_fetch_code_notes_server_response(response, &response_obj);
+}
+
+int rc_api_process_fetch_code_notes_server_response(rc_api_fetch_code_notes_response_t* response, const rc_api_server_response_t* server_response) {
   rc_json_field_t array_field;
   rc_json_iterator_t iterator;
   rc_api_code_note_t* note;
@@ -52,7 +62,7 @@ int rc_api_process_fetch_code_notes_response(rc_api_fetch_code_notes_response_t*
   memset(response, 0, sizeof(*response));
   rc_buf_init(&response->response.buffer);
 
-  result = rc_json_parse_response(&response->response, server_response, fields, sizeof(fields) / sizeof(fields[0]));
+  result = rc_json_parse_server_response(&response->response, server_response, fields, sizeof(fields) / sizeof(fields[0]));
   if (result != RC_OK || !response->response.succeeded)
     return result;
 
@@ -137,6 +147,16 @@ int rc_api_init_update_code_note_request(rc_api_request_t* request, const rc_api
 }
 
 int rc_api_process_update_code_note_response(rc_api_update_code_note_response_t* response, const char* server_response) {
+  rc_api_server_response_t response_obj;
+
+  memset(&response_obj, 0, sizeof(response_obj));
+  response_obj.body = server_response;
+  response_obj.body_length = rc_json_get_object_string_length(server_response);
+
+  return rc_api_process_update_code_note_server_response(response, &response_obj);
+}
+
+int rc_api_process_update_code_note_server_response(rc_api_update_code_note_response_t* response, const rc_api_server_response_t* server_response) {
   int result;
 
   rc_json_field_t fields[] = {
@@ -152,7 +172,7 @@ int rc_api_process_update_code_note_response(rc_api_update_code_note_response_t*
   memset(response, 0, sizeof(*response));
   rc_buf_init(&response->response.buffer);
 
-  result = rc_json_parse_response(&response->response, server_response, fields, sizeof(fields) / sizeof(fields[0]));
+  result = rc_json_parse_server_response(&response->response, server_response, fields, sizeof(fields) / sizeof(fields[0]));
   if (result != RC_OK || !response->response.succeeded)
     return result;
 
@@ -221,6 +241,16 @@ int rc_api_init_update_achievement_request(rc_api_request_t* request, const rc_a
 }
 
 int rc_api_process_update_achievement_response(rc_api_update_achievement_response_t* response, const char* server_response) {
+  rc_api_server_response_t response_obj;
+
+  memset(&response_obj, 0, sizeof(response_obj));
+  response_obj.body = server_response;
+  response_obj.body_length = rc_json_get_object_string_length(server_response);
+
+  return rc_api_process_update_achievement_server_response(response, &response_obj);
+}
+
+int rc_api_process_update_achievement_server_response(rc_api_update_achievement_response_t* response, const rc_api_server_response_t* server_response) {
   int result;
 
   rc_json_field_t fields[] = {
@@ -232,7 +262,7 @@ int rc_api_process_update_achievement_response(rc_api_update_achievement_respons
   memset(response, 0, sizeof(*response));
   rc_buf_init(&response->response.buffer);
 
-  result = rc_json_parse_response(&response->response, server_response, fields, sizeof(fields) / sizeof(fields[0]));
+  result = rc_json_parse_server_response(&response->response, server_response, fields, sizeof(fields) / sizeof(fields[0]));
   if (result != RC_OK || !response->response.succeeded)
     return result;
 
@@ -313,6 +343,16 @@ int rc_api_init_update_leaderboard_request(rc_api_request_t* request, const rc_a
 }
 
 int rc_api_process_update_leaderboard_response(rc_api_update_leaderboard_response_t* response, const char* server_response) {
+  rc_api_server_response_t response_obj;
+
+  memset(&response_obj, 0, sizeof(response_obj));
+  response_obj.body = server_response;
+  response_obj.body_length = rc_json_get_object_string_length(server_response);
+
+  return rc_api_process_update_leaderboard_server_response(response, &response_obj);
+}
+
+int rc_api_process_update_leaderboard_server_response(rc_api_update_leaderboard_response_t* response, const rc_api_server_response_t* server_response) {
     int result;
 
     rc_json_field_t fields[] = {
@@ -324,7 +364,7 @@ int rc_api_process_update_leaderboard_response(rc_api_update_leaderboard_respons
     memset(response, 0, sizeof(*response));
     rc_buf_init(&response->response.buffer);
 
-    result = rc_json_parse_response(&response->response, server_response, fields, sizeof(fields) / sizeof(fields[0]));
+    result = rc_json_parse_server_response(&response->response, server_response, fields, sizeof(fields) / sizeof(fields[0]));
     if (result != RC_OK || !response->response.succeeded)
         return result;
 
@@ -357,6 +397,16 @@ int rc_api_init_fetch_badge_range_request(rc_api_request_t* request, const rc_ap
 }
 
 int rc_api_process_fetch_badge_range_response(rc_api_fetch_badge_range_response_t* response, const char* server_response) {
+  rc_api_server_response_t response_obj;
+
+  memset(&response_obj, 0, sizeof(response_obj));
+  response_obj.body = server_response;
+  response_obj.body_length = rc_json_get_object_string_length(server_response);
+
+  return rc_api_process_fetch_badge_range_server_response(response, &response_obj);
+}
+
+int rc_api_process_fetch_badge_range_server_response(rc_api_fetch_badge_range_response_t* response, const rc_api_server_response_t* server_response) {
   int result;
 
   rc_json_field_t fields[] = {
@@ -369,7 +419,7 @@ int rc_api_process_fetch_badge_range_response(rc_api_fetch_badge_range_response_
   memset(response, 0, sizeof(*response));
   rc_buf_init(&response->response.buffer);
 
-  result = rc_json_parse_response(&response->response, server_response, fields, sizeof(fields) / sizeof(fields[0]));
+  result = rc_json_parse_server_response(&response->response, server_response, fields, sizeof(fields) / sizeof(fields[0]));
   if (result != RC_OK || !response->response.succeeded)
     return result;
 
@@ -419,6 +469,16 @@ int rc_api_init_add_game_hash_request(rc_api_request_t* request, const rc_api_ad
 }
 
 int rc_api_process_add_game_hash_response(rc_api_add_game_hash_response_t* response, const char* server_response) {
+  rc_api_server_response_t response_obj;
+
+  memset(&response_obj, 0, sizeof(response_obj));
+  response_obj.body = server_response;
+  response_obj.body_length = rc_json_get_object_string_length(server_response);
+
+  return rc_api_process_add_game_hash_server_response(response, &response_obj);
+}
+
+int rc_api_process_add_game_hash_server_response(rc_api_add_game_hash_response_t* response, const rc_api_server_response_t* server_response) {
   int result;
 
   rc_json_field_t fields[] = {
@@ -440,7 +500,7 @@ int rc_api_process_add_game_hash_response(rc_api_add_game_hash_response_t* respo
   memset(response, 0, sizeof(*response));
   rc_buf_init(&response->response.buffer);
 
-  result = rc_json_parse_response(&response->response, server_response, fields, sizeof(fields) / sizeof(fields[0]));
+  result = rc_json_parse_server_response(&response->response, server_response, fields, sizeof(fields) / sizeof(fields[0]));
   if (result != RC_OK || !response->response.succeeded)
     return result;
 

--- a/src/rapi/rc_api_info.c
+++ b/src/rapi/rc_api_info.c
@@ -34,6 +34,16 @@ int rc_api_init_fetch_achievement_info_request(rc_api_request_t* request, const 
 }
 
 int rc_api_process_fetch_achievement_info_response(rc_api_fetch_achievement_info_response_t* response, const char* server_response) {
+  rc_api_server_response_t response_obj;
+
+  memset(&response_obj, 0, sizeof(response_obj));
+  response_obj.body = server_response;
+  response_obj.body_length = rc_json_get_object_string_length(server_response);
+
+  return rc_api_process_fetch_achievement_info_server_response(response, &response_obj);
+}
+
+int rc_api_process_fetch_achievement_info_server_response(rc_api_fetch_achievement_info_response_t* response, const rc_api_server_response_t* server_response) {
   rc_api_achievement_awarded_entry_t* entry;
   rc_json_field_t array_field;
   rc_json_iterator_t iterator;
@@ -67,7 +77,7 @@ int rc_api_process_fetch_achievement_info_response(rc_api_fetch_achievement_info
   memset(response, 0, sizeof(*response));
   rc_buf_init(&response->response.buffer);
 
-  result = rc_json_parse_response(&response->response, server_response, fields, sizeof(fields) / sizeof(fields[0]));
+  result = rc_json_parse_server_response(&response->response, server_response, fields, sizeof(fields) / sizeof(fields[0]));
   if (result != RC_OK)
     return result;
 
@@ -142,6 +152,16 @@ int rc_api_init_fetch_leaderboard_info_request(rc_api_request_t* request, const 
 }
 
 int rc_api_process_fetch_leaderboard_info_response(rc_api_fetch_leaderboard_info_response_t* response, const char* server_response) {
+  rc_api_server_response_t response_obj;
+
+  memset(&response_obj, 0, sizeof(response_obj));
+  response_obj.body = server_response;
+  response_obj.body_length = rc_json_get_object_string_length(server_response);
+
+  return rc_api_process_fetch_leaderboard_info_server_response(response, &response_obj);
+}
+
+int rc_api_process_fetch_leaderboard_info_server_response(rc_api_fetch_leaderboard_info_response_t* response, const rc_api_server_response_t* server_response) {
   rc_api_lboard_info_entry_t* entry;
   rc_json_field_t array_field;
   rc_json_iterator_t iterator;
@@ -188,7 +208,7 @@ int rc_api_process_fetch_leaderboard_info_response(rc_api_fetch_leaderboard_info
   memset(response, 0, sizeof(*response));
   rc_buf_init(&response->response.buffer);
 
-  result = rc_json_parse_response(&response->response, server_response, fields, sizeof(fields) / sizeof(fields[0]));
+  result = rc_json_parse_server_response(&response->response, server_response, fields, sizeof(fields) / sizeof(fields[0]));
   if (result != RC_OK)
     return result;
 
@@ -288,6 +308,16 @@ int rc_api_init_fetch_games_list_request(rc_api_request_t* request, const rc_api
 }
 
 int rc_api_process_fetch_games_list_response(rc_api_fetch_games_list_response_t* response, const char* server_response) {
+  rc_api_server_response_t response_obj;
+
+  memset(&response_obj, 0, sizeof(response_obj));
+  response_obj.body = server_response;
+  response_obj.body_length = rc_json_get_object_string_length(server_response);
+
+  return rc_api_process_fetch_games_list_server_response(response, &response_obj);
+}
+
+int rc_api_process_fetch_games_list_server_response(rc_api_fetch_games_list_response_t* response, const rc_api_server_response_t* server_response) {
   rc_api_game_list_entry_t* entry;
   rc_json_iterator_t iterator;
   rc_json_field_t field;
@@ -303,7 +333,7 @@ int rc_api_process_fetch_games_list_response(rc_api_fetch_games_list_response_t*
   memset(response, 0, sizeof(*response));
   rc_buf_init(&response->response.buffer);
 
-  result = rc_json_parse_response(&response->response, server_response, fields, sizeof(fields) / sizeof(fields[0]));
+  result = rc_json_parse_server_response(&response->response, server_response, fields, sizeof(fields) / sizeof(fields[0]));
   if (result != RC_OK)
     return result;
 

--- a/src/rapi/rc_api_runtime.c
+++ b/src/rapi/rc_api_runtime.c
@@ -75,7 +75,8 @@ int rc_api_init_fetch_game_data_request(rc_api_request_t* request, const rc_api_
 int rc_api_process_fetch_game_data_response(rc_api_fetch_game_data_response_t* response, const char* server_response) {
   rc_api_achievement_definition_t* achievement;
   rc_api_leaderboard_definition_t* leaderboard;
-  rc_json_field_t iterator;
+  rc_json_field_t array_field;
+  rc_json_iterator_t iterator;
   const char* str;
   const char* last_author = "";
   const char* last_author_field = "";
@@ -177,13 +178,17 @@ int rc_api_process_fetch_game_data_response(rc_api_fetch_game_data_response_t* r
   if (!response->rich_presence_script)
     response->rich_presence_script = "";
 
-  if (!rc_json_get_required_array(&response->num_achievements, &iterator, &response->response, &patchdata_fields[5], "Achievements"))
+  if (!rc_json_get_required_array(&response->num_achievements, &array_field, &response->response, &patchdata_fields[5], "Achievements"))
     return RC_MISSING_VALUE;
 
   if (response->num_achievements) {
     response->achievements = (rc_api_achievement_definition_t*)rc_buf_alloc(&response->response.buffer, response->num_achievements * sizeof(rc_api_achievement_definition_t));
     if (!response->achievements)
       return RC_OUT_OF_MEMORY;
+
+    memset(&iterator, 0, sizeof(iterator));
+    iterator.json = array_field.value_start;
+    iterator.end = array_field.value_end;
 
     achievement = response->achievements;
     while (rc_json_get_array_entry_object(achievement_fields, sizeof(achievement_fields) / sizeof(achievement_fields[0]), &iterator)) {
@@ -226,13 +231,17 @@ int rc_api_process_fetch_game_data_response(rc_api_fetch_game_data_response_t* r
     }
   }
 
-  if (!rc_json_get_required_array(&response->num_leaderboards, &iterator, &response->response, &patchdata_fields[6], "Leaderboards"))
+  if (!rc_json_get_required_array(&response->num_leaderboards, &array_field, &response->response, &patchdata_fields[6], "Leaderboards"))
     return RC_MISSING_VALUE;
 
   if (response->num_leaderboards) {
     response->leaderboards = (rc_api_leaderboard_definition_t*)rc_buf_alloc(&response->response.buffer, response->num_leaderboards * sizeof(rc_api_leaderboard_definition_t));
     if (!response->leaderboards)
       return RC_OUT_OF_MEMORY;
+
+    memset(&iterator, 0, sizeof(iterator));
+    iterator.json = array_field.value_start;
+    iterator.end = array_field.value_end;
 
     leaderboard = response->leaderboards;
     while (rc_json_get_array_entry_object(leaderboard_fields, sizeof(leaderboard_fields) / sizeof(leaderboard_fields[0]), &iterator)) {
@@ -432,7 +441,8 @@ int rc_api_init_submit_lboard_entry_request(rc_api_request_t* request, const rc_
 
 int rc_api_process_submit_lboard_entry_response(rc_api_submit_lboard_entry_response_t* response, const char* server_response) {
   rc_api_lboard_entry_t* entry;
-  rc_json_field_t iterator;
+  rc_json_field_t array_field;
+  rc_json_iterator_t iterator;
   const char* str;
   int result;
 
@@ -504,13 +514,17 @@ int rc_api_process_submit_lboard_entry_response(rc_api_submit_lboard_entry_respo
     return RC_MISSING_VALUE;
   response->num_entries = (unsigned)atoi(str);
 
-  if (!rc_json_get_required_array(&response->num_top_entries, &iterator, &response->response, &response_fields[3], "TopEntries"))
+  if (!rc_json_get_required_array(&response->num_top_entries, &array_field, &response->response, &response_fields[3], "TopEntries"))
     return RC_MISSING_VALUE;
 
   if (response->num_top_entries) {
     response->top_entries = (rc_api_lboard_entry_t*)rc_buf_alloc(&response->response.buffer, response->num_top_entries * sizeof(rc_api_lboard_entry_t));
     if (!response->top_entries)
       return RC_OUT_OF_MEMORY;
+
+    memset(&iterator, 0, sizeof(iterator));
+    iterator.json = array_field.value_start;
+    iterator.end = array_field.value_end;
 
     entry = response->top_entries;
     while (rc_json_get_array_entry_object(entry_fields, sizeof(entry_fields) / sizeof(entry_fields[0]), &iterator)) {

--- a/src/rapi/rc_api_runtime.c
+++ b/src/rapi/rc_api_runtime.c
@@ -30,6 +30,16 @@ int rc_api_init_resolve_hash_request(rc_api_request_t* request, const rc_api_res
 }
 
 int rc_api_process_resolve_hash_response(rc_api_resolve_hash_response_t* response, const char* server_response) {
+  rc_api_server_response_t response_obj;
+
+  memset(&response_obj, 0, sizeof(response_obj));
+  response_obj.body = server_response;
+  response_obj.body_length = rc_json_get_object_string_length(server_response);
+
+  return rc_api_process_resolve_hash_server_response(response, &response_obj);
+}
+
+int rc_api_process_resolve_hash_server_response(rc_api_resolve_hash_response_t* response, const rc_api_server_response_t* server_response) {
   int result;
   rc_json_field_t fields[] = {
     RC_JSON_NEW_FIELD("Success"),
@@ -40,7 +50,7 @@ int rc_api_process_resolve_hash_response(rc_api_resolve_hash_response_t* respons
   memset(response, 0, sizeof(*response));
   rc_buf_init(&response->response.buffer);
 
-  result = rc_json_parse_response(&response->response, server_response, fields, sizeof(fields) / sizeof(fields[0]));
+  result = rc_json_parse_server_response(&response->response, server_response, fields, sizeof(fields) / sizeof(fields[0]));
   if (result != RC_OK)
     return result;
 
@@ -73,6 +83,16 @@ int rc_api_init_fetch_game_data_request(rc_api_request_t* request, const rc_api_
 }
 
 int rc_api_process_fetch_game_data_response(rc_api_fetch_game_data_response_t* response, const char* server_response) {
+  rc_api_server_response_t response_obj;
+
+  memset(&response_obj, 0, sizeof(response_obj));
+  response_obj.body = server_response;
+  response_obj.body_length = rc_json_get_object_string_length(server_response);
+
+  return rc_api_process_fetch_game_data_server_response(response, &response_obj);
+}
+
+int rc_api_process_fetch_game_data_server_response(rc_api_fetch_game_data_response_t* response, const rc_api_server_response_t* server_response) {
   rc_api_achievement_definition_t* achievement;
   rc_api_leaderboard_definition_t* leaderboard;
   rc_json_field_t array_field;
@@ -132,7 +152,7 @@ int rc_api_process_fetch_game_data_response(rc_api_fetch_game_data_response_t* r
   memset(response, 0, sizeof(*response));
   rc_buf_init(&response->response.buffer);
 
-  result = rc_json_parse_response(&response->response, server_response, fields, sizeof(fields) / sizeof(fields[0]));
+  result = rc_json_parse_server_response(&response->response, server_response, fields, sizeof(fields) / sizeof(fields[0]));
   if (result != RC_OK || !response->response.succeeded)
     return result;
 
@@ -304,6 +324,16 @@ int rc_api_init_ping_request(rc_api_request_t* request, const rc_api_ping_reques
 }
 
 int rc_api_process_ping_response(rc_api_ping_response_t* response, const char* server_response) {
+  rc_api_server_response_t response_obj;
+
+  memset(&response_obj, 0, sizeof(response_obj));
+  response_obj.body = server_response;
+  response_obj.body_length = rc_json_get_object_string_length(server_response);
+
+  return rc_api_process_ping_server_response(response, &response_obj);
+}
+
+int rc_api_process_ping_server_response(rc_api_ping_response_t* response, const rc_api_server_response_t* server_response) {
   rc_json_field_t fields[] = {
     RC_JSON_NEW_FIELD("Success"),
     RC_JSON_NEW_FIELD("Error")
@@ -312,7 +342,7 @@ int rc_api_process_ping_response(rc_api_ping_response_t* response, const char* s
   memset(response, 0, sizeof(*response));
   rc_buf_init(&response->response.buffer);
 
-  return rc_json_parse_response(&response->response, server_response, fields, sizeof(fields) / sizeof(fields[0]));
+  return rc_json_parse_server_response(&response->response, server_response, fields, sizeof(fields) / sizeof(fields[0]));
 }
 
 void rc_api_destroy_ping_response(rc_api_ping_response_t* response) {
@@ -358,6 +388,16 @@ int rc_api_init_award_achievement_request(rc_api_request_t* request, const rc_ap
 }
 
 int rc_api_process_award_achievement_response(rc_api_award_achievement_response_t* response, const char* server_response) {
+  rc_api_server_response_t response_obj;
+
+  memset(&response_obj, 0, sizeof(response_obj));
+  response_obj.body = server_response;
+  response_obj.body_length = rc_json_get_object_string_length(server_response);
+
+  return rc_api_process_award_achievement_server_response(response, &response_obj);
+}
+
+int rc_api_process_award_achievement_server_response(rc_api_award_achievement_response_t* response, const rc_api_server_response_t* server_response) {
   int result;
   rc_json_field_t fields[] = {
     RC_JSON_NEW_FIELD("Success"),
@@ -371,7 +411,7 @@ int rc_api_process_award_achievement_response(rc_api_award_achievement_response_
   memset(response, 0, sizeof(*response));
   rc_buf_init(&response->response.buffer);
 
-  result = rc_json_parse_response(&response->response, server_response, fields, sizeof(fields) / sizeof(fields[0]));
+  result = rc_json_parse_server_response(&response->response, server_response, fields, sizeof(fields) / sizeof(fields[0]));
   if (result != RC_OK)
     return result;
 
@@ -440,6 +480,16 @@ int rc_api_init_submit_lboard_entry_request(rc_api_request_t* request, const rc_
 }
 
 int rc_api_process_submit_lboard_entry_response(rc_api_submit_lboard_entry_response_t* response, const char* server_response) {
+  rc_api_server_response_t response_obj;
+
+  memset(&response_obj, 0, sizeof(response_obj));
+  response_obj.body = server_response;
+  response_obj.body_length = rc_json_get_object_string_length(server_response);
+
+  return rc_api_process_submit_lboard_entry_server_response(response, &response_obj);
+}
+
+int rc_api_process_submit_lboard_entry_server_response(rc_api_submit_lboard_entry_response_t* response, const rc_api_server_response_t* server_response) {
   rc_api_lboard_entry_t* entry;
   rc_json_field_t array_field;
   rc_json_iterator_t iterator;
@@ -495,7 +545,7 @@ int rc_api_process_submit_lboard_entry_response(rc_api_submit_lboard_entry_respo
   memset(response, 0, sizeof(*response));
   rc_buf_init(&response->response.buffer);
 
-  result = rc_json_parse_response(&response->response, server_response, fields, sizeof(fields) / sizeof(fields[0]));
+  result = rc_json_parse_server_response(&response->response, server_response, fields, sizeof(fields) / sizeof(fields[0]));
   if (result != RC_OK || !response->response.succeeded)
     return result;
 

--- a/src/rapi/rc_api_user.c
+++ b/src/rapi/rc_api_user.c
@@ -33,6 +33,14 @@ int rc_api_init_login_request(rc_api_request_t* request, const rc_api_login_requ
 }
 
 int rc_api_process_login_response(rc_api_login_response_t* response, const char* server_response) {
+  rc_api_server_response_t response_obj;
+  memset(&response_obj, 0, sizeof(response_obj));
+  response_obj.body = server_response;
+  response_obj.body_length = rc_json_get_object_string_length(server_response);
+  return rc_api_process_login_server_response(response, &response_obj);
+}
+
+int rc_api_process_login_server_response(rc_api_login_response_t* response, const rc_api_server_response_t* server_response) {
   int result;
   rc_json_field_t fields[] = {
     RC_JSON_NEW_FIELD("Success"),
@@ -48,7 +56,7 @@ int rc_api_process_login_response(rc_api_login_response_t* response, const char*
   memset(response, 0, sizeof(*response));
   rc_buf_init(&response->response.buffer);
 
-  result = rc_json_parse_response(&response->response, server_response, fields, sizeof(fields) / sizeof(fields[0]));
+  result = rc_json_parse_server_response(&response->response, server_response, fields, sizeof(fields) / sizeof(fields[0]));
   if (result != RC_OK || !response->response.succeeded)
     return result;
 

--- a/src/rapi/rc_api_user.c
+++ b/src/rapi/rc_api_user.c
@@ -34,9 +34,11 @@ int rc_api_init_login_request(rc_api_request_t* request, const rc_api_login_requ
 
 int rc_api_process_login_response(rc_api_login_response_t* response, const char* server_response) {
   rc_api_server_response_t response_obj;
+
   memset(&response_obj, 0, sizeof(response_obj));
   response_obj.body = server_response;
   response_obj.body_length = rc_json_get_object_string_length(server_response);
+
   return rc_api_process_login_server_response(response, &response_obj);
 }
 
@@ -108,6 +110,16 @@ int rc_api_init_start_session_request(rc_api_request_t* request, const rc_api_st
 }
 
 int rc_api_process_start_session_response(rc_api_start_session_response_t* response, const char* server_response) {
+  rc_api_server_response_t response_obj;
+
+  memset(&response_obj, 0, sizeof(response_obj));
+  response_obj.body = server_response;
+  response_obj.body_length = rc_json_get_object_string_length(server_response);
+
+  return rc_api_process_start_session_server_response(response, &response_obj);
+}
+
+int rc_api_process_start_session_server_response(rc_api_start_session_response_t* response, const rc_api_server_response_t* server_response) {
   rc_json_field_t fields[] = {
     RC_JSON_NEW_FIELD("Success"),
     RC_JSON_NEW_FIELD("Error")
@@ -116,7 +128,7 @@ int rc_api_process_start_session_response(rc_api_start_session_response_t* respo
   memset(response, 0, sizeof(*response));
   rc_buf_init(&response->response.buffer);
 
-  return rc_json_parse_response(&response->response, server_response, fields, sizeof(fields) / sizeof(fields[0]));
+  return rc_json_parse_server_response(&response->response, server_response, fields, sizeof(fields) / sizeof(fields[0]));
 }
 
 void rc_api_destroy_start_session_response(rc_api_start_session_response_t* response) {
@@ -142,6 +154,16 @@ int rc_api_init_fetch_user_unlocks_request(rc_api_request_t* request, const rc_a
 }
 
 int rc_api_process_fetch_user_unlocks_response(rc_api_fetch_user_unlocks_response_t* response, const char* server_response) {
+  rc_api_server_response_t response_obj;
+
+  memset(&response_obj, 0, sizeof(response_obj));
+  response_obj.body = server_response;
+  response_obj.body_length = rc_json_get_object_string_length(server_response);
+
+  return rc_api_process_fetch_user_unlocks_server_response(response, &response_obj);
+}
+
+int rc_api_process_fetch_user_unlocks_server_response(rc_api_fetch_user_unlocks_response_t* response, const rc_api_server_response_t* server_response) {
   int result;
   rc_json_field_t fields[] = {
     RC_JSON_NEW_FIELD("Success"),
@@ -156,7 +178,7 @@ int rc_api_process_fetch_user_unlocks_response(rc_api_fetch_user_unlocks_respons
   memset(response, 0, sizeof(*response));
   rc_buf_init(&response->response.buffer);
 
-  result = rc_json_parse_response(&response->response, server_response, fields, sizeof(fields) / sizeof(fields[0]));
+  result = rc_json_parse_server_response(&response->response, server_response, fields, sizeof(fields) / sizeof(fields[0]));
   if (result != RC_OK || !response->response.succeeded)
     return result;
 

--- a/src/rcheevos/rc_client.c
+++ b/src/rcheevos/rc_client.c
@@ -307,7 +307,7 @@ static void rc_client_login_callback(const rc_api_server_response_t* server_resp
     return;
   }
 
-  result = rc_api_process_login_response(&login_response, server_response->body);
+  result = rc_api_process_login_server_response(&login_response, server_response);
   error_message = rc_client_server_error_message(&result, server_response->http_status_code, &login_response.response);
   if (error_message) {
     rc_mutex_lock(&client->state.mutex);
@@ -1112,7 +1112,7 @@ static void rc_client_start_session_callback(const rc_api_server_response_t* ser
     return;
   }
 
-  result = rc_api_process_start_session_response(&start_session_response, server_response->body);
+  result = rc_api_process_start_session_server_response(&start_session_response, server_response);
   error_message = rc_client_server_error_message(&result, server_response->http_status_code, &start_session_response.response);
   outstanding_requests = rc_client_end_load_state(load_state);
 
@@ -1145,7 +1145,7 @@ static void rc_client_unlocks_callback(const rc_api_server_response_t* server_re
     return;
   }
 
-  result = rc_api_process_fetch_user_unlocks_response(&fetch_user_unlocks_response, server_response->body);
+  result = rc_api_process_fetch_user_unlocks_server_response(&fetch_user_unlocks_response, server_response);
   error_message = rc_client_server_error_message(&result, server_response->http_status_code, &fetch_user_unlocks_response.response);
   outstanding_requests = rc_client_end_load_state(load_state);
 
@@ -1467,7 +1467,7 @@ static void rc_client_fetch_game_data_callback(const rc_api_server_response_t* s
     return;
   }
 
-  result = rc_api_process_fetch_game_data_response(&fetch_game_data_response, server_response->body);
+  result = rc_api_process_fetch_game_data_server_response(&fetch_game_data_response, server_response);
   error_message = rc_client_server_error_message(&result, server_response->http_status_code, &fetch_game_data_response.response);
 
   outstanding_requests = rc_client_end_load_state(load_state);
@@ -1695,7 +1695,7 @@ static void rc_client_identify_game_callback(const rc_api_server_response_t* ser
     return;
   }
 
-  result = rc_api_process_resolve_hash_response(&resolve_hash_response, server_response->body);
+  result = rc_api_process_resolve_hash_server_response(&resolve_hash_response, server_response);
   error_message = rc_client_server_error_message(&result, server_response->http_status_code, &resolve_hash_response.response);
 
   if (error_message) {
@@ -2037,7 +2037,7 @@ static void rc_client_identify_changed_media_callback(const rc_api_server_respon
   rc_client_t* client = load_state->client;
   rc_api_resolve_hash_response_t resolve_hash_response;
 
-  int result = rc_api_process_resolve_hash_response(&resolve_hash_response, server_response->body);
+  int result = rc_api_process_resolve_hash_server_response(&resolve_hash_response, server_response);
   const char* error_message = rc_client_server_error_message(&result, server_response->http_status_code, &resolve_hash_response.response);
 
   if (rc_client_async_handle_aborted(client, &load_state->async_handle)) {
@@ -2683,7 +2683,7 @@ static void rc_client_award_achievement_callback(const rc_api_server_response_t*
       (rc_client_award_achievement_callback_data_t*)callback_data;
   rc_api_award_achievement_response_t award_achievement_response;
 
-  int result = rc_api_process_award_achievement_response(&award_achievement_response, server_response->body);
+  int result = rc_api_process_award_achievement_server_response(&award_achievement_response, server_response);
   const char* error_message = rc_client_server_error_message(&result, server_response->http_status_code, &award_achievement_response.response);
 
   if (error_message) {
@@ -3243,7 +3243,7 @@ static void rc_client_submit_leaderboard_entry_callback(const rc_api_server_resp
       (rc_client_submit_leaderboard_entry_callback_data_t*)callback_data;
   rc_api_submit_lboard_entry_response_t submit_lboard_entry_response;
 
-  int result = rc_api_process_submit_lboard_entry_response(&submit_lboard_entry_response, server_response->body);
+  int result = rc_api_process_submit_lboard_entry_server_response(&submit_lboard_entry_response, server_response);
   const char* error_message = rc_client_server_error_message(&result, server_response->http_status_code, &submit_lboard_entry_response.response);
 
   if (error_message) {
@@ -3404,7 +3404,7 @@ static void rc_client_fetch_leaderboard_entries_callback(const rc_api_server_res
     return;
   }
 
-  result = rc_api_process_fetch_leaderboard_info_response(&lbinfo_response, server_response->body);
+  result = rc_api_process_fetch_leaderboard_info_server_response(&lbinfo_response, server_response);
   error_message = rc_client_server_error_message(&result, server_response->http_status_code, &lbinfo_response.response);
   if (error_message) {
     RC_CLIENT_LOG_ERR_FORMATTED(client, "Fetch leaderboard %u info failed: %s", lbinfo_callback_data->leaderboard_id, error_message);
@@ -3543,7 +3543,7 @@ static void rc_client_ping_callback(const rc_api_server_response_t* server_respo
   rc_client_t* client = (rc_client_t*)callback_data;
   rc_api_ping_response_t response;
 
-  int result = rc_api_process_ping_response(&response, server_response->body);
+  int result = rc_api_process_ping_server_response(&response, server_response);
   const char* error_message = rc_client_server_error_message(&result, server_response->http_status_code, &response.response);
   if (error_message) {
     RC_CLIENT_LOG_WARN_FORMATTED(client, "Ping response error: %s", error_message);

--- a/test/rapi/test_rc_api_common.c
+++ b/test/rapi/test_rc_api_common.c
@@ -11,9 +11,9 @@
 static void _assert_json_parse_response(rc_api_response_t* response, rc_json_field_t* field, const char* json, int expected_result) {
   int result;
   rc_json_field_t fields[] = {
-    {"Success"},
-    {"Error"},
-    {"Test"}
+    RC_JSON_NEW_FIELD("Success"),
+    RC_JSON_NEW_FIELD("Error"),
+    RC_JSON_NEW_FIELD("Test")
   };
   rc_buf_init(&response->buffer);
 
@@ -65,9 +65,9 @@ static void test_json_parse_response_non_json() {
   int result;
   rc_api_response_t response;
   rc_json_field_t fields[] = {
-    {"Success"},
-    {"Error"},
-    {"Test"}
+    RC_JSON_NEW_FIELD("Success"),
+    RC_JSON_NEW_FIELD("Error"),
+    RC_JSON_NEW_FIELD("Test")
   };
   rc_buf_init(&response.buffer);
 
@@ -83,9 +83,9 @@ static void test_json_parse_response_error_from_server() {
   int result;
   rc_api_response_t response;
   rc_json_field_t fields[] = {
-    {"Success"},
-    {"Error"},
-    {"Test"}
+    RC_JSON_NEW_FIELD("Success"),
+    RC_JSON_NEW_FIELD("Error"),
+    RC_JSON_NEW_FIELD("Test")
   };
   rc_buf_init(&response.buffer);
 

--- a/test/rapi/test_rc_api_runtime.c
+++ b/test/rapi/test_rc_api_runtime.c
@@ -722,6 +722,64 @@ static void test_process_award_achievement_response_429_json() {
   rc_api_destroy_award_achievement_response(&award_achievement_response);
 }
 
+static void test_process_award_achievement_response_503_fancy() {
+  rc_api_award_achievement_response_t award_achievement_response;
+  const char* server_response =
+    "<!DOCTYPE html>\n"
+    "<html>\n"
+    "<head>\n"
+    "  <meta charset='utf-8'>\n"
+    "  <meta name='viewport' content='width=device-width, initial-scale=1'>\n"
+    "  <style>\n"
+    "  body {\n"
+    "    background-color: #1a1a1a;\n"
+    "    color: white; width: 100%;\n"
+    "  }\n"
+    "  a {\n"
+    "    color: #cc9900;\n"
+    "    text-decoration: none;\n"
+    "  }\n"
+    "  .center {\n"
+    "    margin: 0;\n"
+    "    padding: 0;\n"
+    "    text - align: center;\n"
+    "    position: absolute;\n"
+    "    top: 50%;\n"
+    "    left: 50%;\n"
+    "    transform: translateX(-50%) translateY(-50%);\n"
+    "  }\n"
+    "  </style>\n"
+    "  <title>503 Service Temporarily Unavailable</title>\n"
+    "</head>\n"
+    "<body style='background-color: #1a1a1a; color:white; width:100%;'>\n"
+    "<div class='center'>\n"
+    "  <img style='text-align: center; width: 75%;' src = 'https://static.retroachievements.org/assets/images/ra-logo-sm.webp'>\n"
+    "  <h1>503</h1>\n"
+    "  <h2>Service Temporarily Unavailable</h2>\n"
+    "  <img src='https://static.retroachievements.org/assets/images/cheevo/sad.webp' alt='Sad Cheevo'>\n"
+    "  <p>The RetroAchievements website is currently offline, we apologize for any inconvenience caused.</p>\n"
+    "  <p><strong><u>You can still earn achievements in any supported emulator.</u></strong></p>\n"
+    "  <p><strong>Make sure that the emulator has informed you that you have successfully logged in before you begin playing to avoid missing unlocks.</strong></p>\n"
+    "  <p>For more information and updates, please join our <a href='https://discord.gg/retroachievements'>Discord</a>.</p>\n"
+    "  <br/>\n"
+    "  <a href='https://retroachievements.org'>retroachievements.org</a>\n"
+    "</div>\n"
+    "</body>\n"
+    "</html>";
+
+  memset(&award_achievement_response, 0, sizeof(award_achievement_response));
+
+  ASSERT_NUM_EQUALS(rc_api_process_award_achievement_response(&award_achievement_response, server_response), RC_INVALID_JSON);
+  ASSERT_NUM_EQUALS(award_achievement_response.response.succeeded, 0);
+  ASSERT_STR_EQUALS(award_achievement_response.response.error_message, "503 Service Temporarily Unavailable");
+  ASSERT_UNUM_EQUALS(award_achievement_response.new_player_score, 0);
+  ASSERT_UNUM_EQUALS(award_achievement_response.new_player_score_softcore, 0);
+  ASSERT_UNUM_EQUALS(award_achievement_response.awarded_achievement_id, 0);
+  ASSERT_UNUM_EQUALS(award_achievement_response.achievements_remaining, 0);
+
+  rc_api_destroy_award_achievement_response(&award_achievement_response);
+}
+
 static void test_init_submit_lboard_entry_request() {
   rc_api_submit_lboard_entry_request_t submit_lboard_entry_request;
   rc_api_request_t request;
@@ -930,6 +988,7 @@ void test_rapi_runtime(void) {
   TEST(test_process_award_achievement_response_no_fields);
   TEST(test_process_award_achievement_response_429);
   TEST(test_process_award_achievement_response_429_json);
+  TEST(test_process_award_achievement_response_503_fancy);
 
   /* submitlbentry */
   TEST(test_init_submit_lboard_entry_request);


### PR DESCRIPTION
For every rc_api_process_X_response function:
```
int rc_api_process_login_response(rc_api_login_response_t* response, const char* server_response);
```

There is now also a second function that accepts a `rc_api_server_response_t` object:
```
int rc_api_process_login_server_response(rc_api_login_response_t* response, const rc_api_server_response_t* server_response);
```

Which allows the caller to pass in the length of the server response (the old function assumes a properly formatted response and can potentially read past the end of the input buffer). It also allows the caller to pass the HTTP status code, which may have significance in the future.