### PR TITLE
Fix qsort with big achievement IDs or unlock times

### DIFF
--- a/src/rcheevos/rc_client.c
+++ b/src/rcheevos/rc_client.c
@@ -2526,16 +2526,21 @@ static int rc_client_compare_achievement_unlock_times(const void* a, const void*
 {
   const rc_client_achievement_t* unlock_a = *(const rc_client_achievement_t**)a;
   const rc_client_achievement_t* unlock_b = *(const rc_client_achievement_t**)b;
-  return (int)(unlock_b->unlock_time - unlock_a->unlock_time);
+  if (unlock_b->unlock_time == unlock_a->unlock_time)
+    return 0;
+  return (unlock_b->unlock_time < unlock_a->unlock_time) ? -1 : 1;
 }
 
 static int rc_client_compare_achievement_progress(const void* a, const void* b)
 {
   const rc_client_achievement_t* unlock_a = *(const rc_client_achievement_t**)a;
   const rc_client_achievement_t* unlock_b = *(const rc_client_achievement_t**)b;
-  if (unlock_b->measured_percent == unlock_a->measured_percent)
-    return (int)(unlock_a->id - unlock_b->id);
-  return (unlock_b->measured_percent > unlock_a->measured_percent) ? 1 : -1;
+  if (unlock_b->measured_percent == unlock_a->measured_percent) {
+    if (unlock_a->id == unlock_b->id)
+      return 0;
+    return (unlock_a->id < unlock_b->id) ? -1 : 1;
+  }
+  return (unlock_b->measured_percent < unlock_a->measured_percent) ? -1 : 1;
 }
 
 static uint8_t rc_client_map_bucket(uint8_t bucket, int grouping)

--- a/test/rcheevos/test_rc_client.c
+++ b/test/rcheevos/test_rc_client.c
@@ -150,6 +150,17 @@ static const char* patchdata_exhaustive = "{\"Success\":true,\"PatchData\":{"
     "\"RichPresencePatch\":\"Display:\\r\\nPoints:@Number(0xH0003)\\r\\n\""
     "}}";
 
+static const char* patchdata_big_ids = "{\"Success\":true,\"PatchData\":{"
+    "\"ID\":1234,\"Title\":\"Sample Game\",\"ConsoleID\":7,\"ImageIcon\":\"/Images/112233.png\","
+    "\"Achievements\":["
+      GENERIC_ACHIEVEMENT_JSON("5", "0xH0005=5") ","
+      GENERIC_ACHIEVEMENT_JSON("6", "M:0xH0006=6") ","
+      GENERIC_ACHIEVEMENT_JSON("4294967295", "0xH0009=9") "," /* UINT_MAX */
+      GENERIC_ACHIEVEMENT_JSON("71", "G:0xX0010=100000")
+    "],"
+    "\"Leaderboards\":[]"
+    "}}";
+
 #define HIDDEN_LEADERBOARD_JSON(id, memaddr, format) "{\"ID\":" id ",\"Title\":\"Leaderboard " id "\"," \
       "\"Description\":\"Desc " id "\",\"Mem\":\"" memaddr "\",\"Format\":\"" format "\",\"Hidden\":true}"
 
@@ -3089,6 +3100,63 @@ static void test_achievement_list_buckets_progress_sort(void)
     ASSERT_STR_EQUALS(list->buckets[1].achievements[0]->measured_progress, "75/100");
     ASSERT_FLOAT_EQUALS(list->buckets[1].achievements[1]->measured_percent, 0.0f);
     ASSERT_STR_EQUALS(list->buckets[1].achievements[1]->measured_progress, "");
+
+    rc_client_destroy_achievement_list(list);
+  }
+
+  rc_client_destroy(g_client);
+}
+
+static void test_achievement_list_buckets_progress_sort_big_ids(void)
+{
+  rc_client_achievement_list_t* list;
+  rc_client_achievement_t** iter;
+  rc_client_achievement_t* achievement;
+
+  uint8_t memory[64];
+  memset(memory, 0, sizeof(memory));
+
+  g_client = mock_client_game_loaded(patchdata_big_ids, no_unlocks);
+  mock_memory(memory, sizeof(memory));
+
+  rc_client_do_frame(g_client); /* advance achievements out of waiting state */
+  event_count = 0;
+
+  g_client->game->subsets->achievements[0].trigger->measured_target = 100;
+  g_client->game->subsets->achievements[0].trigger->measured_value = 86;
+  g_client->game->subsets->achievements[1].trigger->measured_target = 100;
+  g_client->game->subsets->achievements[1].trigger->measured_value = 85;
+  g_client->game->subsets->achievements[2].trigger->measured_target = 100;
+  g_client->game->subsets->achievements[2].trigger->measured_value = 85;
+
+  list = rc_client_create_achievement_list(g_client, RC_CLIENT_ACHIEVEMENT_CATEGORY_CORE, RC_CLIENT_ACHIEVEMENT_LIST_GROUPING_PROGRESS);
+  ASSERT_PTR_NOT_NULL(list);
+  if (list) {
+    ASSERT_NUM_EQUALS(list->num_buckets, 2);
+
+    ASSERT_NUM_EQUALS(list->buckets[0].bucket_type, RC_CLIENT_ACHIEVEMENT_BUCKET_ALMOST_THERE);
+    ASSERT_NUM_EQUALS(list->buckets[0].subset_id, 0);
+    ASSERT_STR_EQUALS(list->buckets[0].label, "Almost There");
+    ASSERT_NUM_EQUALS(list->buckets[0].num_achievements, 3);
+    iter = list->buckets[0].achievements;
+    achievement = *iter++;
+    ASSERT_FLOAT_EQUALS(achievement->measured_percent, 86.0f);
+    ASSERT_STR_EQUALS(achievement->measured_progress, "86/100");
+    achievement = *iter++;
+    ASSERT_FLOAT_EQUALS(achievement->measured_percent, 85.0f);
+    ASSERT_STR_EQUALS(achievement->measured_progress, "85/100");
+    ASSERT_NUM_EQUALS(achievement->id, 6);
+    achievement = *iter++;
+    ASSERT_FLOAT_EQUALS(achievement->measured_percent, 85.0f);
+    ASSERT_STR_EQUALS(achievement->measured_progress, "85/100");
+    ASSERT_NUM_EQUALS(achievement->id, 4294967295UL);
+
+    ASSERT_NUM_EQUALS(list->buckets[1].bucket_type, RC_CLIENT_ACHIEVEMENT_BUCKET_LOCKED);
+    ASSERT_NUM_EQUALS(list->buckets[1].subset_id, 0);
+    ASSERT_STR_EQUALS(list->buckets[1].label, "Locked");
+    ASSERT_NUM_EQUALS(list->buckets[1].num_achievements, 1);
+    ASSERT_FLOAT_EQUALS(list->buckets[1].achievements[0]->measured_percent, 0.0f);
+    ASSERT_STR_EQUALS(list->buckets[1].achievements[0]->measured_progress, "");
 
     rc_client_destroy_achievement_list(list);
   }
@@ -7706,6 +7774,7 @@ void test_client(void) {
   TEST(test_achievement_list_simple_with_unofficial_off);
   TEST(test_achievement_list_buckets);
   TEST(test_achievement_list_buckets_progress_sort);
+  TEST(test_achievement_list_buckets_progress_sort_big_ids);
   TEST(test_achievement_list_subset_with_unofficial_and_unsupported);
   TEST(test_achievement_list_subset_buckets);
   TEST(test_achievement_list_subset_buckets_subset_first);


### PR DESCRIPTION
As mentioned in https://github.com/RetroAchievements/rcheevos/commit/f207be8d01f7e39ced6a8d60303f872b30ee8bc3#r127529070, existing `qsort` predicates can under/overflow with input values big enough. Consider the following case for achievement IDs, but an equivalent scenario is possible for unlock times too.

* Achievement A has ID 5 and progress 50.0.
* Achievement B has ID 4294967295 (UINT_MAX) and progress 50.0.

As per the intended sorting rules, achievement A should come before achievement B. Howver, calculations done the way they are currently end up overflowing on `A->ID - B->ID`, in this case producing the result `6`. This, being a positive number, signals to `qsort` to put A after B.

This PR changes comparisons to be explicit and not rely on subtractions to avoid issues like this. A **new** test with such edge case data has been added and verified to fail without this PR and pass with it.