### PR TITLE
update rc_api_start_session to use new API

### DIFF
--- a/include/rc_api_user.h
+++ b/include/rc_api_user.h
@@ -66,9 +66,33 @@ typedef struct rc_api_start_session_request_t {
 rc_api_start_session_request_t;
 
 /**
+ * Response data for an achievement unlock.
+ */
+typedef struct rc_api_unlock_entry_t {
+  /* The unique identifier of the unlocked achievement */
+  unsigned achievement_id;
+  /* When the achievement was unlocked */
+  time_t when;
+}
+rc_api_unlock_entry_t;
+
+/**
  * Response data for a start session request.
  */
 typedef struct rc_api_start_session_response_t {
+  /* An array of hardcore user unlocks */
+  rc_api_unlock_entry_t* hardcore_unlocks;
+  /* The number of items in the hardcore_unlocks array */
+  unsigned num_hardcore_unlocks;
+
+  /* An array of user unlocks */
+  rc_api_unlock_entry_t* unlocks;
+  /* The number of items in the unlocks array */
+  unsigned num_unlocks;
+
+  /* The server timestamp when the response was generated */
+  time_t server_now;
+
   /* Common server-provided response information */
   rc_api_response_t response;
 }

--- a/include/rc_api_user.h
+++ b/include/rc_api_user.h
@@ -82,11 +82,11 @@ rc_api_unlock_entry_t;
 typedef struct rc_api_start_session_response_t {
   /* An array of hardcore user unlocks */
   rc_api_unlock_entry_t* hardcore_unlocks;
-  /* The number of items in the hardcore_unlocks array */
-  unsigned num_hardcore_unlocks;
-
   /* An array of user unlocks */
   rc_api_unlock_entry_t* unlocks;
+
+  /* The number of items in the hardcore_unlocks array */
+  unsigned num_hardcore_unlocks;
   /* The number of items in the unlocks array */
   unsigned num_unlocks;
 

--- a/include/rc_api_user.h
+++ b/include/rc_api_user.h
@@ -3,6 +3,8 @@
 
 #include "rc_api_request.h"
 
+#include <time.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/rapi/rc_api_common.c
+++ b/src/rapi/rc_api_common.c
@@ -422,13 +422,25 @@ int rc_json_get_required_array(unsigned* num_entries, rc_json_field_t* array_fie
 #ifndef NDEBUG
   if (strcmp(field->name, field_name) != 0)
     return 0;
+#endif
+
+  if (!rc_json_get_optional_array(num_entries, array_field, response, field, field_name))
+    return rc_json_missing_field(response, field);
+
+  return 1;
+}
+
+int rc_json_get_optional_array(unsigned* num_entries, rc_json_field_t* array_field, rc_api_response_t* response, const rc_json_field_t* field, const char* field_name) {
+#ifndef NDEBUG
+  if (strcmp(field->name, field_name) != 0)
+    return 0;
 #else
   (void)field_name;
 #endif
 
   if (!field->value_start || *field->value_start != '[') {
     *num_entries = 0;
-    return rc_json_missing_field(response, field);
+    return 0;
   }
 
   memcpy(array_field, field, sizeof(*array_field));

--- a/src/rapi/rc_api_common.h
+++ b/src/rapi/rc_api_common.h
@@ -53,6 +53,7 @@ void rc_json_get_optional_string(const char** out, rc_api_response_t* response, 
 void rc_json_get_optional_num(int* out, const rc_json_field_t* field, const char* field_name, int default_value);
 void rc_json_get_optional_unum(unsigned* out, const rc_json_field_t* field, const char* field_name, unsigned default_value);
 void rc_json_get_optional_bool(int* out, const rc_json_field_t* field, const char* field_name, int default_value);
+int rc_json_get_optional_array(unsigned* num_entries, rc_json_field_t* iterator, rc_api_response_t* response, const rc_json_field_t* field, const char* field_name);
 int rc_json_get_required_string(const char** out, rc_api_response_t* response, const rc_json_field_t* field, const char* field_name);
 int rc_json_get_required_num(int* out, rc_api_response_t* response, const rc_json_field_t* field, const char* field_name);
 int rc_json_get_required_unum(unsigned* out, rc_api_response_t* response, const rc_json_field_t* field, const char* field_name);

--- a/src/rcheevos/rc_client.c
+++ b/src/rcheevos/rc_client.c
@@ -1027,9 +1027,9 @@ static void rc_client_apply_unlocks(rc_client_subset_info_t* subset, rc_api_unlo
       if (scan->public_.id == unlock->achievement_id) {
         scan->public_.unlocked |= mode;
 
-        if (mode == RC_CLIENT_ACHIEVEMENT_UNLOCKED_HARDCORE)
+        if (mode & RC_CLIENT_ACHIEVEMENT_UNLOCKED_HARDCORE)
           scan->unlock_time_hardcore = unlock->when;
-        else
+        if (mode & RC_CLIENT_ACHIEVEMENT_UNLOCKED_SOFTCORE)
           scan->unlock_time_softcore = unlock->when;
 
         if (scan == start)
@@ -1064,10 +1064,10 @@ static void rc_client_activate_game(rc_client_load_state_t* load_state, rc_api_s
   }
   else {
     if (client->state.spectator_mode == RC_CLIENT_SPECTATOR_MODE_OFF) {
-      rc_client_apply_unlocks(load_state->subset, start_session_response->unlocks,
-          start_session_response->num_unlocks, RC_CLIENT_ACHIEVEMENT_UNLOCKED_SOFTCORE);
       rc_client_apply_unlocks(load_state->subset, start_session_response->hardcore_unlocks,
           start_session_response->num_hardcore_unlocks, RC_CLIENT_ACHIEVEMENT_UNLOCKED_BOTH);
+      rc_client_apply_unlocks(load_state->subset, start_session_response->unlocks,
+        start_session_response->num_unlocks, RC_CLIENT_ACHIEVEMENT_UNLOCKED_SOFTCORE);
     }
 
     rc_mutex_lock(&client->state.mutex);

--- a/src/rcheevos/rc_client.c
+++ b/src/rcheevos/rc_client.c
@@ -273,6 +273,22 @@ static int rc_client_should_retry(const rc_api_server_response_t* server_respons
       /* too many unlocks occurred at the same time */
       return 1;
 
+    case 521: /* 521 Web Server is Down */
+      /* cloudfare could not find the server */
+      return 1;
+
+    case 522: /* 522 Connection Timed Out */
+      /* timeout connecting to server from cloudfare */
+      return 1;
+
+    case 523: /* 523 Origin is Unreachable */
+      /* cloudfare cannot find server */
+      return 1;
+
+    case 524: /* 524 A Timeout Occurred */
+      /* connection to server from cloudfare was dropped before request was completed */
+      return 1;
+
     default:
       return 0;
   }

--- a/test/rapi/test_rc_api_user.c
+++ b/test/rapi/test_rc_api_user.c
@@ -19,7 +19,7 @@ static void test_init_start_session_request()
 
   ASSERT_NUM_EQUALS(rc_api_init_start_session_request(&request, &start_session_request), RC_OK);
   ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
-  ASSERT_STR_EQUALS(request.post_data,  "r=postactivity&u=Username&t=API_TOKEN&a=3&m=1234&l=" RCHEEVOS_VERSION_STRING);
+  ASSERT_STR_EQUALS(request.post_data,  "r=startsession&u=Username&t=API_TOKEN&g=1234&l=" RCHEEVOS_VERSION_STRING);
   ASSERT_STR_EQUALS(request.content_type, RC_CONTENT_TYPE_URLENCODED);
 
   rc_api_destroy_request(&request);
@@ -39,7 +39,7 @@ static void test_init_start_session_request_no_game()
   rc_api_destroy_request(&request);
 }
 
-static void test_process_start_session_response()
+static void test_process_start_session_response_legacy()
 {
   rc_api_start_session_response_t start_session_response;
   const char* server_response = "{\"Success\":true}";
@@ -49,6 +49,49 @@ static void test_process_start_session_response()
   ASSERT_NUM_EQUALS(rc_api_process_start_session_response(&start_session_response, server_response), RC_OK);
   ASSERT_NUM_EQUALS(start_session_response.response.succeeded, 1);
   ASSERT_PTR_NULL(start_session_response.response.error_message);
+  ASSERT_NUM_EQUALS(start_session_response.num_unlocks, 0);
+  ASSERT_NUM_EQUALS(start_session_response.num_hardcore_unlocks, 0);
+  ASSERT_NUM_EQUALS(start_session_response.server_now, 0);
+
+  rc_api_destroy_start_session_response(&start_session_response);
+}
+
+static void test_process_start_session_response()
+{
+  rc_api_start_session_response_t start_session_response;
+  const char* server_response = "{\"Success\":true,\"HardcoreUnlocks\":["
+      "{\"ID\":111,\"When\":1234567890},"
+      "{\"ID\":112,\"When\":1234567891},"
+      "{\"ID\":113,\"When\":1234567860}"
+    "],\"Unlocks\":["
+      "{\"ID\":111,\"When\":1234567890},"
+      "{\"ID\":112,\"When\":1234567841},"
+      "{\"ID\":113,\"When\":1234567860},"
+      "{\"ID\":114,\"When\":1234567840}"
+    "],\"ServerNow\":1234577777}";
+
+  memset(&start_session_response, 0, sizeof(start_session_response));
+
+  ASSERT_NUM_EQUALS(rc_api_process_start_session_response(&start_session_response, server_response), RC_OK);
+  ASSERT_NUM_EQUALS(start_session_response.response.succeeded, 1);
+  ASSERT_PTR_NULL(start_session_response.response.error_message);
+  ASSERT_NUM_EQUALS(start_session_response.num_unlocks, 4);
+  ASSERT_NUM_EQUALS(start_session_response.unlocks[0].achievement_id, 111);
+  ASSERT_NUM_EQUALS(start_session_response.unlocks[0].when, 1234567890);
+  ASSERT_NUM_EQUALS(start_session_response.unlocks[1].achievement_id, 112);
+  ASSERT_NUM_EQUALS(start_session_response.unlocks[1].when, 1234567841);
+  ASSERT_NUM_EQUALS(start_session_response.unlocks[2].achievement_id, 113);
+  ASSERT_NUM_EQUALS(start_session_response.unlocks[2].when, 1234567860);
+  ASSERT_NUM_EQUALS(start_session_response.unlocks[3].achievement_id, 114);
+  ASSERT_NUM_EQUALS(start_session_response.unlocks[3].when, 1234567840);
+  ASSERT_NUM_EQUALS(start_session_response.num_hardcore_unlocks, 3);
+  ASSERT_NUM_EQUALS(start_session_response.hardcore_unlocks[0].achievement_id, 111);
+  ASSERT_NUM_EQUALS(start_session_response.hardcore_unlocks[0].when, 1234567890);
+  ASSERT_NUM_EQUALS(start_session_response.hardcore_unlocks[1].achievement_id, 112);
+  ASSERT_NUM_EQUALS(start_session_response.hardcore_unlocks[1].when, 1234567891);
+  ASSERT_NUM_EQUALS(start_session_response.hardcore_unlocks[2].achievement_id, 113);
+  ASSERT_NUM_EQUALS(start_session_response.hardcore_unlocks[2].when, 1234567860);
+  ASSERT_NUM_EQUALS(start_session_response.server_now, 1234577777);
 
   rc_api_destroy_start_session_response(&start_session_response);
 }
@@ -505,6 +548,7 @@ void test_rapi_user(void) {
   TEST(test_init_start_session_request);
   TEST(test_init_start_session_request_no_game);
 
+  TEST(test_process_start_session_response_legacy);
   TEST(test_process_start_session_response);
   TEST(test_process_start_session_response_invalid_credentials);
 

--- a/test/rapi/test_rc_api_user.c
+++ b/test/rapi/test_rc_api_user.c
@@ -59,14 +59,14 @@ static void test_process_start_session_response_legacy()
 static void test_process_start_session_response()
 {
   rc_api_start_session_response_t start_session_response;
+  /* startsession API only returns HardcoreUnlocks if an achievement has been earned in hardcore,
+   * even if the softcore unlock has a different timestamp. Unlocks are only returned for things
+   * only unlocked in softcore. */
   const char* server_response = "{\"Success\":true,\"HardcoreUnlocks\":["
       "{\"ID\":111,\"When\":1234567890},"
       "{\"ID\":112,\"When\":1234567891},"
       "{\"ID\":113,\"When\":1234567860}"
     "],\"Unlocks\":["
-      "{\"ID\":111,\"When\":1234567890},"
-      "{\"ID\":112,\"When\":1234567841},"
-      "{\"ID\":113,\"When\":1234567860},"
       "{\"ID\":114,\"When\":1234567840}"
     "],\"ServerNow\":1234577777}";
 
@@ -75,15 +75,9 @@ static void test_process_start_session_response()
   ASSERT_NUM_EQUALS(rc_api_process_start_session_response(&start_session_response, server_response), RC_OK);
   ASSERT_NUM_EQUALS(start_session_response.response.succeeded, 1);
   ASSERT_PTR_NULL(start_session_response.response.error_message);
-  ASSERT_NUM_EQUALS(start_session_response.num_unlocks, 4);
-  ASSERT_NUM_EQUALS(start_session_response.unlocks[0].achievement_id, 111);
-  ASSERT_NUM_EQUALS(start_session_response.unlocks[0].when, 1234567890);
-  ASSERT_NUM_EQUALS(start_session_response.unlocks[1].achievement_id, 112);
-  ASSERT_NUM_EQUALS(start_session_response.unlocks[1].when, 1234567841);
-  ASSERT_NUM_EQUALS(start_session_response.unlocks[2].achievement_id, 113);
-  ASSERT_NUM_EQUALS(start_session_response.unlocks[2].when, 1234567860);
-  ASSERT_NUM_EQUALS(start_session_response.unlocks[3].achievement_id, 114);
-  ASSERT_NUM_EQUALS(start_session_response.unlocks[3].when, 1234567840);
+  ASSERT_NUM_EQUALS(start_session_response.num_unlocks, 1);
+  ASSERT_NUM_EQUALS(start_session_response.unlocks[0].achievement_id, 114);
+  ASSERT_NUM_EQUALS(start_session_response.unlocks[0].when, 1234567840);
   ASSERT_NUM_EQUALS(start_session_response.num_hardcore_unlocks, 3);
   ASSERT_NUM_EQUALS(start_session_response.hardcore_unlocks[0].achievement_id, 111);
   ASSERT_NUM_EQUALS(start_session_response.hardcore_unlocks[0].when, 1234567890);

--- a/test/rcheevos/test_rc_client.c
+++ b/test/rcheevos/test_rc_client.c
@@ -518,7 +518,7 @@ static void mock_client_load_game(const char* patchdata, const char* hardcore_un
   event_count = 0;
   mock_api_response("r=gameid&m=0123456789ABCDEF", "{\"Success\":true,\"GameID\":1234}");
   mock_api_response("r=patch&u=Username&t=ApiToken&g=1234", patchdata);
-  mock_api_response("r=postactivity&u=Username&t=ApiToken&a=3&m=1234&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
+  mock_api_response("r=startsession&u=Username&t=ApiToken&g=1234&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
   mock_api_response("r=unlocks&u=Username&t=ApiToken&g=1234&h=0", softcore_unlocks);
   mock_api_response("r=unlocks&u=Username&t=ApiToken&g=1234&h=1", hardcore_unlocks);
 
@@ -540,7 +540,7 @@ static rc_client_t* mock_client_game_loaded(const char* patchdata, const char* h
 static void mock_client_load_subset(const char* patchdata, const char* hardcore_unlocks, const char* softcore_unlocks)
 {
   mock_api_response("r=patch&u=Username&t=ApiToken&g=2345", patchdata);
-  mock_api_response("r=postactivity&u=Username&t=ApiToken&a=3&m=2345&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
+  mock_api_response("r=startsession&u=Username&t=ApiToken&g=2345&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
   mock_api_response("r=unlocks&u=Username&t=ApiToken&g=2345&h=0", softcore_unlocks);
   mock_api_response("r=unlocks&u=Username&t=ApiToken&g=2345&h=1", hardcore_unlocks);
 
@@ -824,7 +824,7 @@ static void test_logout_during_fetch_game(void)
 
   async_api_response("r=gameid&m=0123456789ABCDEF", "{\"Success\":true,\"GameID\":1234}");
   async_api_response("r=patch&u=Username&t=ApiToken&g=1234", patchdata_2ach_1lbd);
-  async_api_response("r=postactivity&u=Username&t=ApiToken&a=3&m=1234&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
+  async_api_response("r=startsession&u=Username&t=ApiToken&g=1234&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
 
   rc_client_logout(g_client);
 
@@ -899,7 +899,7 @@ static void test_get_user_game_summary_encore_mode(void)
   reset_mock_api_handlers();
   mock_api_response("r=gameid&m=0123456789ABCDEF", "{\"Success\":true,\"GameID\":1234}");
   mock_api_response("r=patch&u=Username&t=ApiToken&g=1234", patchdata_exhaustive);
-  mock_api_response("r=postactivity&u=Username&t=ApiToken&a=3&m=1234&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
+  mock_api_response("r=startsession&u=Username&t=ApiToken&g=1234&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
   mock_api_response("r=unlocks&u=Username&t=ApiToken&g=1234&h=0", unlock_6_8_and_9);
   mock_api_response("r=unlocks&u=Username&t=ApiToken&g=1234&h=1", unlock_8);
 
@@ -1017,7 +1017,7 @@ static void test_load_game(void)
   reset_mock_api_handlers();
   mock_api_response("r=gameid&m=0123456789ABCDEF", "{\"Success\":true,\"GameID\":1234}");
   mock_api_response("r=patch&u=Username&t=ApiToken&g=1234", patchdata_2ach_1lbd);
-  mock_api_response("r=postactivity&u=Username&t=ApiToken&a=3&m=1234&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
+  mock_api_response("r=startsession&u=Username&t=ApiToken&g=1234&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
   mock_api_response("r=unlocks&u=Username&t=ApiToken&g=1234&h=0", no_unlocks);
   mock_api_response("r=unlocks&u=Username&t=ApiToken&g=1234&h=1", no_unlocks);
 
@@ -1090,7 +1090,7 @@ static void test_load_game_async_login(void)
   assert_api_pending("r=patch&u=Username&t=ApiToken&g=1234");
 
   async_api_response("r=patch&u=Username&t=ApiToken&g=1234", patchdata_2ach_1lbd);
-  async_api_response("r=postactivity&u=Username&t=ApiToken&a=3&m=1234&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
+  async_api_response("r=startsession&u=Username&t=ApiToken&g=1234&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
   async_api_response("r=unlocks&u=Username&t=ApiToken&g=1234&h=0", no_unlocks);
   async_api_response("r=unlocks&u=Username&t=ApiToken&g=1234&h=1", no_unlocks);
 
@@ -1153,7 +1153,7 @@ static void test_load_game_gameid_failure(void)
   reset_mock_api_handlers();
   mock_api_error("r=gameid&m=0123456789ABCDEF", response_429, 429);
   mock_api_response("r=patch&u=Username&t=ApiToken&g=1234", patchdata_2ach_1lbd);
-  mock_api_response("r=postactivity&u=Username&t=ApiToken&a=3&m=1234&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
+  mock_api_response("r=startsession&u=Username&t=ApiToken&g=1234&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
   mock_api_response("r=unlocks&u=Username&t=ApiToken&g=1234&h=0", "{\"Success\":true,\"UserUnlocks\":[]}");
   mock_api_response("r=unlocks&u=Username&t=ApiToken&g=1234&h=1", "{\"Success\":true,\"UserUnlocks\":[]}");
 
@@ -1172,7 +1172,7 @@ static void test_load_game_patch_failure(void)
   reset_mock_api_handlers();
   mock_api_response("r=gameid&m=0123456789ABCDEF", "{\"Success\":true,\"GameID\":1234}");
   mock_api_error("r=patch&u=Username&t=ApiToken&g=1234", response_429, 429);
-  mock_api_response("r=postactivity&u=Username&t=ApiToken&a=3&m=1234&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
+  mock_api_response("r=startsession&u=Username&t=ApiToken&g=1234&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
   mock_api_response("r=unlocks&u=Username&t=ApiToken&g=1234&h=0", "{\"Success\":true,\"UserUnlocks\":[]}");
   mock_api_response("r=unlocks&u=Username&t=ApiToken&g=1234&h=1", "{\"Success\":true,\"UserUnlocks\":[]}");
 
@@ -1184,14 +1184,14 @@ static void test_load_game_patch_failure(void)
   rc_client_destroy(g_client);
 }
 
-static void test_load_game_postactivity_failure(void)
+static void test_load_game_startsession_failure(void)
 {
   g_client = mock_client_logged_in();
 
   reset_mock_api_handlers();
   mock_api_response("r=gameid&m=0123456789ABCDEF", "{\"Success\":true,\"GameID\":1234}");
   mock_api_response("r=patch&u=Username&t=ApiToken&g=1234", patchdata_2ach_1lbd);
-  mock_api_error("r=postactivity&u=Username&t=ApiToken&a=3&m=1234&l=" RCHEEVOS_VERSION_STRING, response_429, 429);
+  mock_api_error("r=startsession&u=Username&t=ApiToken&g=1234&l=" RCHEEVOS_VERSION_STRING, response_429, 429);
   mock_api_response("r=unlocks&u=Username&t=ApiToken&g=1234&h=0", "{\"Success\":true,\"UserUnlocks\":[]}");
   mock_api_response("r=unlocks&u=Username&t=ApiToken&g=1234&h=1", "{\"Success\":true,\"UserUnlocks\":[]}");
 
@@ -1210,7 +1210,7 @@ static void test_load_game_softcore_unlocks_failure(void)
   reset_mock_api_handlers();
   mock_api_response("r=gameid&m=0123456789ABCDEF", "{\"Success\":true,\"GameID\":1234}");
   mock_api_response("r=patch&u=Username&t=ApiToken&g=1234", patchdata_2ach_1lbd);
-  mock_api_response("r=postactivity&u=Username&t=ApiToken&a=3&m=1234&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
+  mock_api_response("r=startsession&u=Username&t=ApiToken&g=1234&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
   mock_api_error("r=unlocks&u=Username&t=ApiToken&g=1234&h=0", response_429, 429);
   mock_api_response("r=unlocks&u=Username&t=ApiToken&g=1234&h=1", "{\"Success\":true,\"UserUnlocks\":[]}");
 
@@ -1229,7 +1229,7 @@ static void test_load_game_hardcore_unlocks_failure(void)
   reset_mock_api_handlers();
   mock_api_response("r=gameid&m=0123456789ABCDEF", "{\"Success\":true,\"GameID\":1234}");
   mock_api_response("r=patch&u=Username&t=ApiToken&g=1234", patchdata_2ach_1lbd);
-  mock_api_response("r=postactivity&u=Username&t=ApiToken&a=3&m=1234&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
+  mock_api_response("r=startsession&u=Username&t=ApiToken&g=1234&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
   mock_api_response("r=unlocks&u=Username&t=ApiToken&g=1234&h=0", "{\"Success\":true,\"UserUnlocks\":[]}");
   mock_api_error("r=unlocks&u=Username&t=ApiToken&g=1234&h=1", response_429, 429);
 
@@ -1281,7 +1281,7 @@ static void test_load_game_patch_aborted(void)
   rc_client_abort_async(g_client, handle);
 
   async_api_response("r=patch&u=Username&t=ApiToken&g=1234", patchdata_2ach_1lbd);
-  assert_api_not_called("r=postactivity&u=Username&t=ApiToken&a=3&m=1234&l=" RCHEEVOS_VERSION_STRING);
+  assert_api_not_called("r=startsession&u=Username&t=ApiToken&g=1234&l=" RCHEEVOS_VERSION_STRING);
 
   ASSERT_PTR_NULL(g_client->state.load);
   ASSERT_PTR_NULL(g_client->game);
@@ -1289,7 +1289,7 @@ static void test_load_game_patch_aborted(void)
   rc_client_destroy(g_client);
 }
 
-static void test_load_game_postactivity_aborted(void)
+static void test_load_game_startsession_aborted(void)
 {
   rc_client_async_handle_t* handle;
 
@@ -1306,7 +1306,7 @@ static void test_load_game_postactivity_aborted(void)
 
   rc_client_abort_async(g_client, handle);
 
-  async_api_response("r=postactivity&u=Username&t=ApiToken&a=3&m=1234&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
+  async_api_response("r=startsession&u=Username&t=ApiToken&g=1234&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
   async_api_response("r=unlocks&u=Username&t=ApiToken&g=1234&h=0", "{\"Success\":true,\"UserUnlocks\":[]}");
   async_api_response("r=unlocks&u=Username&t=ApiToken&g=1234&h=1", "{\"Success\":true,\"UserUnlocks\":[]}");
 
@@ -1330,7 +1330,7 @@ static void test_load_game_softcore_unlocks_aborted(void)
 
   async_api_response("r=gameid&m=0123456789ABCDEF", "{\"Success\":true,\"GameID\":1234}");
   async_api_response("r=patch&u=Username&t=ApiToken&g=1234", patchdata_2ach_1lbd);
-  async_api_response("r=postactivity&u=Username&t=ApiToken&a=3&m=1234&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
+  async_api_response("r=startsession&u=Username&t=ApiToken&g=1234&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
 
   rc_client_abort_async(g_client, handle);
 
@@ -1357,7 +1357,7 @@ static void test_load_game_hardcore_unlocks_aborted(void)
 
   async_api_response("r=gameid&m=0123456789ABCDEF", "{\"Success\":true,\"GameID\":1234}");
   async_api_response("r=patch&u=Username&t=ApiToken&g=1234", patchdata_2ach_1lbd);
-  async_api_response("r=postactivity&u=Username&t=ApiToken&a=3&m=1234&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
+  async_api_response("r=startsession&u=Username&t=ApiToken&g=1234&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
   async_api_response("r=unlocks&u=Username&t=ApiToken&g=1234&h=0", "{\"Success\":true,\"UserUnlocks\":[]}");
 
   rc_client_abort_async(g_client, handle);
@@ -1541,7 +1541,7 @@ static void test_identify_and_load_game_console_specified(void)
   reset_mock_api_handlers();
   mock_api_response("r=gameid&m=6a2305a2b6675a97ff792709be1ca857", "{\"Success\":true,\"GameID\":1234}");
   mock_api_response("r=patch&u=Username&t=ApiToken&g=1234", patchdata_2ach_1lbd);
-  mock_api_response("r=postactivity&u=Username&t=ApiToken&a=3&m=1234&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
+  mock_api_response("r=startsession&u=Username&t=ApiToken&g=1234&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
   mock_api_response("r=unlocks&u=Username&t=ApiToken&g=1234&h=0", no_unlocks);
   mock_api_response("r=unlocks&u=Username&t=ApiToken&g=1234&h=1", no_unlocks);
 
@@ -1576,7 +1576,7 @@ static void test_identify_and_load_game_console_not_specified(void)
   reset_mock_api_handlers();
   mock_api_response("r=gameid&m=6a2305a2b6675a97ff792709be1ca857", "{\"Success\":true,\"GameID\":1234}");
   mock_api_response("r=patch&u=Username&t=ApiToken&g=1234", patchdata_2ach_1lbd);
-  mock_api_response("r=postactivity&u=Username&t=ApiToken&a=3&m=1234&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
+  mock_api_response("r=startsession&u=Username&t=ApiToken&g=1234&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
   mock_api_response("r=unlocks&u=Username&t=ApiToken&g=1234&h=0", no_unlocks);
   mock_api_response("r=unlocks&u=Username&t=ApiToken&g=1234&h=1", no_unlocks);
 
@@ -1625,7 +1625,7 @@ static void test_identify_and_load_game_multiconsole_first(void)
 
   async_api_response("r=gameid&m=6a2305a2b6675a97ff792709be1ca857", "{\"Success\":true,\"GameID\":1234}");
   async_api_response("r=patch&u=Username&t=ApiToken&g=1234", patchdata_2ach_1lbd);
-  async_api_response("r=postactivity&u=Username&t=ApiToken&a=3&m=1234&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
+  async_api_response("r=startsession&u=Username&t=ApiToken&g=1234&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
   async_api_response("r=unlocks&u=Username&t=ApiToken&g=1234&h=0", no_unlocks);
   async_api_response("r=unlocks&u=Username&t=ApiToken&g=1234&h=1", no_unlocks);
 
@@ -1676,7 +1676,7 @@ static void test_identify_and_load_game_multiconsole_second(void)
   assert_api_pending("r=gameid&m=64b131c5c7fec32985d9c99700babb7e");
   async_api_response("r=gameid&m=64b131c5c7fec32985d9c99700babb7e", "{\"Success\":true,\"GameID\":1234}");
   async_api_response("r=patch&u=Username&t=ApiToken&g=1234", patchdata_2ach_1lbd);
-  async_api_response("r=postactivity&u=Username&t=ApiToken&a=3&m=1234&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
+  async_api_response("r=startsession&u=Username&t=ApiToken&g=1234&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
   async_api_response("r=unlocks&u=Username&t=ApiToken&g=1234&h=0", no_unlocks);
   async_api_response("r=unlocks&u=Username&t=ApiToken&g=1234&h=1", no_unlocks);
 
@@ -1820,7 +1820,7 @@ static void test_identify_and_load_game_multihash(void)
   reset_mock_api_handlers();
   mock_api_response("r=gameid&m=6a2305a2b6675a97ff792709be1ca857", "{\"Success\":true,\"GameID\":1234}");
   mock_api_response("r=patch&u=Username&t=ApiToken&g=1234", patchdata_2ach_1lbd);
-  mock_api_response("r=postactivity&u=Username&t=ApiToken&a=3&m=1234&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
+  mock_api_response("r=startsession&u=Username&t=ApiToken&g=1234&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
   mock_api_response("r=unlocks&u=Username&t=ApiToken&g=1234&h=0", no_unlocks);
   mock_api_response("r=unlocks&u=Username&t=ApiToken&g=1234&h=1", no_unlocks);
 
@@ -1900,7 +1900,7 @@ static void test_identify_and_load_game_multihash_differ(void)
   /* second lookup should succeed */
   async_api_response("r=gameid&m=4989b063a40dcfa28291ff8d675050e3", "{\"Success\":true,\"GameID\":1234}");
   async_api_response("r=patch&u=Username&t=ApiToken&g=1234", patchdata_2ach_1lbd);
-  async_api_response("r=postactivity&u=Username&t=ApiToken&a=3&m=1234&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
+  async_api_response("r=startsession&u=Username&t=ApiToken&g=1234&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
   async_api_response("r=unlocks&u=Username&t=ApiToken&g=1234&h=0", no_unlocks);
   async_api_response("r=unlocks&u=Username&t=ApiToken&g=1234&h=1", no_unlocks);
 
@@ -2210,7 +2210,7 @@ static void test_change_media_while_loading(void)
   assert_api_not_called("r=gameid&m=6a2305a2b6675a97ff792709be1ca857");
 
   /* finish loading game */
-  async_api_response("r=postactivity&u=Username&t=ApiToken&a=3&m=1234&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
+  async_api_response("r=startsession&u=Username&t=ApiToken&g=1234&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
   assert_api_not_called("r=gameid&m=6a2305a2b6675a97ff792709be1ca857");
   async_api_response("r=unlocks&u=Username&t=ApiToken&g=1234&h=0", no_unlocks);
   assert_api_not_called("r=gameid&m=6a2305a2b6675a97ff792709be1ca857");
@@ -2261,7 +2261,7 @@ static void test_change_media_while_loading_later(void)
   assert_api_pending("r=gameid&m=6a2305a2b6675a97ff792709be1ca857");
 
   /* finish loading game */
-  async_api_response("r=postactivity&u=Username&t=ApiToken&a=3&m=1234&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
+  async_api_response("r=startsession&u=Username&t=ApiToken&g=1234&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
   async_api_response("r=unlocks&u=Username&t=ApiToken&g=1234&h=0", no_unlocks);
   async_api_response("r=unlocks&u=Username&t=ApiToken&g=1234&h=1", no_unlocks);
   async_api_response("r=gameid&m=6a2305a2b6675a97ff792709be1ca857", "{\"Success\":true,\"GameID\":1234}");
@@ -2380,14 +2380,14 @@ static void test_load_subset(void)
   reset_mock_api_handlers();
   mock_api_response("r=gameid&m=0123456789ABCDEF", "{\"Success\":true,\"GameID\":1234}");
   mock_api_response("r=patch&u=Username&t=ApiToken&g=1234", patchdata_2ach_1lbd);
-  mock_api_response("r=postactivity&u=Username&t=ApiToken&a=3&m=1234&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
+  mock_api_response("r=startsession&u=Username&t=ApiToken&g=1234&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
   mock_api_response("r=unlocks&u=Username&t=ApiToken&g=1234&h=0", no_unlocks);
   mock_api_response("r=unlocks&u=Username&t=ApiToken&g=1234&h=1", no_unlocks);
 
   rc_client_begin_load_game(g_client, "0123456789ABCDEF", rc_client_callback_expect_success, g_callback_userdata);
 
   mock_api_response("r=patch&u=Username&t=ApiToken&g=2345", patchdata_subset);
-  mock_api_response("r=postactivity&u=Username&t=ApiToken&a=3&m=2345&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
+  mock_api_response("r=startsession&u=Username&t=ApiToken&g=2345&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
   mock_api_response("r=unlocks&u=Username&t=ApiToken&g=2345&h=0", no_unlocks);
   mock_api_response("r=unlocks&u=Username&t=ApiToken&g=2345&h=1", no_unlocks);
 
@@ -3304,13 +3304,13 @@ static void test_achievement_list_subset_buckets_subset_first(void)
   reset_mock_api_handlers();
   mock_api_response("r=gameid&m=0123456789ABCDEF", "{\"Success\":true,\"GameID\":2345}");
   mock_api_response("r=patch&u=Username&t=ApiToken&g=2345", patchdata_subset2);
-  mock_api_response("r=postactivity&u=Username&t=ApiToken&a=3&m=2345&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
+  mock_api_response("r=startsession&u=Username&t=ApiToken&g=2345&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
   mock_api_response("r=unlocks&u=Username&t=ApiToken&g=2345&h=0", unlock_5502);
   mock_api_response("r=unlocks&u=Username&t=ApiToken&g=2345&h=1", unlock_5502);
   rc_client_begin_load_game(g_client, "0123456789ABCDEF", rc_client_callback_expect_success, g_callback_userdata);
 
   mock_api_response("r=patch&u=Username&t=ApiToken&g=1234", patchdata_exhaustive);
-  mock_api_response("r=postactivity&u=Username&t=ApiToken&a=3&m=1234&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
+  mock_api_response("r=startsession&u=Username&t=ApiToken&g=1234&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
   mock_api_response("r=unlocks&u=Username&t=ApiToken&g=1234&h=0", unlock_8);
   mock_api_response("r=unlocks&u=Username&t=ApiToken&g=1234&h=1", unlock_8);
   rc_client_begin_load_subset(g_client, 1234, rc_client_callback_expect_success, g_callback_userdata);
@@ -7135,12 +7135,12 @@ void test_client(void) {
   TEST(test_load_game_async_login_with_incorrect_password);
   TEST(test_load_game_gameid_failure);
   TEST(test_load_game_patch_failure);
-  TEST(test_load_game_postactivity_failure);
+  TEST(test_load_game_startsession_failure);
   TEST(test_load_game_softcore_unlocks_failure);
   TEST(test_load_game_hardcore_unlocks_failure);
   TEST(test_load_game_gameid_aborted);
   TEST(test_load_game_patch_aborted);
-  TEST(test_load_game_postactivity_aborted);
+  TEST(test_load_game_startsession_aborted);
   TEST(test_load_game_softcore_unlocks_aborted);
   TEST(test_load_game_hardcore_unlocks_aborted);
   TEST(test_load_game_while_spectating);

--- a/test/rcheevos/test_rc_client.c
+++ b/test/rcheevos/test_rc_client.c
@@ -205,7 +205,6 @@ static const char* no_unlocks = "{\"Success\":true,\"Unlocks\":[],\"HardcoreUnlo
 
 /* startsession API only returns HardcoreUnlocks if an achievement has been earned in hardcore,
  * even if the softcore unlock has a different timestamp */
-static const char* unlock_5501 = "{\"Success\":true,\"HardcoreUnlocks\":[{\"ID\":5501,\"When\":1234567890}]}";
 static const char* unlock_5502 = "{\"Success\":true,\"HardcoreUnlocks\":[{\"ID\":5502,\"When\":1234567890}]}";
 static const char* unlock_5501h_and_5502 = "{\"Success\":true,\"Unlocks\":["
       "{\"ID\":5502,\"When\":1234567899}"

--- a/test/rcheevos/test_rc_client.c
+++ b/test/rcheevos/test_rc_client.c
@@ -203,37 +203,22 @@ static const char* patchdata_subset2 = "{\"Success\":true,\"PatchData\":{"
 
 static const char* no_unlocks = "{\"Success\":true,\"Unlocks\":[],\"HardcoreUnlocks\":[]}";
 
-static const char* unlock_5501 = "{\"Success\":true,\"Unlocks\":["
-      "{\"ID\":5501,\"When\":1234567890}"
-    "],\"HardcoreUnlocks\":["
-      "{\"ID\":5501,\"When\":1234567890}"
-    "]}";
-static const char* unlock_5502 = "{\"Success\":true,\"Unlocks\":["
-      "{\"ID\":5502,\"When\":1234567890}"
-    "],\"HardcoreUnlocks\":["
-      "{\"ID\":5502,\"When\":1234567890}"
-    "]}";
+/* startsession API only returns HardcoreUnlocks if an achievement has been earned in hardcore,
+ * even if the softcore unlock has a different timestamp */
+static const char* unlock_5501 = "{\"Success\":true,\"HardcoreUnlocks\":[{\"ID\":5501,\"When\":1234567890}]}";
+static const char* unlock_5502 = "{\"Success\":true,\"HardcoreUnlocks\":[{\"ID\":5502,\"When\":1234567890}]}";
 static const char* unlock_5501h_and_5502 = "{\"Success\":true,\"Unlocks\":["
-      "{\"ID\":5501,\"When\":1234567890},"
       "{\"ID\":5502,\"When\":1234567899}"
     "],\"HardcoreUnlocks\":["
       "{\"ID\":5501,\"When\":1234567890}"
     "]}";
-static const char* unlock_5501_and_5502 = "{\"Success\":true,\"Unlocks\":["
-      "{\"ID\":5501,\"When\":1234567890},"
-      "{\"ID\":5502,\"When\":1234567899}"
-    "],\"HardcoreUnlocks\":["
+static const char* unlock_5501_and_5502 = "{\"Success\":true,\"HardcoreUnlocks\":["
       "{\"ID\":5501,\"When\":1234567890},"
       "{\"ID\":5502,\"When\":1234567899}"
     "]}";
-static const char* unlock_8 = "{\"Success\":true,\"Unlocks\":["
-      "{\"ID\":8,\"When\":1234567890}"
-    "],\"HardcoreUnlocks\":["
-      "{\"ID\":8,\"When\":1234567890}"
-    "]}";
+static const char* unlock_8 = "{\"Success\":true,\"HardcoreUnlocks\":[{\"ID\":8,\"When\":1234567890}]}";
 static const char* unlock_6_8h_and_9 = "{\"Success\":true,\"Unlocks\":["
       "{\"ID\":6,\"When\":1234567890},"
-      "{\"ID\":8,\"When\":1234567895},"
       "{\"ID\":9,\"When\":1234567899}"
     "],\"HardcoreUnlocks\":["
       "{\"ID\":8,\"When\":1234567895}"

--- a/test/test.c
+++ b/test/test.c
@@ -95,7 +95,6 @@ int main(void) {
   test_richpresence();
   test_runtime();
   test_runtime_progress();
-  test_client();
 
   test_consoleinfo();
   test_rc_libretro();
@@ -105,14 +104,16 @@ int main(void) {
 
   test_url();
 
-  test_cdreader();
-  test_hash();
-
   test_rapi_common();
   test_rapi_user();
   test_rapi_runtime();
   test_rapi_info();
   test_rapi_editor();
+
+  test_client();
+
+  test_cdreader();
+  test_hash();
 #endif
 
   TEST_FRAMEWORK_SHUTDOWN();


### PR DESCRIPTION
`rc_api_start_session` previously just posted the new session entry in the activity table. Two additional server requests were made in parallel to fetch the user's hardcore and softcore unlock information. 

https://github.com/RetroAchievements/RAWeb/pull/1538 added a new API that does all three in a single server call. This modifies the `rc_api_start_session` functions to use the new server API.

Existing clients may now use the unlock information returned by this API to avoid making one or more calls to `rc_api_fetch_user_unlocks`. The change will automatically be leveraged by the `rc_client` implementation.