### PR TITLE
Better Swift support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,32 @@
+// swift-tools-version: 5.8
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "rcheevos",
+    products: [
+        // Products define the executables and libraries a package produces, and make them visible to other packages.
+        .library(
+            name: "rcheevos",
+            targets: ["rcheevos"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .target(
+            name: "rcheevos",
+            dependencies: [],
+            path: ".",
+            exclude: ["src/rcheevos/rc_libretro.c"],
+            sources: ["include", "src/rcheevos", "src/rapi", "src/rhash"],
+            publicHeadersPath: "include",
+            cSettings: [
+                .define("RC_DISABLE_LUA")
+            ]),
+    ]
+)

--- a/include/module.modulemap
+++ b/include/module.modulemap
@@ -47,6 +47,10 @@ module rcheevos {
     
     module rc_runtime {
         header "rc_runtime.h"
+        export *
+    }
+    
+    module rc_runtime_types {
         header "rc_runtime_types.h"
         export *
     }

--- a/include/module.modulemap
+++ b/include/module.modulemap
@@ -1,0 +1,67 @@
+module rcheevos {
+    umbrella header "rcheevos.h"
+    
+    module rapi {
+        module rc_api_editor {
+            header "rc_api_editor.h"
+            export *
+        }
+        
+        module rc_api_info {
+            header "rc_api_info.h"
+            export *
+        }
+        
+        module rc_api_request {
+            header "rc_api_request.h"
+            export *
+        }
+        
+        module rc_api_runtime {
+            header "rc_api_runtime.h"
+            export *
+        }
+        
+        module rc_api_user {
+            header "rc_api_user.h"
+            export *
+        }
+
+        export *
+    }
+    
+    module rc_client {
+        header "rc_client.h"
+        export *
+    }
+    
+    module rc_consoles {
+        header "rc_consoles.h"
+        export *
+    }
+    
+    module rc_error {
+        header "rc_error.h"
+        export *
+    }
+    
+    module rc_runtime {
+        header "rc_runtime.h"
+        header "rc_runtime_types.h"
+        export *
+    }
+    
+    module rc_hash {
+        header "rc_hash.h"
+        export *
+    }
+    
+    export *
+    module * { export * }
+    
+    //rurl is deprecated
+    explicit module rc_url {
+        header "rc_url.h"
+        export *
+    }
+}


### PR DESCRIPTION
The module map makes it possible for Swift to find rcheevos headers not included in what it expects to be the umbrella header (`rcheevos.h`).