### PR TITLE
update actions/checkout to v4

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Install dependencies
       run: |
         sudo apt-get update
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Install dependencies
       run: |
         sudo apt-get update
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Install dependencies
       run: |
         sudo apt-get update
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Install dependencies
       run: |
         sudo apt-get update
@@ -89,7 +89,7 @@ jobs:
     runs-on: windows-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Install MSBuild
       uses: microsoft/setup-msbuild@v1.0.2
     - name: Build
@@ -103,7 +103,7 @@ jobs:
     runs-on: windows-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Build
       run: make ARCH=x64 BUILD=c89 CC=gcc test
       working-directory: test


### PR DESCRIPTION
Updating [actions/checkout](https://github.com/actions/checkout) to v4.

Zero impact expected.

Just to prevent warnings like this ([link](https://github.com/RetroAchievements/rcheevos/actions/runs/6243334316)):
![image](https://github.com/RetroAchievements/rcheevos/assets/8508804/ffb842d4-cb24-4c1f-8b95-9f9bbfb5614a)
