### PR TITLE
convert server error code strings to return values

### DIFF
--- a/include/rc_api_request.h
+++ b/include/rc_api_request.h
@@ -59,6 +59,8 @@ typedef struct rc_api_response_t {
   int succeeded;
   /* Server-provided message associated to the failure */
   const char* error_message;
+  /* Server-provided error code associated to the failure */
+  const char* error_code;
 
   /* Storage for the response data */
   rc_api_buffer_t buffer;

--- a/include/rc_error.h
+++ b/include/rc_error.h
@@ -42,7 +42,10 @@ enum {
   RC_NO_GAME_LOADED = -29,
   RC_HARDCORE_DISABLED = -30,
   RC_ABORTED = -31,
-  RC_NO_RESPONSE = -32
+  RC_NO_RESPONSE = -32,
+  RC_ACCESS_DENIED = -33,
+  RC_INVALID_CREDENTIALS = -34,
+  RC_EXPIRED_TOKEN = -35
 };
 
 const char* rc_error_str(int ret);

--- a/src/rapi/rc_api_user.c
+++ b/src/rapi/rc_api_user.c
@@ -47,6 +47,7 @@ int rc_api_process_login_server_response(rc_api_login_response_t* response, cons
   rc_json_field_t fields[] = {
     RC_JSON_NEW_FIELD("Success"),
     RC_JSON_NEW_FIELD("Error"),
+    RC_JSON_NEW_FIELD("Code"),
     RC_JSON_NEW_FIELD("User"),
     RC_JSON_NEW_FIELD("Token"),
     RC_JSON_NEW_FIELD("Score"),
@@ -62,16 +63,16 @@ int rc_api_process_login_server_response(rc_api_login_response_t* response, cons
   if (result != RC_OK || !response->response.succeeded)
     return result;
 
-  if (!rc_json_get_required_string(&response->username, &response->response, &fields[2], "User"))
+  if (!rc_json_get_required_string(&response->username, &response->response, &fields[3], "User"))
     return RC_MISSING_VALUE;
-  if (!rc_json_get_required_string(&response->api_token, &response->response, &fields[3], "Token"))
+  if (!rc_json_get_required_string(&response->api_token, &response->response, &fields[4], "Token"))
     return RC_MISSING_VALUE;
 
-  rc_json_get_optional_unum(&response->score, &fields[4], "Score", 0);
-  rc_json_get_optional_unum(&response->score_softcore, &fields[5], "SoftcoreScore", 0);
-  rc_json_get_optional_unum(&response->num_unread_messages, &fields[6], "Messages", 0);
+  rc_json_get_optional_unum(&response->score, &fields[5], "Score", 0);
+  rc_json_get_optional_unum(&response->score_softcore, &fields[6], "SoftcoreScore", 0);
+  rc_json_get_optional_unum(&response->num_unread_messages, &fields[7], "Messages", 0);
 
-  rc_json_get_optional_string(&response->display_name, &response->response, &fields[7], "DisplayName", response->username);
+  rc_json_get_optional_string(&response->display_name, &response->response, &fields[8], "DisplayName", response->username);
 
   return RC_OK;
 }

--- a/src/rcheevos/alloc.c
+++ b/src/rcheevos/alloc.c
@@ -206,6 +206,9 @@ const char* rc_error_str(int ret)
     case RC_HARDCORE_DISABLED: return "Hardcore disabled";
     case RC_ABORTED: return "Aborted";
     case RC_NO_RESPONSE: return "No response";
+    case RC_ACCESS_DENIED: return "Access denied";
+    case RC_INVALID_CREDENTIALS: return "Invalid credentials";
+    case RC_EXPIRED_TOKEN: return "Expired token";
     default: return "Unknown error";
   }
 }

--- a/test/rcheevos/test_rc_client.c
+++ b/test/rcheevos/test_rc_client.c
@@ -703,7 +703,7 @@ static void test_login_required_fields(void)
 
 static void rc_client_callback_expect_credentials_error(int result, const char* error_message, rc_client_t* client, void* callback_userdata)
 {
-  ASSERT_NUM_EQUALS(result, RC_API_FAILURE);
+  ASSERT_NUM_EQUALS(result, RC_INVALID_CREDENTIALS);
   ASSERT_STR_EQUALS(error_message, "Invalid User/Password combination. Please try again");
   ASSERT_PTR_EQUALS(client, g_client);
   ASSERT_PTR_EQUALS(callback_userdata, g_callback_userdata);
@@ -713,9 +713,80 @@ static void test_login_with_incorrect_password(void)
 {
   g_client = mock_client_not_logged_in();
   reset_mock_api_handlers();
-  mock_api_error("r=login&u=User&p=Pa%24%24word", "{\"Success\":false,\"Error\":\"Invalid User/Password combination. Please try again\"}", 403);
+  mock_api_error("r=login&u=User&p=Pa%24%24word",
+      "{\"Success\":false,\"Error\":\"Invalid User/Password combination. Please try again\","
+       "\"Status\":401,\"Code\":\"invalid_credentials\"}", 401);
 
   rc_client_begin_login_with_password(g_client, "User", "Pa$$word", rc_client_callback_expect_credentials_error, g_callback_userdata);
+
+  ASSERT_PTR_NULL(rc_client_get_user_info(g_client));
+
+  rc_client_destroy(g_client);
+}
+
+static void rc_client_callback_expect_token_error(int result, const char* error_message, rc_client_t* client, void* callback_userdata)
+{
+  ASSERT_NUM_EQUALS(result, RC_INVALID_CREDENTIALS);
+  ASSERT_STR_EQUALS(error_message, "Invalid User/Token combination.");
+  ASSERT_PTR_EQUALS(client, g_client);
+  ASSERT_PTR_EQUALS(callback_userdata, g_callback_userdata);
+}
+
+static void test_login_with_incorrect_token(void)
+{
+  g_client = mock_client_not_logged_in();
+  reset_mock_api_handlers();
+  mock_api_error("r=login&u=User&t=TOKEN",
+      "{\"Success\":false,\"Error\":\"Invalid User/Token combination.\","
+      "\"Status\":401,\"Code\":\"invalid_credentials\"}", 401);
+
+  rc_client_begin_login_with_token(g_client, "User", "TOKEN", rc_client_callback_expect_token_error, g_callback_userdata);
+
+  ASSERT_PTR_NULL(rc_client_get_user_info(g_client));
+
+  rc_client_destroy(g_client);
+}
+
+static void rc_client_callback_expect_expired_token(int result, const char* error_message, rc_client_t* client, void* callback_userdata)
+{
+  ASSERT_NUM_EQUALS(result, RC_EXPIRED_TOKEN);
+  ASSERT_STR_EQUALS(error_message, "The access token has expired. Please log in again.");
+  ASSERT_PTR_EQUALS(client, g_client);
+  ASSERT_PTR_EQUALS(callback_userdata, g_callback_userdata);
+}
+
+static void test_login_with_expired_token(void)
+{
+  g_client = mock_client_not_logged_in();
+  reset_mock_api_handlers();
+  mock_api_error("r=login&u=User&t=EXPIRED",
+      "{\"Success\":false,\"Error\":\"The access token has expired. Please log in again.\","
+      "\"Status\":401,\"Code\":\"expired_token\"}", 403);
+
+  rc_client_begin_login_with_token(g_client, "User", "EXPIRED", rc_client_callback_expect_expired_token, g_callback_userdata);
+
+  ASSERT_PTR_NULL(rc_client_get_user_info(g_client));
+
+  rc_client_destroy(g_client);
+}
+
+static void rc_client_callback_expect_access_denied(int result, const char* error_message, rc_client_t* client, void* callback_userdata)
+{
+  ASSERT_NUM_EQUALS(result, RC_ACCESS_DENIED);
+  ASSERT_STR_EQUALS(error_message, "Access denied.");
+  ASSERT_PTR_EQUALS(client, g_client);
+  ASSERT_PTR_EQUALS(callback_userdata, g_callback_userdata);
+}
+
+static void test_login_with_banned_account(void)
+{
+  g_client = mock_client_not_logged_in();
+  reset_mock_api_handlers();
+  mock_api_error("r=login&u=User&p=Pa%24%24word",
+      "{\"Success\":false,\"Error\":\"Access denied.\","
+      "\"Status\":403,\"Code\":\"access_denied\"}", 403);
+
+  rc_client_begin_login_with_password(g_client, "User", "Pa$$word", rc_client_callback_expect_access_denied, g_callback_userdata);
 
   ASSERT_PTR_NULL(rc_client_get_user_info(g_client));
 
@@ -1251,7 +1322,8 @@ static void test_load_game_async_login_with_incorrect_password(void)
 
   /* login failure will trigger process to continue */
   async_api_error("r=login&u=Username&p=Pa%24%24word",
-      "{\"Success\":false,\"Error\":\"Invalid User/Password combination. Please try again\"}", 403);
+      "{\"Success\":false,\"Error\":\"Invalid User/Password combination. Please try again\","
+      "\"Status\":401,\"Code\":\"invalid_credentials\"}", 401);
   assert_api_not_called("r=patch&u=Username&t=ApiToken&g=1234");
 
   ASSERT_PTR_NULL(g_client->user.username);
@@ -7799,6 +7871,9 @@ void test_client(void) {
   TEST(test_login_with_token);
   TEST(test_login_required_fields);
   TEST(test_login_with_incorrect_password);
+  TEST(test_login_with_incorrect_token);
+  TEST(test_login_with_expired_token);
+  TEST(test_login_with_banned_account);
   TEST(test_login_incomplete_response);
   TEST(test_login_with_password_async);
   TEST(test_login_with_password_async_aborted);


### PR DESCRIPTION
Leverages changes made in https://github.com/RetroAchievements/RAWeb/pull/1692 to return more specific error codes for login failures:

| code | description |
| ---- | ----------- |
| RC_INVALID_CREDENTIALS | The provided credentials were not recognized. |
| RC_EXPIRED_TOKEN | The provided token has expired. The user should re-enter their credentials to generate a new token. |
| RC_ACCESS_DENIED | Valid credentials were provided, but the user lacks permission. For login, this typically means the user has not verified their account. |
