### PR TITLE
use explicitly sized fields for addresses/values/ids

### DIFF
--- a/include/rc_api_editor.h
+++ b/include/rc_api_editor.h
@@ -3,6 +3,8 @@
 
 #include "rc_api_request.h"
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -21,7 +23,7 @@ rc_api_fetch_code_notes_request_t;
 /* A code note definiton */
 typedef struct rc_api_code_note_t {
   /* The address the note is associated to */
-  unsigned address;
+  uint32_t address;
   /* The name of the use who last updated the note */
   const char* author;
   /* The contents of the note */
@@ -35,7 +37,7 @@ typedef struct rc_api_fetch_code_notes_response_t {
   /* An array of code notes for the game */
   rc_api_code_note_t* notes;
   /* The number of items in the notes array */
-  unsigned num_notes;
+  uint32_t num_notes;
 
   /* Common server-provided response information */
   rc_api_response_t response;
@@ -58,9 +60,9 @@ typedef struct rc_api_update_code_note_request_t {
   /* The API token from the login request */
   const char* api_token;
   /* The unique identifier of the game */
-  unsigned game_id;
+  uint32_t game_id;
   /* The address the note is associated to */
-  unsigned address;
+  uint32_t address;
   /* The contents of the note (NULL or empty to delete a note) */
   const char* note;
 }
@@ -91,9 +93,9 @@ typedef struct rc_api_update_achievement_request_t {
   /* The API token from the login request */
   const char* api_token;
   /* The unique identifier of the achievement (0 to create a new achievement) */
-  unsigned achievement_id;
+  uint32_t achievement_id;
   /* The unique identifier of the game */
-  unsigned game_id;
+  uint32_t game_id;
   /* The name of the achievement */
   const char* title;
   /* The description of the achievement */
@@ -103,9 +105,9 @@ typedef struct rc_api_update_achievement_request_t {
   /* The serialized trigger for the achievement */
   const char* trigger;
   /* The number of points the achievement is worth */
-  unsigned points;
+  uint32_t points;
   /* The category of the achievement */
-  unsigned category;
+  uint32_t category;
 }
 rc_api_update_achievement_request_t;
 
@@ -114,7 +116,7 @@ rc_api_update_achievement_request_t;
  */
 typedef struct rc_api_update_achievement_response_t {
   /* The unique identifier of the achievement */
-  unsigned achievement_id;
+  uint32_t achievement_id;
 
   /* Common server-provided response information */
   rc_api_response_t response;
@@ -137,9 +139,9 @@ typedef struct rc_api_update_leaderboard_request_t {
   /* The API token from the login request */
   const char* api_token;
   /* The unique identifier of the leaderboard (0 to create a new leaderboard) */
-  unsigned leaderboard_id;
+  uint32_t leaderboard_id;
   /* The unique identifier of the game */
-  unsigned game_id;
+  uint32_t game_id;
   /* The name of the leaderboard */
   const char* title;
   /* The description of the leaderboard */
@@ -155,7 +157,7 @@ typedef struct rc_api_update_leaderboard_request_t {
   /* The format of leaderboard values */
   const char* format;
   /* Whether or not lower scores are better for the leaderboard */
-  int lower_is_better;
+  uint32_t lower_is_better;
 }
 rc_api_update_leaderboard_request_t;
 
@@ -164,7 +166,7 @@ rc_api_update_leaderboard_request_t;
  */
 typedef struct rc_api_update_leaderboard_response_t {
   /* The unique identifier of the leaderboard */
-  unsigned leaderboard_id;
+  uint32_t leaderboard_id;
 
   /* Common server-provided response information */
   rc_api_response_t response;
@@ -183,7 +185,7 @@ void rc_api_destroy_update_leaderboard_response(rc_api_update_leaderboard_respon
  */
 typedef struct rc_api_fetch_badge_range_request_t {
   /* Unused */
-  unsigned unused;
+  uint32_t unused;
 }
 rc_api_fetch_badge_range_request_t;
 
@@ -192,9 +194,9 @@ rc_api_fetch_badge_range_request_t;
  */
 typedef struct rc_api_fetch_badge_range_response_t {
   /* The numeric identifier of the first valid badge ID */
-  unsigned first_badge_id;
+  uint32_t first_badge_id;
   /* The numeric identifier of the first unassigned badge ID */
-  unsigned next_badge_id;
+  uint32_t next_badge_id;
 
   /* Common server-provided response information */
   rc_api_response_t response;
@@ -217,9 +219,9 @@ typedef struct rc_api_add_game_hash_request_t {
   /* The API token from the login request */
   const char* api_token;
   /* The unique identifier of the game (0 to create a new game entry) */
-  unsigned game_id;
+  uint32_t game_id;
   /* The unique identifier of the console for the game */
-  unsigned console_id;
+  uint32_t console_id;
   /* The title of the game */
   const char* title;
   /* The hash being added */
@@ -234,7 +236,7 @@ rc_api_add_game_hash_request_t;
  */
 typedef struct rc_api_add_game_hash_response_t {
   /* The unique identifier of the game */
-  unsigned game_id;
+  uint32_t game_id;
 
   /* Common server-provided response information */
   rc_api_response_t response;

--- a/include/rc_api_info.h
+++ b/include/rc_api_info.h
@@ -3,6 +3,7 @@
 
 #include "rc_api_request.h"
 
+#include <stdint.h>
 #include <time.h>
 
 #ifdef __cplusplus
@@ -20,13 +21,13 @@ typedef struct rc_api_fetch_achievement_info_request_t {
   /* The API token from the login request */
   const char* api_token;
   /* The unique identifier of the achievement */
-  unsigned achievement_id;
+  uint32_t achievement_id;
   /* The 1-based index of the first entry to retrieve */
-  unsigned first_entry;
+  uint32_t first_entry;
   /* The number of entries to retrieve */
-  unsigned count;
+  uint32_t count;
   /* Non-zero to only return unlocks earned by the user's friends */
-  unsigned friends_only;
+  uint32_t friends_only;
 }
 rc_api_fetch_achievement_info_request_t;
 
@@ -44,18 +45,18 @@ rc_api_achievement_awarded_entry_t;
  */
 typedef struct rc_api_fetch_achievement_info_response_t {
   /* The unique identifier of the achievement */
-  unsigned id;
+  uint32_t id;
   /* The unique identifier of the game to which the leaderboard is associated */
-  unsigned game_id;
+  uint32_t game_id;
   /* The number of times the achievement has been awarded */
-  unsigned num_awarded;
+  uint32_t num_awarded;
   /* The number of players that have earned at least one achievement for the game */
-  unsigned num_players;
+  uint32_t num_players;
 
   /* An array of recently rewarded entries */
   rc_api_achievement_awarded_entry_t* recently_awarded;
   /* The number of items in the recently_awarded array */
-  unsigned num_recently_awarded;
+  uint32_t num_recently_awarded;
 
   /* Common server-provided response information */
   rc_api_response_t response;
@@ -74,11 +75,11 @@ void rc_api_destroy_fetch_achievement_info_response(rc_api_fetch_achievement_inf
  */
 typedef struct rc_api_fetch_leaderboard_info_request_t {
   /* The unique identifier of the leaderboard */
-  unsigned leaderboard_id;
+  uint32_t leaderboard_id;
   /* The number of entries to retrieve */
-  unsigned count;
+  uint32_t count;
   /* The 1-based index of the first entry to retrieve */
-  unsigned first_entry;
+  uint32_t first_entry;
   /* The username of the player around whom the entries should be returned */
   const char* username;
 }
@@ -89,11 +90,11 @@ typedef struct rc_api_lboard_info_entry_t {
   /* The user associated to the entry */
   const char* username;
   /* The rank of the entry */
-  unsigned rank;
+  uint32_t rank;
   /* The index of the entry */
-  unsigned index;
+  uint32_t index;
   /* The value of the entry */
-  int score;
+  int32_t score;
   /* When the entry was submitted */
   time_t submitted;
 }
@@ -104,11 +105,11 @@ rc_api_lboard_info_entry_t;
  */
 typedef struct rc_api_fetch_leaderboard_info_response_t {
   /* The unique identifier of the leaderboard */
-  unsigned id;
+  uint32_t id;
   /* The format to pass to rc_format_value to format the leaderboard value */
   int format;
   /* If non-zero, indicates that lower scores appear first */
-  int lower_is_better;
+  uint32_t lower_is_better;
   /* The title of the leaderboard */
   const char* title;
   /* The description of the leaderboard */
@@ -116,7 +117,7 @@ typedef struct rc_api_fetch_leaderboard_info_response_t {
   /* The definition of the leaderboard to be passed to rc_runtime_activate_lboard */
   const char* definition;
   /* The unique identifier of the game to which the leaderboard is associated */
-  unsigned game_id;
+  uint32_t game_id;
   /* The author of the leaderboard */
   const char* author;
   /* When the leaderboard was first uploaded to the server */
@@ -127,7 +128,7 @@ typedef struct rc_api_fetch_leaderboard_info_response_t {
   /* An array of requested entries */
   rc_api_lboard_info_entry_t* entries;
   /* The number of items in the entries array */
-  unsigned num_entries;
+  uint32_t num_entries;
 
   /* Common server-provided response information */
   rc_api_response_t response;
@@ -146,14 +147,14 @@ void rc_api_destroy_fetch_leaderboard_info_response(rc_api_fetch_leaderboard_inf
  */
 typedef struct rc_api_fetch_games_list_request_t {
   /* The unique identifier of the console to query */
-  unsigned console_id;
+  uint32_t console_id;
 }
 rc_api_fetch_games_list_request_t;
 
 /* A game list entry */
 typedef struct rc_api_game_list_entry_t {
   /* The unique identifier of the game */
-  unsigned id;
+  uint32_t id;
   /* The name of the game */
   const char* name;
 }
@@ -166,7 +167,7 @@ typedef struct rc_api_fetch_games_list_response_t {
   /* An array of requested entries */
   rc_api_game_list_entry_t* entries;
   /* The number of items in the entries array */
-  unsigned num_entries;
+  uint32_t num_entries;
 
   /* Common server-provided response information */
   rc_api_response_t response;

--- a/include/rc_api_runtime.h
+++ b/include/rc_api_runtime.h
@@ -3,6 +3,7 @@
 
 #include "rc_api_request.h"
 
+#include <stdint.h>
 #include <time.h>
 
 #ifdef __cplusplus
@@ -19,7 +20,7 @@ typedef struct rc_api_fetch_image_request_t {
   /* The name of the image to fetch */
   const char* image_name;
   /* The type of image to fetch */
-  int image_type;
+  uint32_t image_type;
 }
 rc_api_fetch_image_request_t;
 
@@ -50,7 +51,7 @@ rc_api_resolve_hash_request_t;
  */
 typedef struct rc_api_resolve_hash_response_t {
   /* The unique identifier of the game, 0 if no match was found */
-  unsigned game_id;
+  uint32_t game_id;
 
   /* Common server-provided response information */
   rc_api_response_t response;
@@ -73,14 +74,14 @@ typedef struct rc_api_fetch_game_data_request_t {
   /* The API token from the login request */
   const char* api_token;
   /* The unique identifier of the game */
-  unsigned game_id;
+  uint32_t game_id;
 }
 rc_api_fetch_game_data_request_t;
 
 /* A leaderboard definition */
 typedef struct rc_api_leaderboard_definition_t {
   /* The unique identifier of the leaderboard */
-  unsigned id;
+  uint32_t id;
   /* The format to pass to rc_format_value to format the leaderboard value */
   int format;
   /* The title of the leaderboard */
@@ -90,20 +91,20 @@ typedef struct rc_api_leaderboard_definition_t {
   /* The definition of the leaderboard to be passed to rc_runtime_activate_lboard */
   const char* definition;
   /* Non-zero if lower values are better for this leaderboard */
-  int lower_is_better;
+  uint8_t lower_is_better;
   /* Non-zero if the leaderboard should not be displayed in a list of leaderboards */
-  int hidden;
+  uint8_t hidden;
 }
 rc_api_leaderboard_definition_t;
 
 /* An achievement definition */
 typedef struct rc_api_achievement_definition_t {
   /* The unique identifier of the achievement */
-  unsigned id;
+  uint32_t id;
   /* The number of points the achievement is worth */
-  unsigned points;
+  uint32_t points;
   /* The achievement category (core, unofficial) */
-  unsigned category;
+  uint32_t category;
   /* The title of the achievement */
   const char* title;
   /* The dscription of the achievement */
@@ -129,9 +130,9 @@ rc_api_achievement_definition_t;
  */
 typedef struct rc_api_fetch_game_data_response_t {
   /* The unique identifier of the game */
-  unsigned id;
+  uint32_t id;
   /* The console associated to the game */
-  unsigned console_id;
+  uint32_t console_id;
   /* The title of the game */
   const char* title;
   /* The image name for the game badge */
@@ -142,12 +143,12 @@ typedef struct rc_api_fetch_game_data_response_t {
   /* An array of achievements for the game */
   rc_api_achievement_definition_t* achievements;
   /* The number of items in the achievements array */
-  unsigned num_achievements;
+  uint32_t num_achievements;
 
   /* An array of leaderboards for the game */
   rc_api_leaderboard_definition_t* leaderboards;
   /* The number of items in the leaderboards array */
-  unsigned num_leaderboards;
+  uint32_t num_leaderboards;
 
   /* Common server-provided response information */
   rc_api_response_t response;
@@ -170,7 +171,7 @@ typedef struct rc_api_ping_request_t {
   /* The API token from the login request */
   const char* api_token;
   /* The unique identifier of the game */
-  unsigned game_id;
+  uint32_t game_id;
   /* (optional) The current rich presence evaluation for the user */
   const char* rich_presence;
 }
@@ -201,9 +202,9 @@ typedef struct rc_api_award_achievement_request_t {
   /* The API token from the login request */
   const char* api_token;
   /* The unique identifier of the achievement */
-  unsigned achievement_id;
+  uint32_t achievement_id;
   /* Non-zero if the achievement was earned in hardcore */
-  int hardcore;
+  uint32_t hardcore;
   /* The hash associated to the game being played */
   const char* game_hash;
 }
@@ -214,14 +215,14 @@ rc_api_award_achievement_request_t;
  */
 typedef struct rc_api_award_achievement_response_t {
   /* The unique identifier of the achievement that was awarded */
-  unsigned awarded_achievement_id;
+  uint32_t awarded_achievement_id;
   /* The updated player score */
-  unsigned new_player_score;
+  uint32_t new_player_score;
   /* The updated player softcore score */
-  unsigned new_player_score_softcore;
+  uint32_t new_player_score_softcore;
   /* The number of achievements the user has not yet unlocked for this game
    * (in hardcore/non-hardcore per hardcore flag in request) */
-  unsigned achievements_remaining;
+  uint32_t achievements_remaining;
 
   /* Common server-provided response information */
   rc_api_response_t response;
@@ -244,9 +245,9 @@ typedef struct rc_api_submit_lboard_entry_request_t {
   /* The API token from the login request */
   const char* api_token;
   /* The unique identifier of the leaderboard */
-  unsigned leaderboard_id;
+  uint32_t leaderboard_id;
   /* The value being submitted */
-  int score;
+  int32_t score;
   /* The hash associated to the game being played */
   const char* game_hash;
 }
@@ -257,9 +258,9 @@ typedef struct rc_api_lboard_entry_t {
   /* The user associated to the entry */
   const char* username;
   /* The rank of the entry */
-  unsigned rank;
+  uint32_t rank;
   /* The value of the entry */
-  int score;
+  int32_t score;
 }
 rc_api_lboard_entry_t;
 
@@ -268,18 +269,18 @@ rc_api_lboard_entry_t;
  */
 typedef struct rc_api_submit_lboard_entry_response_t {
   /* The value that was submitted */
-  int submitted_score;
+  int32_t submitted_score;
   /* The player's best submitted value */
-  int best_score;
+  int32_t best_score;
   /* The player's new rank within the leaderboard */
-  unsigned new_rank;
+  uint32_t new_rank;
   /* The total number of entries in the leaderboard */
-  unsigned num_entries;
+  uint32_t num_entries;
 
   /* An array of the top entries for the leaderboard */
   rc_api_lboard_entry_t* top_entries;
   /* The number of items in the top_entries array */
-  unsigned num_top_entries;
+  uint32_t num_top_entries;
 
   /* Common server-provided response information */
   rc_api_response_t response;

--- a/include/rc_api_user.h
+++ b/include/rc_api_user.h
@@ -3,6 +3,7 @@
 
 #include "rc_api_request.h"
 
+#include <stdint.h>
 #include <time.h>
 
 #ifdef __cplusplus
@@ -34,11 +35,11 @@ typedef struct rc_api_login_response_t {
   /* The API token to use for all future requests */
   const char* api_token;
   /* The current score of the player */
-  unsigned score;
+  uint32_t score;
   /* The current softcore score of the player */
-  unsigned score_softcore;
+  uint32_t score_softcore;
   /* The number of unread messages waiting for the player on the web site */
-  unsigned num_unread_messages;
+  uint32_t num_unread_messages;
   /* The preferred name to display for the player */
   const char* display_name;
 
@@ -63,7 +64,7 @@ typedef struct rc_api_start_session_request_t {
   /* The API token from the login request */
   const char* api_token;
   /* The unique identifier of the game */
-  unsigned game_id;
+  uint32_t game_id;
 }
 rc_api_start_session_request_t;
 
@@ -72,7 +73,7 @@ rc_api_start_session_request_t;
  */
 typedef struct rc_api_unlock_entry_t {
   /* The unique identifier of the unlocked achievement */
-  unsigned achievement_id;
+  uint32_t achievement_id;
   /* When the achievement was unlocked */
   time_t when;
 }
@@ -88,9 +89,9 @@ typedef struct rc_api_start_session_response_t {
   rc_api_unlock_entry_t* unlocks;
 
   /* The number of items in the hardcore_unlocks array */
-  unsigned num_hardcore_unlocks;
+  uint32_t num_hardcore_unlocks;
   /* The number of items in the unlocks array */
-  unsigned num_unlocks;
+  uint32_t num_unlocks;
 
   /* The server timestamp when the response was generated */
   time_t server_now;
@@ -116,9 +117,9 @@ typedef struct rc_api_fetch_user_unlocks_request_t {
   /* The API token from the login request */
   const char* api_token;
   /* The unique identifier of the game */
-  unsigned game_id;
+  uint32_t game_id;
   /* Non-zero to fetch hardcore unlocks, 0 to fetch non-hardcore unlocks */
-  int hardcore;
+  uint32_t hardcore;
 }
 rc_api_fetch_user_unlocks_request_t;
 
@@ -127,9 +128,9 @@ rc_api_fetch_user_unlocks_request_t;
  */
 typedef struct rc_api_fetch_user_unlocks_response_t {
   /* An array of achievement IDs previously unlocked by the user */
-  unsigned* achievement_ids;
+  uint32_t* achievement_ids;
   /* The number of items in the achievement_ids array */
-  unsigned num_achievement_ids;
+  uint32_t num_achievement_ids;
 
   /* Common server-provided response information */
   rc_api_response_t response;

--- a/include/rc_runtime.h
+++ b/include/rc_runtime.h
@@ -8,6 +8,7 @@ extern "C" {
 #include "rc_error.h"
 
 #include <stddef.h>
+#include <stdint.h>
 
 /*****************************************************************************\
 | Forward Declarations (defined in rc_runtime_types.h)                        |
@@ -34,32 +35,32 @@ typedef struct rc_value_t rc_value_t;
  * num_bytes is greater than 1, the value is read in little-endian from
  * memory.
  */
-typedef unsigned (*rc_runtime_peek_t)(unsigned address, unsigned num_bytes, void* ud);
+typedef uint32_t(*rc_runtime_peek_t)(uint32_t address, uint32_t num_bytes, void* ud);
 
 /*****************************************************************************\
 | Runtime                                                                     |
 \*****************************************************************************/
 
 typedef struct rc_runtime_trigger_t {
-  unsigned id;
+  uint32_t id;
   rc_trigger_t* trigger;
   void* buffer;
   rc_memref_t* invalid_memref;
   unsigned char md5[16];
-  int serialized_size;
-  char owns_memrefs;
+  int32_t serialized_size;
+  uint8_t owns_memrefs;
 }
 rc_runtime_trigger_t;
 
 typedef struct rc_runtime_lboard_t {
-  unsigned id;
-  int value;
+  uint32_t id;
+  int32_t value;
   rc_lboard_t* lboard;
   void* buffer;
   rc_memref_t* invalid_memref;
   unsigned char md5[16];
-  int serialized_size;
-  char owns_memrefs;
+  uint32_t serialized_size;
+  uint8_t owns_memrefs;
 }
 rc_runtime_lboard_t;
 
@@ -68,18 +69,18 @@ typedef struct rc_runtime_richpresence_t {
   void* buffer;
   struct rc_runtime_richpresence_t* previous;
   unsigned char md5[16];
-  char owns_memrefs;
+  uint8_t owns_memrefs;
 }
 rc_runtime_richpresence_t;
 
 typedef struct rc_runtime_t {
   rc_runtime_trigger_t* triggers;
-  unsigned trigger_count;
-  unsigned trigger_capacity;
+  uint32_t trigger_count;
+  uint32_t trigger_capacity;
 
   rc_runtime_lboard_t* lboards;
-  unsigned lboard_count;
-  unsigned lboard_capacity;
+  uint32_t lboard_count;
+  uint32_t lboard_capacity;
 
   rc_runtime_richpresence_t* richpresence;
 
@@ -89,7 +90,7 @@ typedef struct rc_runtime_t {
   rc_value_t* variables;
   rc_value_t** next_variable;
 
-  char owns_self;
+  uint8_t owns_self;
 }
 rc_runtime_t;
 
@@ -129,9 +130,9 @@ enum {
 };
 
 typedef struct rc_runtime_event_t {
-  unsigned id;
-  int value;
-  char type;
+  uint32_t id;
+  int32_t value;
+  uint8_t type;
 }
 rc_runtime_event_t;
 
@@ -140,9 +141,9 @@ typedef void (*rc_runtime_event_handler_t)(const rc_runtime_event_t* runtime_eve
 void rc_runtime_do_frame(rc_runtime_t* runtime, rc_runtime_event_handler_t event_handler, rc_runtime_peek_t peek, void* ud, lua_State* L);
 void rc_runtime_reset(rc_runtime_t* runtime);
 
-typedef int (*rc_runtime_validate_address_t)(unsigned address);
+typedef int (*rc_runtime_validate_address_t)(uint32_t address);
 void rc_runtime_validate_addresses(rc_runtime_t* runtime, rc_runtime_event_handler_t event_handler, rc_runtime_validate_address_t validate_handler);
-void rc_runtime_invalidate_address(rc_runtime_t* runtime, unsigned address);
+void rc_runtime_invalidate_address(rc_runtime_t* runtime, uint32_t address);
 
 int rc_runtime_progress_size(const rc_runtime_t* runtime, lua_State* L);
 int rc_runtime_serialize_progress(void* buffer, const rc_runtime_t* runtime, lua_State* L);

--- a/include/rc_runtime_types.h
+++ b/include/rc_runtime_types.h
@@ -7,6 +7,8 @@ extern "C" {
 
 #include "rc_error.h"
 
+#include <stdint.h>
+
 #ifndef RC_RUNTIME_H /* prevents pedantic redefiniton error */
 
 typedef struct lua_State lua_State;
@@ -28,7 +30,7 @@ typedef struct rc_value_t rc_value_t;
  * num_bytes is greater than 1, the value is read in little-endian from
  * memory.
  */
-typedef unsigned (*rc_peek_t)(unsigned address, unsigned num_bytes, void* ud);
+typedef uint32_t(*rc_peek_t)(uint32_t address, uint32_t num_bytes, void* ud);
 
 /*****************************************************************************\
 | Memory References                                                           |
@@ -63,19 +65,19 @@ enum {
 
 typedef struct rc_memref_value_t {
   /* The current value of this memory reference. */
-  unsigned value;
+  uint32_t value;
   /* The last differing value of this memory reference. */
-  unsigned prior;
+  uint32_t prior;
 
   /* The size of the value. */
-  char size;
+  uint8_t size;
   /* True if the value changed this frame. */
-  char changed;
+  uint8_t changed;
   /* The value type of the value (for variables) */
-  char type;
+  uint8_t type;
   /* True if the reference will be used in indirection.
    * NOTE: This is actually a property of the rc_memref_t, but we put it here to save space */
-  char is_indirect;
+  uint8_t is_indirect;
 }
 rc_memref_value_t;
 
@@ -84,7 +86,7 @@ struct rc_memref_t {
   rc_memref_value_t value;
 
   /* The memory address of this variable. */
-  unsigned address;
+  uint32_t address;
 
   /* The next memory reference in the chain. */
   rc_memref_t* next;
@@ -112,7 +114,7 @@ typedef struct rc_operand_t {
     rc_memref_t* memref;
 
     /* An integer value. */
-    unsigned num;
+    uint32_t num;
 
     /* A floating point value. */
     double dbl;
@@ -122,10 +124,10 @@ typedef struct rc_operand_t {
   } value;
 
   /* specifies which member of the value union is being used */
-  char type;
+  uint8_t type;
 
   /* the actual RC_MEMSIZE of the operand - memref.size may differ */
-  char size;
+  uint8_t size;
 }
 rc_operand_t;
 
@@ -183,27 +185,27 @@ struct rc_condition_t {
   rc_operand_t operand2;
 
   /* Required hits to fire this condition. */
-  unsigned required_hits;
+  uint32_t required_hits;
   /* Number of hits so far. */
-  unsigned current_hits;
+  uint32_t current_hits;
 
   /* The next condition in the chain. */
   rc_condition_t* next;
 
-  /* The type of the condition. */
-  char type;
+  /* The type of the condition. (RC_CONDITION_*) */
+  uint8_t type;
 
-  /* The comparison operator to use. */
-  char oper; /* operator is a reserved word in C++. */
+  /* The comparison operator to use. (RC_OPERATOR_*) */
+  uint8_t oper; /* operator is a reserved word in C++. */
 
-  /* Set if the condition needs to processed as part of the "check if paused" pass. */
-  char pause;
+  /* Set if the condition needs to processed as part of the "check if paused" pass. (bool) */
+  uint8_t pause;
 
-  /* Whether or not the condition evaluated true on the last check */
-  char is_true;
+  /* Whether or not the condition evaluated true on the last check. (bool) */
+  uint8_t is_true;
 
-  /* Unique identifier of optimized comparator to use */
-  char optimized_comparator;
+  /* Unique identifier of optimized comparator to use. (RC_PROCESSING_COMPARE_*) */
+  uint8_t optimized_comparator;
 };
 
 /*****************************************************************************\
@@ -220,13 +222,13 @@ struct rc_condset_t {
   rc_condition_t* conditions;
 
   /* True if any condition in the set is a pause condition. */
-  char has_pause;
+  uint8_t has_pause;
 
   /* True if the set is currently paused. */
-  char is_paused;
+  uint8_t is_paused;
 
   /* True if the set has indirect memory references. */
-  char has_indirect_memrefs;
+  uint8_t has_indirect_memrefs;
 };
 
 /*****************************************************************************\
@@ -255,22 +257,22 @@ struct rc_trigger_t {
   rc_memref_t* memrefs;
 
   /* The current state of the MEASURED condition. */
-  unsigned measured_value;
+  uint32_t measured_value;
 
   /* The target state of the MEASURED condition */
-  unsigned measured_target;
+  uint32_t measured_target;
 
   /* The current state of the trigger */
-  char state;
+  uint8_t state;
 
   /* True if at least one condition has a non-zero hit count */
-  char has_hits;
+  uint8_t has_hits;
 
   /* True if at least one condition has a non-zero required hit count */
-  char has_required_hits;
+  uint8_t has_required_hits;
 
   /* True if the measured value should be displayed as a percentage */
-  char measured_as_percent;
+  uint8_t measured_as_percent;
 };
 
 int rc_trigger_size(const char* memaddr);
@@ -327,7 +329,7 @@ struct rc_lboard_t {
   rc_value_t* progress;
   rc_memref_t* memrefs;
 
-  char state;
+  uint8_t state;
 };
 
 int rc_lboard_size(const char* memaddr);
@@ -366,8 +368,8 @@ int rc_format_value(char* buffer, int size, int value, int format);
 typedef struct rc_richpresence_lookup_item_t rc_richpresence_lookup_item_t;
 
 struct rc_richpresence_lookup_item_t {
-  unsigned first;
-  unsigned last;
+  uint32_t first;
+  uint32_t last;
   rc_richpresence_lookup_item_t* left;
   rc_richpresence_lookup_item_t* right;
   const char* label;
@@ -380,7 +382,7 @@ struct rc_richpresence_lookup_t {
   rc_richpresence_lookup_t* next;
   const char* name;
   const char* default_label;
-  unsigned short format;
+  uint8_t format;
 };
 
 typedef struct rc_richpresence_display_part_t rc_richpresence_display_part_t;
@@ -390,7 +392,7 @@ struct rc_richpresence_display_part_t {
   const char* text;
   rc_richpresence_lookup_t* lookup;
   rc_memref_value_t *value;
-  unsigned short display_type;
+  uint8_t display_type;
 };
 
 typedef struct rc_richpresence_display_t rc_richpresence_display_t;

--- a/src/rapi/rc_api_info.c
+++ b/src/rapi/rc_api_info.c
@@ -217,7 +217,7 @@ int rc_api_process_fetch_leaderboard_info_server_response(rc_api_fetch_leaderboa
 
   if (!rc_json_get_required_unum(&response->id, &response->response, &leaderboarddata_fields[0], "LBID"))
     return RC_MISSING_VALUE;
-  if (!rc_json_get_required_num(&response->lower_is_better, &response->response, &leaderboarddata_fields[2], "LowerIsBetter"))
+  if (!rc_json_get_required_unum(&response->lower_is_better, &response->response, &leaderboarddata_fields[2], "LowerIsBetter"))
     return RC_MISSING_VALUE;
   if (!rc_json_get_required_string(&response->title, &response->response, &leaderboarddata_fields[3], "LBTitle"))
     return RC_MISSING_VALUE;

--- a/src/rapi/rc_api_runtime.c
+++ b/src/rapi/rc_api_runtime.c
@@ -273,8 +273,10 @@ int rc_api_process_fetch_game_data_server_response(rc_api_fetch_game_data_respon
         return RC_MISSING_VALUE;
       if (!rc_json_get_required_string(&leaderboard->definition, &response->response, &leaderboard_fields[3], "Mem"))
         return RC_MISSING_VALUE;
-      rc_json_get_optional_bool(&leaderboard->lower_is_better, &leaderboard_fields[5], "LowerIsBetter", 0);
-      rc_json_get_optional_bool(&leaderboard->hidden, &leaderboard_fields[6], "Hidden", 0);
+      rc_json_get_optional_bool(&result, &leaderboard_fields[5], "LowerIsBetter", 0);
+      leaderboard->lower_is_better = (uint8_t)result;
+      rc_json_get_optional_bool(&result, &leaderboard_fields[6], "Hidden", 0);
+      leaderboard->hidden = (uint8_t)result;
 
       if (!leaderboard_fields[4].value_end)
         return RC_MISSING_VALUE;

--- a/src/rc_client.c
+++ b/src/rc_client.c
@@ -3984,10 +3984,10 @@ static void rc_client_invalidate_processing_memref(rc_client_t* client)
   client->state.processing_memref = NULL;
 }
 
-static unsigned rc_client_peek_le(unsigned address, unsigned num_bytes, void* ud)
+static uint32_t rc_client_peek_le(uint32_t address, uint32_t num_bytes, void* ud)
 {
   rc_client_t* client = (rc_client_t*)ud;
-  unsigned value = 0;
+  uint32_t value = 0;
   uint32_t num_read = 0;
 
   /* if we know the address is out of range, and it's part of a pointer chain
@@ -4007,7 +4007,7 @@ static unsigned rc_client_peek_le(unsigned address, unsigned num_bytes, void* ud
   return 0;
 }
 
-static unsigned rc_client_peek(unsigned address, unsigned num_bytes, void* ud)
+static uint32_t rc_client_peek(uint32_t address, uint32_t num_bytes, void* ud)
 {
   rc_client_t* client = (rc_client_t*)ud;
   uint8_t buffer[4];

--- a/src/rcheevos/condition.c
+++ b/src/rcheevos/condition.c
@@ -149,7 +149,7 @@ static int rc_parse_operator(const char** memaddr) {
   }
 }
 
-rc_condition_t* rc_parse_condition(const char** memaddr, rc_parse_state_t* parse, int is_indirect) {
+rc_condition_t* rc_parse_condition(const char** memaddr, rc_parse_state_t* parse, uint8_t is_indirect) {
   rc_condition_t* self;
   const char* aux;
   int result;

--- a/src/rcheevos/memref.c
+++ b/src/rcheevos/memref.c
@@ -6,7 +6,7 @@
 
 #define MEMREF_PLACEHOLDER_ADDRESS 0xFFFFFFFF
 
-rc_memref_t* rc_alloc_memref(rc_parse_state_t* parse, unsigned address, char size, char is_indirect) {
+rc_memref_t* rc_alloc_memref(rc_parse_state_t* parse, uint32_t address, uint8_t size, uint8_t is_indirect) {
   rc_memref_t** next_memref;
   rc_memref_t* memref;
 
@@ -41,7 +41,7 @@ rc_memref_t* rc_alloc_memref(rc_parse_state_t* parse, unsigned address, char siz
   return memref;
 }
 
-int rc_parse_memref(const char** memaddr, char* size, unsigned* address) {
+int rc_parse_memref(const char** memaddr, uint8_t* size, uint32_t* address) {
   const char* aux = *memaddr;
   char* end;
   unsigned long value;
@@ -114,7 +114,7 @@ int rc_parse_memref(const char** memaddr, char* size, unsigned* address) {
   if (value > 0xffffffffU)
     value = 0xffffffffU;
 
-  *address = (unsigned)value;
+  *address = (uint32_t)value;
   *memaddr = end;
   return RC_OK;
 }
@@ -230,9 +230,9 @@ static void rc_transform_memref_mbf32_le(rc_typed_value_t* value) {
   value->type = RC_VALUE_TYPE_FLOAT;
 }
 
-static const unsigned char rc_bits_set[16] = { 0,1,1,2,1,2,2,3,1,2,2,3,2,3,3,4 };
+static const uint8_t rc_bits_set[16] = { 0,1,1,2,1,2,2,3,1,2,2,3,2,3,3,4 };
 
-void rc_transform_memref_value(rc_typed_value_t* value, char size) {
+void rc_transform_memref_value(rc_typed_value_t* value, uint8_t size) {
   /* ASSERT: value->type == RC_VALUE_TYPE_UNSIGNED */
   switch (size)
   {
@@ -335,7 +335,7 @@ void rc_transform_memref_value(rc_typed_value_t* value, char size) {
   }
 }
 
-static const unsigned rc_memref_masks[] = {
+static const uint32_t rc_memref_masks[] = {
   0x000000ff, /* RC_MEMSIZE_8_BITS     */
   0x0000ffff, /* RC_MEMSIZE_16_BITS    */
   0x00ffffff, /* RC_MEMSIZE_24_BITS    */
@@ -361,7 +361,7 @@ static const unsigned rc_memref_masks[] = {
   0xffffffff  /* RC_MEMSIZE_VARIABLE   */
 };
 
-unsigned rc_memref_mask(char size) {
+uint32_t rc_memref_mask(uint8_t size) {
   const size_t index = (size_t)size;
   if (index >= sizeof(rc_memref_masks) / sizeof(rc_memref_masks[0]))
     return 0xffffffff;
@@ -372,7 +372,7 @@ unsigned rc_memref_mask(char size) {
 /* all sizes less than 8-bits (1 byte) are mapped to 8-bits. 24-bit is mapped to 32-bit
  * as we don't expect the client to understand a request for 3 bytes. all other reads are
  * mapped to the little-endian read of the same size. */
-static const char rc_memref_shared_sizes[] = {
+static const uint8_t rc_memref_shared_sizes[] = {
   RC_MEMSIZE_8_BITS,  /* RC_MEMSIZE_8_BITS     */
   RC_MEMSIZE_16_BITS, /* RC_MEMSIZE_16_BITS    */
   RC_MEMSIZE_32_BITS, /* RC_MEMSIZE_24_BITS    */
@@ -398,7 +398,7 @@ static const char rc_memref_shared_sizes[] = {
   RC_MEMSIZE_32_BITS  /* RC_MEMSIZE_VARIABLE   */
 };
 
-char rc_memref_shared_size(char size) {
+uint8_t rc_memref_shared_size(uint8_t size) {
   const size_t index = (size_t)size;
   if (index >= sizeof(rc_memref_shared_sizes) / sizeof(rc_memref_shared_sizes[0]))
     return size;
@@ -406,7 +406,7 @@ char rc_memref_shared_size(char size) {
   return rc_memref_shared_sizes[index];
 }
 
-unsigned rc_peek_value(unsigned address, char size, rc_peek_t peek, void* ud) {
+uint32_t rc_peek_value(uint32_t address, uint8_t size, rc_peek_t peek, void* ud) {
   if (!peek)
     return 0;
 
@@ -437,7 +437,7 @@ unsigned rc_peek_value(unsigned address, char size, rc_peek_t peek, void* ud) {
   }
 }
 
-void rc_update_memref_value(rc_memref_value_t* memref, unsigned new_value) {
+void rc_update_memref_value(rc_memref_value_t* memref, uint32_t new_value) {
   if (memref->value == new_value) {
     memref->changed = 0;
   }

--- a/src/rcheevos/operand.c
+++ b/src/rcheevos/operand.c
@@ -68,10 +68,10 @@ static int rc_parse_operand_lua(rc_operand_t* self, const char** memaddr, rc_par
   return RC_OK;
 }
 
-static int rc_parse_operand_memory(rc_operand_t* self, const char** memaddr, rc_parse_state_t* parse, int is_indirect) {
+static int rc_parse_operand_memory(rc_operand_t* self, const char** memaddr, rc_parse_state_t* parse, uint8_t is_indirect) {
   const char* aux = *memaddr;
-  unsigned address;
-  char size;
+  uint32_t address;
+  uint8_t size;
   int ret;
 
   switch (*aux) {
@@ -115,7 +115,7 @@ static int rc_parse_operand_memory(rc_operand_t* self, const char** memaddr, rc_
       size = self->size;
   }
 
-  self->value.memref = rc_alloc_memref(parse, address, size, (char)is_indirect);
+  self->value.memref = rc_alloc_memref(parse, address, size, is_indirect);
   if (parse->offset < 0)
     return parse->offset;
 
@@ -123,7 +123,7 @@ static int rc_parse_operand_memory(rc_operand_t* self, const char** memaddr, rc_
   return RC_OK;
 }
 
-int rc_parse_operand(rc_operand_t* self, const char** memaddr, int is_indirect, rc_parse_state_t* parse) {
+int rc_parse_operand(rc_operand_t* self, const char** memaddr, uint8_t is_indirect, rc_parse_state_t* parse) {
   const char* aux = *memaddr;
   char* end;
   int ret;
@@ -286,11 +286,11 @@ typedef struct {
 rc_luapeek_t;
 
 static int rc_luapeek(lua_State* L) {
-  unsigned address = (unsigned)luaL_checkinteger(L, 1);
-  unsigned num_bytes = (unsigned)luaL_checkinteger(L, 2);
+  uint32_t address = (uint32_t)luaL_checkinteger(L, 1);
+  uint32_t num_bytes = (uint32_t)luaL_checkinteger(L, 2);
   rc_luapeek_t* luapeek = (rc_luapeek_t*)lua_touserdata(L, 3);
 
-  unsigned value = luapeek->peek(address, num_bytes, luapeek->ud);
+  uint32_t value = luapeek->peek(address, num_bytes, luapeek->ud);
 
   lua_pushinteger(L, value);
   return 1;
@@ -330,7 +330,7 @@ int rc_operand_is_float(const rc_operand_t* self) {
   return rc_operand_is_float_memref(self);
 }
 
-unsigned rc_transform_operand_value(unsigned value, const rc_operand_t* self) {
+uint32_t rc_transform_operand_value(uint32_t value, const rc_operand_t* self) {
   switch (self->type)
   {
     case RC_OPERAND_BCD:
@@ -451,10 +451,10 @@ void rc_evaluate_operand(rc_typed_value_t* result, rc_operand_t* self, rc_eval_s
 
         if (lua_pcall(eval_state->L, 2, 1, 0) == LUA_OK) {
           if (lua_isboolean(eval_state->L, -1)) {
-            result->value.u32 = (unsigned)lua_toboolean(eval_state->L, -1);
+            result->value.u32 = (uint32_t)lua_toboolean(eval_state->L, -1);
           }
           else {
-            result->value.u32 = (unsigned)lua_tonumber(eval_state->L, -1);
+            result->value.u32 = (uint32_t)lua_tonumber(eval_state->L, -1);
           }
         }
 

--- a/src/rcheevos/rc_internal.h
+++ b/src/rcheevos/rc_internal.h
@@ -42,7 +42,7 @@ RC_ALLOW_ALIGN(char)
 typedef struct rc_scratch_buffer {
   struct rc_scratch_buffer* next;
   int offset;
-  unsigned char buffer[512 - 16];
+  uint8_t buffer[512 - 16];
 }
 rc_scratch_buffer_t;
 
@@ -77,8 +77,8 @@ enum {
 
 typedef struct {
   union {
-    unsigned u32;
-    int i32;
+    uint32_t u32;
+    int32_t i32;
     float f32;
   } value;
 
@@ -90,19 +90,19 @@ rc_typed_value_t;
 
 typedef struct {
   rc_typed_value_t add_value;/* AddSource/SubSource */
-  int add_hits;             /* AddHits */
-  unsigned add_address;     /* AddAddress */
+  int32_t add_hits;             /* AddHits */
+  uint32_t add_address;     /* AddAddress */
 
   rc_peek_t peek;
   void* peek_userdata;
   lua_State* L;
 
   rc_typed_value_t measured_value;  /* Measured */
-  char was_reset;           /* ResetIf triggered */
-  char has_hits;            /* one of more hit counts is non-zero */
-  char primed;              /* true if all non-Trigger conditions are true */
-  char measured_from_hits;  /* true if the measured_value came from a condition's hit count */
-  char was_cond_reset;      /* ResetNextIf triggered */
+  uint8_t was_reset;                /* ResetIf triggered */
+  uint8_t has_hits;                 /* one of more hit counts is non-zero */
+  uint8_t primed;                   /* true if all non-Trigger conditions are true */
+  uint8_t measured_from_hits;       /* true if the measured_value came from a condition's hit count */
+  uint8_t was_cond_reset;           /* ResetNextIf triggered */
 }
 rc_eval_state_t;
 
@@ -118,11 +118,11 @@ typedef struct {
   rc_memref_t** first_memref;
   rc_value_t** variables;
 
-  unsigned measured_target;
+  uint32_t measured_target;
   int lines_read;
 
-  char has_required_hits;
-  char measured_as_percent;
+  uint8_t has_required_hits;
+  uint8_t measured_as_percent;
 }
 rc_parse_state_t;
 
@@ -137,15 +137,15 @@ char* rc_alloc_str(rc_parse_state_t* parse, const char* text, int length);
 
 unsigned rc_djb2(const char* input);
 
-rc_memref_t* rc_alloc_memref(rc_parse_state_t* parse, unsigned address, char size, char is_indirect);
-int rc_parse_memref(const char** memaddr, char* size, unsigned* address);
+rc_memref_t* rc_alloc_memref(rc_parse_state_t* parse, uint32_t address, uint8_t size, uint8_t is_indirect);
+int rc_parse_memref(const char** memaddr, uint8_t* size, uint32_t* address);
 void rc_update_memref_values(rc_memref_t* memref, rc_peek_t peek, void* ud);
-void rc_update_memref_value(rc_memref_value_t* memref, unsigned value);
-unsigned rc_get_memref_value(rc_memref_t* memref, int operand_type, rc_eval_state_t* eval_state);
-char rc_memref_shared_size(char size);
-unsigned rc_memref_mask(char size);
-void rc_transform_memref_value(rc_typed_value_t* value, char size);
-unsigned rc_peek_value(unsigned address, char size, rc_peek_t peek, void* ud);
+void rc_update_memref_value(rc_memref_value_t* memref, uint32_t value);
+uint32_t rc_get_memref_value(rc_memref_t* memref, int operand_type, rc_eval_state_t* eval_state);
+uint8_t rc_memref_shared_size(uint8_t size);
+uint32_t rc_memref_mask(uint8_t size);
+void rc_transform_memref_value(rc_typed_value_t* value, uint8_t size);
+uint32_t rc_peek_value(uint32_t address, uint8_t size, rc_peek_t peek, void* ud);
 
 void rc_parse_trigger_internal(rc_trigger_t* self, const char** memaddr, rc_parse_state_t* parse);
 int rc_trigger_state_active(int state);
@@ -170,12 +170,12 @@ enum {
   RC_PROCESSING_COMPARE_ALWAYS_FALSE
 };
 
-rc_condition_t* rc_parse_condition(const char** memaddr, rc_parse_state_t* parse, int is_indirect);
+rc_condition_t* rc_parse_condition(const char** memaddr, rc_parse_state_t* parse, uint8_t is_indirect);
 int rc_test_condition(rc_condition_t* self, rc_eval_state_t* eval_state);
 void rc_evaluate_condition_value(rc_typed_value_t* value, rc_condition_t* self, rc_eval_state_t* eval_state);
 int rc_condition_is_combining(const rc_condition_t* self);
 
-int rc_parse_operand(rc_operand_t* self, const char** memaddr, int is_indirect, rc_parse_state_t* parse);
+int rc_parse_operand(rc_operand_t* self, const char** memaddr, uint8_t is_indirect, rc_parse_state_t* parse);
 void rc_evaluate_operand(rc_typed_value_t* value, rc_operand_t* self, rc_eval_state_t* eval_state);
 int rc_operand_is_float_memref(const rc_operand_t* self);
 int rc_operand_is_float(const rc_operand_t* self);

--- a/src/rcheevos/richpresence.c
+++ b/src/rcheevos/richpresence.c
@@ -16,8 +16,8 @@ enum {
 static rc_memref_value_t* rc_alloc_helper_variable_memref_value(const char* memaddr, int memaddr_len, rc_parse_state_t* parse) {
   const char* end;
   rc_value_t* variable;
-  unsigned address;
-  char size;
+  uint32_t address;
+  uint8_t size;
 
   /* single memory reference lookups without a modifier flag can be handled without a variable */
   end = memaddr;
@@ -78,7 +78,7 @@ static const char* rc_parse_line(const char* line, const char** end, rc_parse_st
 typedef struct rc_richpresence_builtin_macro_t {
   const char* name;
   size_t name_len;
-  unsigned short display_type;
+  uint8_t display_type;
 } rc_richpresence_builtin_macro_t;
 
 static rc_richpresence_display_t* rc_parse_richpresence_display_internal(const char* line, const char* endline, rc_parse_state_t* parse, rc_richpresence_lookup_t* first_lookup) {
@@ -525,7 +525,7 @@ void rc_parse_richpresence_internal(rc_richpresence_t* self, const char* script,
         memcpy(format, line, chars);
         format[chars] = '\0';
 
-        lookup->format = (unsigned short)rc_parse_format(format);
+        lookup->format = (uint8_t)rc_parse_format(format);
       } else {
         lookup->format = RC_FORMAT_VALUE;
       }

--- a/src/rcheevos/runtime.c
+++ b/src/rcheevos/runtime.c
@@ -814,7 +814,7 @@ static void rc_runtime_invalidate_memref(rc_runtime_t* self, rc_memref_t* memref
   }
 }
 
-void rc_runtime_invalidate_address(rc_runtime_t* self, unsigned address) {
+void rc_runtime_invalidate_address(rc_runtime_t* self, uint32_t address) {
   rc_memref_t** last_memref = &self->memrefs;
   rc_memref_t* memref = self->memrefs;
 

--- a/src/rhash/cdreader.c
+++ b/src/rhash/cdreader.c
@@ -31,7 +31,7 @@ struct cdrom_t
 #endif
 };
 
-static int cdreader_get_sector(unsigned char header[16])
+static int cdreader_get_sector(uint8_t header[16])
 {
   int minutes = (header[12] >> 4) * 10 + (header[12] & 0x0F);
   int seconds = (header[13] >> 4) * 10 + (header[13] & 0x0F);
@@ -50,11 +50,11 @@ static void cdreader_determine_sector_size(struct cdrom_t* cdrom)
    * Then check for the presence of "CD001", which is gauranteed to be in either the
    * boot record or primary volume descriptor, one of which is always at sector 16.
    */
-  const unsigned char sync_pattern[] = {
+  const uint8_t sync_pattern[] = {
     0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x00
   };
 
-  unsigned char header[32];
+  uint8_t header[32];
   const int64_t toc_sector = 16 + cdrom->track_pregap_sectors;
 
   cdrom->sector_size = 0;

--- a/test/rcheevos/mock_memory.h
+++ b/test/rcheevos/mock_memory.h
@@ -2,16 +2,16 @@
 #define MOCK_MEMORY_H
 
 typedef struct {
-  unsigned char* ram;
-  unsigned size;
+  uint8_t* ram;
+  uint32_t size;
 }
 memory_t;
 
-static unsigned peekb(unsigned address, memory_t* memory) {
+static uint32_t peekb(uint32_t address, memory_t* memory) {
   return address < memory->size ? memory->ram[address] : 0;
 }
 
-static unsigned peek(unsigned address, unsigned num_bytes, void* ud) {
+static uint32_t peek(uint32_t address, uint32_t num_bytes, void* ud) {
   memory_t* memory = (memory_t*)ud;
 
   switch (num_bytes) {

--- a/test/rcheevos/test_condition.c
+++ b/test/rcheevos/test_condition.c
@@ -123,7 +123,7 @@ static void test_evaluate_condition(const char* memaddr, int expected_comparator
   char buffer[512];
   rc_memref_t* memrefs;
   int ret;
-  unsigned char ram[] = {0x00, 0x11, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x11, 0x34, 0xAB, 0x56};
   memory_t memory;
 
   memory.ram = ram;
@@ -179,7 +179,7 @@ static void test_evaluate_condition_float(const char* memaddr, int expected_resu
   char buffer[512];
   rc_memref_t* memrefs;
   int ret;
-  unsigned char ram[] = {0x00, 0x00, 0x00, 0x40, 0x83, 0x49, 0x0F, 0xDB}; /* FF0=2, FF4=2*pi */
+  uint8_t ram[] = {0x00, 0x00, 0x00, 0x40, 0x83, 0x49, 0x0F, 0xDB}; /* FF0=2, FF4=2*pi */
   memory_t memory;
 
   memory.ram = ram;
@@ -203,7 +203,7 @@ static void test_evaluate_condition_float(const char* memaddr, int expected_resu
 }
 
 static void test_condition_compare_delta() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condition_t* cond;
   rc_parse_state_t parse;
@@ -237,7 +237,7 @@ static void test_condition_compare_delta() {
 }
 
 static void test_condition_delta_24bit() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condition_t* cond;
   rc_parse_state_t parse;
@@ -283,7 +283,7 @@ static void test_condition_delta_24bit() {
 }
 
 static void test_condition_prior_24bit() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condition_t* cond;
   rc_parse_state_t parse;

--- a/test/rcheevos/test_condset.c
+++ b/test/rcheevos/test_condset.c
@@ -71,7 +71,7 @@ static void _assert_hit_count(rc_condset_t* condset, int cond_index, unsigned ex
 
 
 static void test_hitcount_increment_when_true() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -88,7 +88,7 @@ static void test_hitcount_increment_when_true() {
 }
 
 static void test_hitcount_does_not_increment_when_false() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -105,7 +105,7 @@ static void test_hitcount_does_not_increment_when_false() {
 }
 
 static void test_hitcount_target() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -141,7 +141,7 @@ static void test_hitcount_target() {
 }
 
 static void test_hitcount_two_conditions(const char* memaddr, unsigned expected_result, unsigned expected_hitcount1, unsigned expected_hitcount2) {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -158,7 +158,7 @@ static void test_hitcount_two_conditions(const char* memaddr, unsigned expected_
 
 static void test_hitcount_three_conditions(const char* memaddr, unsigned expected_result, unsigned expected_hitcount1, 
     unsigned expected_hitcount2, unsigned expected_hitcount3) {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -175,7 +175,7 @@ static void test_hitcount_three_conditions(const char* memaddr, unsigned expecte
 }
 
 static void test_pauseif() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -208,7 +208,7 @@ static void test_pauseif() {
 }
 
 static void test_pauseif_hitcount_one() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -231,7 +231,7 @@ static void test_pauseif_hitcount_one() {
 }
 
 static void test_pauseif_hitcount_two() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -260,7 +260,7 @@ static void test_pauseif_hitcount_two() {
 }
 
 static void test_pauseif_hitcount_with_reset() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -293,7 +293,7 @@ static void test_pauseif_hitcount_with_reset() {
 }
 
 static void test_pauseif_does_not_increment_hits() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -340,7 +340,7 @@ static void test_pauseif_does_not_increment_hits() {
 }
 
 static void test_pauseif_delta_updated() {
-  unsigned char ram[] = {0x00, 0x00, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x00, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -378,7 +378,7 @@ static void test_pauseif_delta_updated() {
 }
 
 static void test_pauseif_indirect_delta_updated() {
-  unsigned char ram[] = {0x00, 0x00, 0x34, 0x3C, 0x56};
+  uint8_t ram[] = {0x00, 0x00, 0x34, 0x3C, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -416,7 +416,7 @@ static void test_pauseif_indirect_delta_updated() {
 }
 
 static void test_pauseif_short_circuit() {
-  unsigned char ram[] = {0x00, 0x00, 0x00, 0x00, 0x00};
+  uint8_t ram[] = {0x00, 0x00, 0x00, 0x00, 0x00};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -486,7 +486,7 @@ static void test_pauseif_short_circuit() {
 }
 
 static void test_resetif() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -530,7 +530,7 @@ static void test_resetif() {
 }
 
 static void test_resetif_cond_with_hittarget() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -580,7 +580,7 @@ static void test_resetif_cond_with_hittarget() {
 }
 
 static void test_resetif_hitcount() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -619,7 +619,7 @@ static void test_resetif_hitcount() {
 }
 
 static void test_resetif_hitcount_one() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -652,7 +652,7 @@ static void test_resetif_hitcount_one() {
 }
 
 static void test_resetif_hitcount_addhits() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -677,7 +677,7 @@ static void test_resetif_hitcount_addhits() {
 }
 
 static void test_pauseif_resetif_hitcounts() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -718,7 +718,7 @@ static void test_pauseif_resetif_hitcounts() {
 }
 
 static void test_resetnextif() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -768,7 +768,7 @@ static void test_resetnextif() {
 }
 
 static void test_resetnextif_non_hitcount_condition() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -819,7 +819,7 @@ static void test_resetnextif_non_hitcount_condition() {
 }
 
 static void test_resetnextif_addhits() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -859,7 +859,7 @@ static void test_resetnextif_addhits() {
 }
 
 static void test_resetnextif_addhits_chain() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -917,7 +917,7 @@ static void test_resetnextif_addhits_chain() {
 }
 
 static void test_resetnextif_addhits_chain_total() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -961,7 +961,7 @@ static void test_resetnextif_addhits_chain_total() {
 }
 
 static void test_resetnextif_using_andnext() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -1010,7 +1010,7 @@ static void test_resetnextif_using_andnext() {
 }
 
 static void test_resetnextif_andnext() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -1059,7 +1059,7 @@ static void test_resetnextif_andnext() {
 }
 
 static void test_resetnextif_andnext_hitchain() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -1115,7 +1115,7 @@ static void test_resetnextif_andnext_hitchain() {
 }
 
 static void test_resetnextif_addaddress() {
-  unsigned char ram[] = {0x00, 0x00, 0x02, 0x03, 0x04};
+  uint8_t ram[] = {0x00, 0x00, 0x02, 0x03, 0x04};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -1191,7 +1191,7 @@ static void test_resetnextif_addaddress() {
 }
 
 static void test_resetnextif_chain() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -1248,7 +1248,7 @@ static void test_resetnextif_chain() {
 }
 
 static void test_resetnextif_chain_andnext() {
-  unsigned char ram[] = {0x00, 0x00, 0x01};
+  uint8_t ram[] = {0x00, 0x00, 0x01};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -1303,7 +1303,7 @@ static void test_resetnextif_chain_andnext() {
 }
 
 static void test_resetnextif_chain_with_hits() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -1391,7 +1391,7 @@ static void test_resetnextif_chain_with_hits() {
 }
 
 static void test_resetnextif_pause_lock() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -1454,7 +1454,7 @@ static void test_resetnextif_pause_lock() {
 }
 
 static void test_addsource() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -1491,7 +1491,7 @@ static void test_addsource() {
 }
 
 static void test_addsource_overflow() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -1513,7 +1513,7 @@ static void test_addsource_overflow() {
 }
 
 static void test_subsource() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -1557,7 +1557,7 @@ static void test_subsource() {
 }
 
 static void test_subsource_legacy_garbage() {
-  unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  uint8_t ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -1601,7 +1601,7 @@ static void test_subsource_legacy_garbage() {
 }
 
 static void test_subsource_overflow() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -1623,7 +1623,7 @@ static void test_subsource_overflow() {
 }
 
 static void test_addsource_subsource() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -1672,7 +1672,7 @@ static void test_addsource_subsource() {
 }
 
 static void test_addsource_multiply() {
-  unsigned char ram[] = {0x00, 0x06, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x06, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -1709,7 +1709,7 @@ static void test_addsource_multiply() {
 }
 
 static void test_subsource_multiply() {
-  unsigned char ram[] = {0x00, 0x06, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x06, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -1746,7 +1746,7 @@ static void test_subsource_multiply() {
 }
 
 static void test_addsource_multiply_fraction() {
-  unsigned char ram[] = {0x00, 0x08, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x08, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -1783,7 +1783,7 @@ static void test_addsource_multiply_fraction() {
 }
 
 static void test_addsource_multiply_address() {
-  unsigned char ram[] = {0x00, 0x06, 0x04, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x06, 0x04, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -1820,7 +1820,7 @@ static void test_addsource_multiply_address() {
 }
 
 static void test_addsource_divide() {
-  unsigned char ram[] = {0x00, 0x06, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x06, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -1857,7 +1857,7 @@ static void test_addsource_divide() {
 }
 
 static void test_addsource_compare_percentage() {
-  unsigned char ram[] = {0x00, 0x06, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x06, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -1879,7 +1879,7 @@ static void test_addsource_compare_percentage() {
 }
 
 static void test_subsource_divide() {
-  unsigned char ram[] = {0x00, 0x06, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x06, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -1916,7 +1916,7 @@ static void test_subsource_divide() {
 }
 
 static void test_addsource_divide_address() {
-  unsigned char ram[] = {0x00, 0x06, 0x10, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x06, 0x10, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -1953,7 +1953,7 @@ static void test_addsource_divide_address() {
 }
 
 static void test_addsource_divide_self() {
-  unsigned char ram[] = {0x00, 0x06, 0x10, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x06, 0x10, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -1990,7 +1990,7 @@ static void test_addsource_divide_self() {
 }
 
 static void test_addsource_mask() {
-  unsigned char ram[] = {0x00, 0x06, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x06, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -2027,7 +2027,7 @@ static void test_addsource_mask() {
 }
 
 static void test_addsource_xor() {
-  unsigned char ram[] = {0x00, 0x06, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x06, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -2064,7 +2064,7 @@ static void test_addsource_xor() {
 }
 
 static void test_addsource_float_first() {
-  unsigned char ram[] = {0x00, 0x06, 0x34, 0xAB, 0x00, 0x00, 0xC0, 0x3F}; /* fF0004 = 1.5 */
+  uint8_t ram[] = {0x00, 0x06, 0x34, 0xAB, 0x00, 0x00, 0xC0, 0x3F}; /* fF0004 = 1.5 */
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -2081,7 +2081,7 @@ static void test_addsource_float_first() {
 }
 
 static void test_addsource_float_second() {
-  unsigned char ram[] = {0x00, 0x06, 0x34, 0xAB, 0x00, 0x00, 0xC0, 0x3F}; /* fF0004 = 1.5 */
+  uint8_t ram[] = {0x00, 0x06, 0x34, 0xAB, 0x00, 0x00, 0xC0, 0x3F}; /* fF0004 = 1.5 */
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -2112,7 +2112,7 @@ static void test_addsource_float_second() {
 }
 
 static void test_subsource_mask() {
-  unsigned char ram[] = {0x00, 0x6C, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x6C, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -2149,7 +2149,7 @@ static void test_subsource_mask() {
 }
 
 static void test_subsource_overflow_comparison_equal() {
-  unsigned char ram[] = {0x00, 0x6C, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x6C, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -2197,7 +2197,7 @@ static void test_subsource_overflow_comparison_equal() {
 }
 
 static void test_subsource_overflow_comparison_greater() {
-  unsigned char ram[] = {0x00, 0x6C, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x6C, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -2246,7 +2246,7 @@ static void test_subsource_overflow_comparison_greater() {
 }
 
 static void test_subsource_overflow_comparison_greater_or_equal() {
-  unsigned char ram[] = {0x00, 0x6C, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x6C, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -2295,7 +2295,7 @@ static void test_subsource_overflow_comparison_greater_or_equal() {
 }
 
 static void test_subsource_overflow_comparison_lesser() {
-  unsigned char ram[] = {0x00, 0x6C, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x6C, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -2344,7 +2344,7 @@ static void test_subsource_overflow_comparison_lesser() {
 }
 
 static void test_subsource_overflow_comparison_lesser_or_equal() {
-  unsigned char ram[] = {0x00, 0x6C, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x6C, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -2393,7 +2393,7 @@ static void test_subsource_overflow_comparison_lesser_or_equal() {
 }
 
 static void test_subsource_float() {
-  unsigned char ram[] = {0x06, 0x00, 0x00, 0x00, 0x92, 0x44, 0x9A, 0x42}; /* fF0004 = 77.133926 */
+  uint8_t ram[] = {0x06, 0x00, 0x00, 0x00, 0x92, 0x44, 0x9A, 0x42}; /* fF0004 = 77.133926 */
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -2414,7 +2414,7 @@ static void test_subsource_float() {
 }
 
 static void test_addhits() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -2462,7 +2462,7 @@ static void test_addhits() {
 }
 
 static void test_addhits_multiple() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -2494,7 +2494,7 @@ static void test_addhits_multiple() {
 }
 
 static void test_addhits_no_target() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -2526,7 +2526,7 @@ static void test_addhits_no_target() {
 }
 
 static void test_addhits_with_addsource() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -2555,7 +2555,7 @@ static void test_addhits_with_addsource() {
 }
 
 static void test_subhits() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -2601,7 +2601,7 @@ static void test_subhits() {
 }
 
 static void test_subhits_below_zero() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -2660,7 +2660,7 @@ static void test_subhits_below_zero() {
 }
 
 static void test_andnext() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -2742,7 +2742,7 @@ static void test_andnext() {
 }
 
 static void test_andnext_boundaries() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -2791,7 +2791,7 @@ static void test_andnext_boundaries() {
 }
 
 static void test_andnext_resetif() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -2868,7 +2868,7 @@ static void test_andnext_resetif() {
 }
 
 static void test_andnext_pauseif() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -2945,7 +2945,7 @@ static void test_andnext_pauseif() {
 }
 
 static void test_andnext_addsource() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -2986,7 +2986,7 @@ static void test_andnext_addsource() {
 }
 
 static void test_andnext_addhits() {
-  unsigned char ram[] = {0x00, 0x00, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x00, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -3032,7 +3032,7 @@ static void test_andnext_addhits() {
 }
 
 static void test_andnext_between_addhits() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -3103,7 +3103,7 @@ static void test_andnext_between_addhits() {
 }
 
 static void test_andnext_with_hits_chain() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -3186,7 +3186,7 @@ static void test_andnext_with_hits_chain() {
 }
 
 static void test_andnext_changes_to() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -3217,7 +3217,7 @@ static void test_andnext_changes_to() {
 }
 
 static void test_ornext() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -3287,7 +3287,7 @@ static void test_ornext() {
 }
 
 static void test_andnext_ornext_interaction() {
-  unsigned char ram[] = {0, 0, 0, 0, 0};
+  uint8_t ram[] = {0, 0, 0, 0, 0};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -3312,7 +3312,7 @@ static void test_andnext_ornext_interaction() {
 }
 
 static void test_addaddress_direct_pointer() {
-  unsigned char ram[] = {0x01, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x01, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -3349,7 +3349,7 @@ static void test_addaddress_direct_pointer() {
 }
 
 static void test_addaddress_direct_pointer_delta() {
-  unsigned char ram[] = { 0x01, 0x12, 0x34, 0xAB, 0x56 };
+  uint8_t ram[] = { 0x01, 0x12, 0x34, 0xAB, 0x56 };
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -3414,7 +3414,7 @@ static void test_addaddress_direct_pointer_delta() {
 }
 
 static void test_addaddress_direct_pointer_prior() {
-  unsigned char ram[] = { 0x01, 0x12, 0x34, 0xAB, 0x56 };
+  uint8_t ram[] = { 0x01, 0x12, 0x34, 0xAB, 0x56 };
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -3483,7 +3483,7 @@ static void test_addaddress_direct_pointer_prior() {
 }
 
 static void test_addaddress_indirect_pointer() {
-  unsigned char ram[] = {0x01, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x01, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -3524,7 +3524,7 @@ static void test_addaddress_indirect_pointer() {
 }
 
 static void test_addaddress_indirect_pointer_negative() {
-  unsigned char ram[] = {0x02, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x02, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -3565,7 +3565,7 @@ static void test_addaddress_indirect_pointer_negative() {
 }
 
 static void test_addaddress_indirect_pointer_out_of_range() {
-  unsigned char ram[] = {0x01, 0x12, 0x34, 0xAB, 0x56, 0x16};
+  uint8_t ram[] = {0x01, 0x12, 0x34, 0xAB, 0x56, 0x16};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -3592,7 +3592,7 @@ static void test_addaddress_indirect_pointer_out_of_range() {
 }
 
 static void test_addaddress_indirect_pointer_multiple() {
-  unsigned char ram[] = {0x01, 0x02, 0x03, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x01, 0x02, 0x03, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -3636,7 +3636,7 @@ static void test_addaddress_indirect_pointer_multiple() {
 }
 
 static void test_addaddress_pointer_data_size_differs_from_pointer_size() {
-  unsigned char ram[] = {0x01, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x01, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -3670,7 +3670,7 @@ static void test_addaddress_pointer_data_size_differs_from_pointer_size() {
 }
 
 static void test_addaddress_double_indirection() {
-  unsigned char ram[] = {0x01, 0x02, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x01, 0x02, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -3708,7 +3708,7 @@ static void test_addaddress_double_indirection() {
 }
 
 static void test_addaddress_double_indirection_with_delta() {
-  unsigned char ram[] = { 0, 2, 4 };
+  uint8_t ram[] = { 0, 2, 4 };
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -3736,7 +3736,7 @@ static void test_addaddress_double_indirection_with_delta() {
 }
 
 static void test_addaddress_double_indirection_with_delta_incorrect() {
-  unsigned char ram[] = { 0, 2, 4 };
+  uint8_t ram[] = { 0, 2, 4 };
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -3769,7 +3769,7 @@ static void test_addaddress_double_indirection_with_delta_incorrect() {
 }
 
 static void test_addaddress_adjust_both_sides() {
-  unsigned char ram[] = {0x02, 0x11, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x02, 0x11, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -3803,7 +3803,7 @@ static void test_addaddress_adjust_both_sides() {
 }
 
 static void test_addaddress_adjust_both_sides_different_bases() {
-  unsigned char ram[] = {0x02, 0x11, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x02, 0x11, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -3830,7 +3830,7 @@ static void test_addaddress_adjust_both_sides_different_bases() {
 }
 
 static void test_addaddress_scaled() {
-  unsigned char ram[] = {0x01, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x01, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -3865,7 +3865,7 @@ static void test_addaddress_scaled() {
 }
 
 static void test_addaddress_scaled_negative() {
-  unsigned char ram[] = {0x01, 0x12, 0x34, 0xAB, 0x01};
+  uint8_t ram[] = {0x01, 0x12, 0x34, 0xAB, 0x01};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;
@@ -3900,7 +3900,7 @@ static void test_addaddress_scaled_negative() {
 }
 
 static void test_prior_sequence() {
-  unsigned char ram[] = {0x00};
+  uint8_t ram[] = {0x00};
   memory_t memory;
   rc_condset_t* condset;
   rc_condset_memrefs_t memrefs;

--- a/test/rcheevos/test_lboard.c
+++ b/test/rcheevos/test_lboard.c
@@ -28,7 +28,7 @@ static int evaluate_lboard(rc_lboard_t* lboard, memory_t* memory, int* value) {
 }
 
 static void test_simple_leaderboard() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_lboard_t* lboard;
   char buffer[1024];
@@ -80,7 +80,7 @@ static void test_simple_leaderboard() {
 }
 
 static void test_start_and_cancel_same_frame() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_lboard_t* lboard;
   char buffer[1024];
@@ -117,7 +117,7 @@ static void test_start_and_cancel_same_frame() {
 }
 
 static void test_start_and_submit_same_frame() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_lboard_t* lboard;
   char buffer[1024];
@@ -147,7 +147,7 @@ static void test_start_and_submit_same_frame() {
 }
 
 static void test_start_and_conditions() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_lboard_t* lboard;
   char buffer[1024];
@@ -173,7 +173,7 @@ static void test_start_and_conditions() {
 }
 
 static void test_start_or_conditions() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_lboard_t* lboard;
   char buffer[1024];
@@ -203,7 +203,7 @@ static void test_start_or_conditions() {
 }
 
 static void test_start_resets_value() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_lboard_t* lboard;
   char buffer[1024];
@@ -254,7 +254,7 @@ static void test_start_resets_value() {
 }
 
 static void test_cancel_or_conditions() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_lboard_t* lboard;
   char buffer[1024];
@@ -284,7 +284,7 @@ static void test_cancel_or_conditions() {
 }
 
 static void test_submit_and_conditions() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_lboard_t* lboard;
   char buffer[1024];
@@ -310,7 +310,7 @@ static void test_submit_and_conditions() {
 }
 
 static void test_submit_or_conditions() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_lboard_t* lboard;
   char buffer[1024];
@@ -340,7 +340,7 @@ static void test_submit_or_conditions() {
 }
 
 static void test_progress() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_lboard_t* lboard;
   char buffer[1024];
@@ -363,7 +363,7 @@ static void test_progress() {
 }
 
 static void test_value_from_hitcount() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_lboard_t* lboard;
   char buffer[1024];
@@ -424,7 +424,7 @@ static void test_value_from_hitcount() {
 }
 
 static void test_value_from_addhits() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_lboard_t* lboard;
   char buffer[1024];
@@ -472,7 +472,7 @@ static void test_value_from_addhits() {
 
 static void test_value_from_float() {
   /* bytes 5-8 are the float value for pi */
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56, 0xDB, 0x0F, 0x49, 0x40};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56, 0xDB, 0x0F, 0x49, 0x40};
   memory_t memory;
   rc_lboard_t* lboard;
   char buffer[1024];
@@ -505,7 +505,7 @@ static void test_value_from_float() {
 
 static void test_value_from_float_scaled() {
   /* bytes 5-8 are the float value for pi */
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56, 0xDB, 0x0F, 0x49, 0x40};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56, 0xDB, 0x0F, 0x49, 0x40};
   memory_t memory;
   rc_lboard_t* lboard;
   char buffer[1024];
@@ -537,7 +537,7 @@ static void test_value_from_float_scaled() {
 }
 
 static void test_maximum_value_from_conditions() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_lboard_t* lboard;
   char buffer[1024];

--- a/test/rcheevos/test_memref.c
+++ b/test/rcheevos/test_memref.c
@@ -335,7 +335,7 @@ static void test_update_memref_values() {
   rc_memref_t* memref1;
   rc_memref_t* memref2;
 
-  unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  uint8_t ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
   memory_t memory;
   memory.ram = ram;
   memory.size = sizeof(ram);

--- a/test/rcheevos/test_operand.c
+++ b/test/rcheevos/test_operand.c
@@ -405,7 +405,7 @@ static void test_parse_float_values() {
 }
 
 static void test_evaluate_memory_references() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   memory.ram = ram;
   memory.size = sizeof(ram);
@@ -516,7 +516,7 @@ static void test_evaluate_memory_references() {
 }
 
 static void test_evaluate_delta_memory_reference() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_operand_t op;
   const char* memaddr;
@@ -554,7 +554,7 @@ static void test_evaluate_delta_memory_reference() {
 }
 
 void test_evaluate_prior_memory_reference() {
-  unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  uint8_t ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
   memory_t memory;
   rc_operand_t op;
   const char* memaddr;
@@ -594,7 +594,7 @@ void test_evaluate_prior_memory_reference() {
 }
 
 static void test_evaluate_memory_references_float() {
-  unsigned char ram[] = {0x00, 0x00, 0x80, 0x3F, 0x81, 0x00, 0x00, 0x00, 0x00, 0x81};
+  uint8_t ram[] = {0x00, 0x00, 0x80, 0x3F, 0x81, 0x00, 0x00, 0x00, 0x00, 0x81};
   memory_t memory;
   memory.ram = ram;
   memory.size = sizeof(ram);
@@ -627,7 +627,7 @@ static void test_evaluate_memory_references_float() {
 }
 
 static void test_evaluate_delta_memory_reference_float() {
-  unsigned char ram[] = {0x00, 0x00, 0x80, 0x3F};
+  uint8_t ram[] = {0x00, 0x00, 0x80, 0x3F};
   memory_t memory;
   rc_operand_t op;
   const char* memaddr;

--- a/test/rcheevos/test_richpresence.c
+++ b/test/rcheevos/test_richpresence.c
@@ -43,7 +43,7 @@ static void test_empty_script() {
 }
 
 static void test_simple_richpresence(const char* script, const char* expected_display_string) {
-  unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  uint8_t ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
   memory_t memory;
   rc_richpresence_t* richpresence;
   char buffer[1024];
@@ -72,7 +72,7 @@ static void assert_buffer_boundary(rc_richpresence_t* richpresence, memory_t* me
 }
 
 static void test_buffer_boundary() {
-  unsigned char ram[] = { 0x00, 0x00, 0x00, 0x01, 0x00 };
+  uint8_t ram[] = { 0x00, 0x00, 0x00, 0x01, 0x00 };
   memory_t memory;
   rc_richpresence_t* richpresence;
   char buffer[2048];
@@ -120,7 +120,7 @@ static void test_buffer_boundary() {
 }
 
 static void test_conditional_display_simple() {
-  unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  uint8_t ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
   memory_t memory;
   rc_richpresence_t* richpresence;
   char buffer[1024];
@@ -139,7 +139,7 @@ static void test_conditional_display_simple() {
 }
 
 static void test_conditional_display_after_default() {
-  unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  uint8_t ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
   memory_t memory;
   rc_richpresence_t* richpresence;
   char buffer[1024];
@@ -162,7 +162,7 @@ static void test_conditional_display_no_default() {
 }
 
 static void test_conditional_display_common_condition() {
-  unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  uint8_t ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
   memory_t memory;
   rc_richpresence_t* richpresence;
   char buffer[1024];
@@ -201,7 +201,7 @@ static void test_conditional_display_common_condition() {
 }
 
 static void test_conditional_display_duplicated_condition() {
-  unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  uint8_t ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
   memory_t memory;
   rc_richpresence_t* richpresence;
   char buffer[1024];
@@ -226,7 +226,7 @@ static void test_conditional_display_invalid_condition_logic() {
 }
 
 static void test_conditional_display_whitespace_text() {
-  unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  uint8_t ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
   memory_t memory;
   rc_richpresence_t* richpresence;
   char buffer[1024];
@@ -245,7 +245,7 @@ static void test_conditional_display_whitespace_text() {
 }
 
 static void test_macro_value() {
-  unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  uint8_t ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
   memory_t memory;
   rc_richpresence_t* richpresence;
   char buffer[1024];
@@ -261,7 +261,7 @@ static void test_macro_value() {
 }
 
 static void test_macro_value_nibble() {
-  unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  uint8_t ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
   memory_t memory;
   rc_richpresence_t* richpresence;
   char buffer[1024];
@@ -282,7 +282,7 @@ static void test_macro_value_nibble() {
 }
 
 static void test_macro_value_bcd() {
-  unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  uint8_t ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
   memory_t memory;
   rc_richpresence_t* richpresence;
   char buffer[1024];
@@ -298,7 +298,7 @@ static void test_macro_value_bcd() {
 }
 
 static void test_macro_value_bitcount() {
-  unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  uint8_t ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
   memory_t memory;
   rc_richpresence_t* richpresence;
   char buffer[1024];
@@ -314,7 +314,7 @@ static void test_macro_value_bitcount() {
 }
 
 static void test_conditional_display_indirect() {
-  unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  uint8_t ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
   memory_t memory;
   rc_richpresence_t* richpresence;
   char buffer[1024];
@@ -333,7 +333,7 @@ static void test_conditional_display_indirect() {
 }
 
 static void test_conditional_display_unnecessary_measured() {
-  unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  uint8_t ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
   memory_t memory;
   rc_richpresence_t* richpresence;
   char buffer[1024];
@@ -352,7 +352,7 @@ static void test_conditional_display_unnecessary_measured() {
 }
 
 static void test_conditional_display_unnecessary_measured_indirect() {
-  unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  uint8_t ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
   memory_t memory;
   rc_richpresence_t* richpresence;
   char buffer[1024];
@@ -371,7 +371,7 @@ static void test_conditional_display_unnecessary_measured_indirect() {
 }
 
 static void test_macro_value_adjusted_negative() {
-  unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  uint8_t ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
   memory_t memory;
   rc_richpresence_t* richpresence;
   char buffer[1024];
@@ -387,7 +387,7 @@ static void test_macro_value_adjusted_negative() {
 }
 
 static void test_macro_value_from_formula() {
-  unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  uint8_t ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
   memory_t memory;
   rc_richpresence_t* richpresence;
   char buffer[1024];
@@ -403,7 +403,7 @@ static void test_macro_value_from_formula() {
 }
 
 static void test_macro_value_from_hits() {
-  unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  uint8_t ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
   memory_t memory;
   rc_richpresence_t* richpresence;
   char buffer[1024];
@@ -421,7 +421,7 @@ static void test_macro_value_from_hits() {
 }
 
 static void test_macro_value_from_indirect() {
-  unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  uint8_t ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
   memory_t memory;
   rc_richpresence_t* richpresence;
   char buffer[1024];
@@ -442,7 +442,7 @@ static void test_macro_value_from_indirect() {
 }
 
 static void test_macro_value_divide_by_zero() {
-  unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  uint8_t ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
   memory_t memory;
   rc_richpresence_t* richpresence;
   char buffer[1024];
@@ -461,7 +461,7 @@ static void test_macro_value_divide_by_zero() {
 }
 
 static void test_macro_value_divide_by_self() {
-  unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  uint8_t ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
   memory_t memory;
   rc_richpresence_t* richpresence;
   char buffer[1024];
@@ -487,7 +487,7 @@ static void test_macro_value_divide_by_self() {
 }
 
 static void test_macro_frames() {
-  unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  uint8_t ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
   memory_t memory;
   rc_richpresence_t* richpresence;
   char buffer[1024];
@@ -503,7 +503,7 @@ static void test_macro_frames() {
 }
 
 static void test_macro_float(const char* format, unsigned value, const char* expected) {
-  unsigned char ram[4];
+  uint8_t ram[4];
   memory_t memory;
   rc_richpresence_t* richpresence;
   char script[128];
@@ -523,7 +523,7 @@ static void test_macro_float(const char* format, unsigned value, const char* exp
 }
 
 static void test_macro_lookup_simple() {
-  unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  uint8_t ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
   memory_t memory;
   rc_richpresence_t* richpresence;
   char buffer[1024];
@@ -543,7 +543,7 @@ static void test_macro_lookup_simple() {
 }
 
 static void test_macro_lookup_with_inline_comment() {
-  unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  uint8_t ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
   memory_t memory;
   rc_richpresence_t* richpresence;
   char buffer[1024];
@@ -563,7 +563,7 @@ static void test_macro_lookup_with_inline_comment() {
 }
 
 static void test_macro_lookup_hex_keys() {
-  unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  uint8_t ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
   memory_t memory;
   rc_richpresence_t* richpresence;
   char buffer[1024];
@@ -583,7 +583,7 @@ static void test_macro_lookup_hex_keys() {
 }
 
 static void test_macro_lookup_default() {
-  unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  uint8_t ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
   memory_t memory;
   rc_richpresence_t* richpresence;
   char buffer[1024];
@@ -603,7 +603,7 @@ static void test_macro_lookup_default() {
 }
 
 static void test_macro_lookup_crlf() {
-  unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  uint8_t ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
   memory_t memory;
   rc_richpresence_t* richpresence;
   char buffer[1024];
@@ -623,7 +623,7 @@ static void test_macro_lookup_crlf() {
 }
 
 static void test_macro_lookup_after_display() {
-  unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  uint8_t ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
   memory_t memory;
   rc_richpresence_t* richpresence;
   char buffer[1024];
@@ -643,7 +643,7 @@ static void test_macro_lookup_after_display() {
 }
 
 static void test_macro_lookup_from_formula() {
-  unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  uint8_t ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
   memory_t memory;
   rc_richpresence_t* richpresence;
   char buffer[1024];
@@ -662,7 +662,7 @@ static void test_macro_lookup_from_formula() {
 }
 
 static void test_macro_lookup_from_indirect() {
-  unsigned char ram[] = { 0x00, 0x00, 0x01, 0x00, 0x56 };
+  uint8_t ram[] = { 0x00, 0x00, 0x01, 0x00, 0x56 };
   memory_t memory;
   rc_richpresence_t* richpresence;
   char buffer[1024];
@@ -681,7 +681,7 @@ static void test_macro_lookup_from_indirect() {
 }
 
 static void test_macro_lookup_repeated() {
-  unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  uint8_t ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
   memory_t memory;
   rc_richpresence_t* richpresence;
   char buffer[1024];
@@ -702,7 +702,7 @@ static void test_macro_lookup_repeated() {
 }
 
 static void test_macro_lookup_shared() {
-  unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  uint8_t ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
   memory_t memory;
   rc_richpresence_t* richpresence;
   char buffer[1024];
@@ -722,7 +722,7 @@ static void test_macro_lookup_shared() {
 }
 
 static void test_macro_lookup_multiple() {
-  unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  uint8_t ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
   memory_t memory;
   rc_richpresence_t* richpresence;
   char buffer[1024];
@@ -742,7 +742,7 @@ static void test_macro_lookup_multiple() {
 }
 
 static void test_macro_lookup_and_value() {
-  unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  uint8_t ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
   memory_t memory;
   rc_richpresence_t* richpresence;
   char buffer[1024];
@@ -761,7 +761,7 @@ static void test_macro_lookup_and_value() {
 }
 
 static void test_macro_lookup_negative_value() {
-  unsigned char ram[] = { 0x00, 0x00, 0x00, 0x00, 0x00 };
+  uint8_t ram[] = { 0x00, 0x00, 0x00, 0x00, 0x00 };
   memory_t memory;
   rc_richpresence_t* richpresence;
   char buffer[1024];
@@ -784,7 +784,7 @@ static void test_macro_lookup_negative_value() {
 }
 
 static void test_macro_lookup_value_with_whitespace() {
-  unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  uint8_t ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
   memory_t memory;
   rc_richpresence_t* richpresence;
   char buffer[1024];
@@ -804,7 +804,7 @@ static void test_macro_lookup_value_with_whitespace() {
 }
 
 static void test_macro_lookup_mapping_repeated() {
-  unsigned char ram[] = { 0x00, 0x04, 0x34, 0xAB, 0x56 };
+  uint8_t ram[] = { 0x00, 0x04, 0x34, 0xAB, 0x56 };
   memory_t memory;
   rc_richpresence_t* richpresence;
   char buffer[1024];
@@ -825,7 +825,7 @@ static void test_macro_lookup_mapping_repeated() {
 }
 
 static void test_macro_lookup_mapping_repeated_csv() {
-  unsigned char ram[] = { 0x00, 0x04, 0x34, 0xAB, 0x56 };
+  uint8_t ram[] = { 0x00, 0x04, 0x34, 0xAB, 0x56 };
   memory_t memory;
   rc_richpresence_t* richpresence;
   char buffer[1024];
@@ -846,7 +846,7 @@ static void test_macro_lookup_mapping_repeated_csv() {
 }
 
 static void test_macro_lookup_mapping_merged() {
-  unsigned char ram[] = { 0x00, 0x04, 0x34, 0xAB, 0x56 };
+  uint8_t ram[] = { 0x00, 0x04, 0x34, 0xAB, 0x56 };
   memory_t memory;
   rc_richpresence_t* richpresence;
   char buffer[1024];
@@ -873,7 +873,7 @@ static void test_macro_lookup_mapping_merged() {
 }
 
 static void test_macro_lookup_mapping_range() {
-  unsigned char ram[] = { 0x00, 0x04, 0x34, 0xAB, 0x56 };
+  uint8_t ram[] = { 0x00, 0x04, 0x34, 0xAB, 0x56 };
   memory_t memory;
   rc_richpresence_t* richpresence;
   char buffer[1024];
@@ -920,7 +920,7 @@ static void test_macro_lookup_invalid() {
 }
 
 static void test_macro_escaped() {
-  unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  uint8_t ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
   memory_t memory;
   rc_richpresence_t* richpresence;
   char buffer[1024];
@@ -934,7 +934,7 @@ static void test_macro_escaped() {
 }
 
 static void test_macro_undefined() {
-  unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  uint8_t ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
   memory_t memory;
   rc_richpresence_t* richpresence;
   char buffer[1024];
@@ -947,7 +947,7 @@ static void test_macro_undefined() {
 }
 
 static void test_macro_undefined_at_end_of_line() {
-  unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  uint8_t ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
   memory_t memory;
   rc_richpresence_t* richpresence;
   char buffer[1024];
@@ -963,7 +963,7 @@ static void test_macro_undefined_at_end_of_line() {
 }
 
 static void test_macro_unterminated() {
-  unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  uint8_t ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
   memory_t memory;
   rc_richpresence_t* richpresence;
   char buffer[1024];
@@ -1016,7 +1016,7 @@ static void test_macro_non_numeric_parameter() {
 }
 
 static void test_builtin_macro(const char* macro, const char* expected) {
-  unsigned char ram[] = { 0x39, 0x30 };
+  uint8_t ram[] = { 0x39, 0x30 };
   memory_t memory;
   rc_richpresence_t* richpresence;
   char script[128];
@@ -1032,7 +1032,7 @@ static void test_builtin_macro(const char* macro, const char* expected) {
 }
 
 static void test_builtin_macro_float(const char* macro, const char* expected) {
-  unsigned char ram[] = { 0x92, 0x44, 0x9A, 0x42 }; /* 77.133926 */
+  uint8_t ram[] = { 0x92, 0x44, 0x9A, 0x42 }; /* 77.133926 */
   memory_t memory;
   rc_richpresence_t* richpresence;
   char script[128];
@@ -1048,7 +1048,7 @@ static void test_builtin_macro_float(const char* macro, const char* expected) {
 }
 
 static void test_builtin_macro_override() {
-  unsigned char ram[] = { 0x39, 0x30 };
+  uint8_t ram[] = { 0x39, 0x30 };
   memory_t memory;
   rc_richpresence_t* richpresence;
   char buffer[256];
@@ -1061,7 +1061,7 @@ static void test_builtin_macro_override() {
 }
 
 static void test_asciichar() {
-  unsigned char ram[] = { 'K', 'e', 'n', '\0', 'V', 'e', 'g', 'a', 1 };
+  uint8_t ram[] = { 'K', 'e', 'n', '\0', 'V', 'e', 'g', 'a', 1 };
   memory_t memory;
   rc_richpresence_t* richpresence;
   char buffer[1024];
@@ -1081,7 +1081,7 @@ static void test_asciichar() {
 
 static void test_ascii8(unsigned char c1, unsigned char c2, unsigned char c3, unsigned char c4,
     unsigned char c5, unsigned char c6, unsigned char c7, unsigned char c8, char* expected) {
-  unsigned char ram[9];
+  uint8_t ram[9];
   memory_t memory;
   rc_richpresence_t* richpresence;
   char buffer[1024];
@@ -1098,7 +1098,7 @@ static void test_ascii8(unsigned char c1, unsigned char c2, unsigned char c3, un
 }
 
 static void test_unicode4(unsigned short c1, unsigned short c2, unsigned short c3, unsigned short c4, char* expected) {
-  unsigned char ram[10];
+  uint8_t ram[10];
   memory_t memory;
   rc_richpresence_t* richpresence;
   char buffer[1024];
@@ -1117,7 +1117,7 @@ static void test_unicode4(unsigned short c1, unsigned short c2, unsigned short c
 }
 
 static void test_random_text_between_sections() {
-  unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  uint8_t ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
   memory_t memory;
   rc_richpresence_t* richpresence;
   char buffer[1024];
@@ -1137,7 +1137,7 @@ static void test_random_text_between_sections() {
 }
 
 static void test_comments() {
-  unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  uint8_t ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
   memory_t memory;
   rc_richpresence_t* richpresence;
   char buffer[1024];
@@ -1157,7 +1157,7 @@ static void test_comments() {
 }
 
 static void test_comments_between_lines() {
-  unsigned char ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  uint8_t ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
   memory_t memory;
   rc_richpresence_t* richpresence;
   char buffer[1024];

--- a/test/rcheevos/test_runtime.c
+++ b/test/rcheevos/test_runtime.c
@@ -64,7 +64,7 @@ static void assert_richpresence_display_string(rc_runtime_t* runtime, memory_t* 
 
 static void test_two_achievements_activate_and_trigger(void)
 {
-  unsigned char ram[] = { 0, 10, 10 };
+  uint8_t ram[] = { 0, 10, 10 };
   memory_t memory;
   rc_runtime_t runtime;
 
@@ -127,7 +127,7 @@ static void test_two_achievements_activate_and_trigger(void)
 
 static void test_deactivate_achievements(void)
 {
-  unsigned char ram[] = { 0, 10, 10 };
+  uint8_t ram[] = { 0, 10, 10 };
   memory_t memory;
   rc_runtime_t runtime;
 
@@ -190,7 +190,7 @@ static void test_deactivate_achievements(void)
 static void test_achievement_measured(void)
 {
   /* bytes 3-7 are the float value for 16*pi */
-  unsigned char ram[] = { 0, 10, 10, 0xDB, 0x0F, 0x49, 0x41 };
+  uint8_t ram[] = { 0, 10, 10, 0xDB, 0x0F, 0x49, 0x41 };
   char buffer[32];
   memory_t memory;
   rc_runtime_t runtime;
@@ -313,7 +313,7 @@ static void test_achievement_measured(void)
 
 static void test_achievement_measured_maxint(void)
 {
-  unsigned char ram[] = { 0xFF, 0xFF, 0xFF, 0xFF };
+  uint8_t ram[] = { 0xFF, 0xFF, 0xFF, 0xFF };
   char buffer[32];
   memory_t memory;
   rc_runtime_t runtime;
@@ -387,7 +387,7 @@ static void test_achievement_measured_maxint(void)
 
 static void test_two_achievements_differing_resets_in_alts(void)
 {
-  unsigned char ram[] = { 0, 10, 10 };
+  uint8_t ram[] = { 0, 10, 10 };
   memory_t memory;
   rc_runtime_t runtime;
 
@@ -445,7 +445,7 @@ static void test_two_achievements_differing_resets_in_alts(void)
 
 static void test_shared_memref(void)
 {
-  unsigned char ram[] = { 0, 10, 10 };
+  uint8_t ram[] = { 0, 10, 10 };
   memory_t memory;
   rc_runtime_t runtime;
   rc_memref_t* memref1;
@@ -516,7 +516,7 @@ static void test_shared_memref(void)
 
 static void test_replace_active_trigger(void)
 {
-  unsigned char ram[] = { 0, 10, 10 };
+  uint8_t ram[] = { 0, 10, 10 };
   memory_t memory;
   rc_runtime_t runtime;
 
@@ -570,7 +570,7 @@ static void discarding_event_handler(const rc_runtime_event_t* e)
 
 static void test_trigger_deactivation(void)
 {
-  unsigned char ram[] = { 0, 9, 10 };
+  uint8_t ram[] = { 0, 9, 10 };
   memory_t memory;
   rc_runtime_t runtime;
 
@@ -612,7 +612,7 @@ static void test_trigger_deactivation(void)
 }
 
 static void test_trigger_with_resetif() {
-  unsigned char ram[] = {0x00, 0x00, 0x00, 0x00, 0x00};
+  uint8_t ram[] = {0x00, 0x00, 0x00, 0x00, 0x00};
   memory_t memory;
   rc_runtime_t runtime;
 
@@ -655,7 +655,7 @@ static void test_trigger_with_resetif() {
 }
 
 static void test_trigger_with_resetnextif() {
-  unsigned char ram[] = {0x00, 0x00, 0x00, 0x00, 0x00};
+  uint8_t ram[] = {0x00, 0x00, 0x00, 0x00, 0x00};
   memory_t memory;
   rc_runtime_t runtime;
 
@@ -710,7 +710,7 @@ static void test_trigger_with_resetnextif() {
 
 static void test_reset_event(void)
 {
-  unsigned char ram[] = { 0, 10, 10 };
+  uint8_t ram[] = { 0, 10, 10 };
   memory_t memory;
   rc_runtime_t runtime;
   rc_condition_t* cond;
@@ -773,7 +773,7 @@ static void test_reset_event(void)
 
 static void test_paused_event(void)
 {
-  unsigned char ram[] = { 0, 10, 10 };
+  uint8_t ram[] = { 0, 10, 10 };
   memory_t memory;
   rc_runtime_t runtime;
 
@@ -825,7 +825,7 @@ static void test_paused_event(void)
 
 static void test_primed_event(void)
 {
-  unsigned char ram[] = { 0, 1, 0, 1, 0, 0 };
+  uint8_t ram[] = { 0, 1, 0, 1, 0, 0 };
   memory_t memory;
   rc_runtime_t runtime;
 
@@ -899,7 +899,7 @@ static void test_primed_event(void)
 
 static void test_progress_event(void)
 {
-  unsigned char ram[] = { 0, 1 };
+  uint8_t ram[] = { 0, 1 };
   memory_t memory;
   rc_runtime_t runtime;
 
@@ -958,7 +958,7 @@ static void test_progress_event(void)
 
 static void test_progress_event_as_percent(void)
 {
-  unsigned char ram[] = { 0, 1 };
+  uint8_t ram[] = { 0, 1 };
   memory_t memory;
   rc_runtime_t runtime;
 
@@ -1028,7 +1028,7 @@ static void test_progress_event_as_percent(void)
 
 static void test_lboard(void)
 {
-  unsigned char ram[] = { 2, 10, 10 };
+  uint8_t ram[] = { 2, 10, 10 };
   memory_t memory;
   rc_runtime_t runtime;
 
@@ -1126,7 +1126,7 @@ static void test_format_lboard_value(int format, int value, const char* expected
 
 static void test_richpresence(void)
 {
-  unsigned char ram[] = { 2, 10, 10 };
+  uint8_t ram[] = { 2, 10, 10 };
   memory_t memory;
   rc_runtime_t runtime;
 
@@ -1160,7 +1160,7 @@ static void test_richpresence(void)
 
 static void test_richpresence_starts_with_macro(void)
 {
-  unsigned char ram[] = { 2, 10, 10 };
+  uint8_t ram[] = { 2, 10, 10 };
   memory_t memory;
   rc_runtime_t runtime;
 
@@ -1179,7 +1179,7 @@ static void test_richpresence_starts_with_macro(void)
 
 static void test_richpresence_macro_only(void)
 {
-  unsigned char ram[] = { 2, 10, 10 };
+  uint8_t ram[] = { 2, 10, 10 };
   memory_t memory;
   rc_runtime_t runtime;
 
@@ -1198,7 +1198,7 @@ static void test_richpresence_macro_only(void)
 
 static void test_richpresence_conditional(void)
 {
-  unsigned char ram[] = { 2, 10, 10 };
+  uint8_t ram[] = { 2, 10, 10 };
   memory_t memory;
   rc_runtime_t runtime;
 
@@ -1227,7 +1227,7 @@ static void test_richpresence_conditional(void)
 
 static void test_richpresence_conditional_with_hits(void)
 {
-  unsigned char ram[] = { 2, 10, 10 };
+  uint8_t ram[] = { 2, 10, 10 };
   memory_t memory;
   rc_runtime_t runtime;
 
@@ -1275,7 +1275,7 @@ static void test_richpresence_conditional_with_hits(void)
 
 static void test_richpresence_conditional_with_hits_after_match(void)
 {
-  unsigned char ram[] = { 2, 10, 10 };
+  uint8_t ram[] = { 2, 10, 10 };
   memory_t memory;
   rc_runtime_t runtime;
 
@@ -1323,7 +1323,7 @@ static void test_richpresence_conditional_with_hits_after_match(void)
 
 static void test_richpresence_reload(void)
 {
-  unsigned char ram[] = { 2, 10, 10 };
+  uint8_t ram[] = { 2, 10, 10 };
   memory_t memory;
   rc_runtime_t runtime;
 
@@ -1361,7 +1361,7 @@ static void test_richpresence_reload(void)
 static void test_richpresence_reload_addaddress(void)
 {
   /* ram[1] must be non-zero */
-  unsigned char ram[] = { 1, 10, 10, 10 };
+  uint8_t ram[] = { 1, 10, 10, 10 };
   memory_t memory;
   rc_runtime_t runtime;
 
@@ -1399,7 +1399,7 @@ static void test_richpresence_reload_addaddress(void)
 
 static void test_richpresence_static(void)
 {
-  unsigned char ram[] = { 2, 10, 10 };
+  uint8_t ram[] = { 2, 10, 10 };
   memory_t memory;
   rc_runtime_t runtime;
 
@@ -1422,11 +1422,11 @@ static void test_richpresence_static(void)
 typedef struct {
   memory_t memory;
   rc_runtime_t* runtime;
-  unsigned invalid_address;
+  uint32_t invalid_address;
 }
 memory_invalid_t;
 
-static unsigned peek_invalid(unsigned address, unsigned num_bytes, void* ud)
+static uint32_t peek_invalid(uint32_t address, uint32_t num_bytes, void* ud)
 {
   memory_invalid_t* memory = (memory_invalid_t*)ud;
   if (memory->invalid_address != address)
@@ -1436,7 +1436,7 @@ static unsigned peek_invalid(unsigned address, unsigned num_bytes, void* ud)
   return 0;
 }
 
-static void assert_do_frame_invalid(rc_runtime_t* runtime, memory_invalid_t* memory, unsigned invalid_address)
+static void assert_do_frame_invalid(rc_runtime_t* runtime, memory_invalid_t* memory, uint32_t invalid_address)
 {
   event_count = 0;
   memory->runtime = runtime;
@@ -1446,7 +1446,7 @@ static void assert_do_frame_invalid(rc_runtime_t* runtime, memory_invalid_t* mem
 
 static void test_invalidate_address(void)
 {
-  unsigned char ram[] = { 0, 10, 10 };
+  uint8_t ram[] = { 0, 10, 10 };
   memory_invalid_t memory;
   rc_runtime_t runtime;
 
@@ -1499,7 +1499,7 @@ static void test_invalidate_address_no_memrefs(void)
 
 static void test_invalidate_address_shared_memref(void)
 {
-  unsigned char ram[] = { 0, 10, 10 };
+  uint8_t ram[] = { 0, 10, 10 };
   memory_invalid_t memory;
   rc_runtime_t runtime;
 
@@ -1533,7 +1533,7 @@ static void test_invalidate_address_shared_memref(void)
 
 static void test_invalidate_address_leaderboard(void)
 {
-  unsigned char ram[] = { 0, 10, 10 };
+  uint8_t ram[] = { 0, 10, 10 };
   memory_invalid_t memory;
   rc_runtime_t runtime;
 

--- a/test/rcheevos/test_runtime_progress.c
+++ b/test/rcheevos/test_runtime_progress.c
@@ -73,7 +73,7 @@ static void _assert_deserialize(rc_runtime_t* runtime, unsigned char* buffer)
 }
 #define assert_deserialize(runtime, buffer) ASSERT_HELPER(_assert_deserialize(runtime, buffer), "assert_deserialize")
 
-static void _assert_sized_memref(rc_runtime_t* runtime, unsigned address, char size, unsigned value, unsigned prev, unsigned prior)
+static void _assert_sized_memref(rc_runtime_t* runtime, uint32_t address, char size, uint32_t value, uint32_t prev, uint32_t prior)
 {
   rc_memref_t* memref = runtime->memrefs;
   while (memref)
@@ -102,7 +102,7 @@ static void _assert_sized_memref(rc_runtime_t* runtime, unsigned address, char s
 #define assert_sized_memref(runtime, address, size, value, prev, prior) ASSERT_HELPER(_assert_sized_memref(runtime, address, size, value, prev, prior), "assert_sized_memref")
 #define assert_memref(runtime, address, value, prev, prior) ASSERT_HELPER(_assert_sized_memref(runtime, address, RC_MEMSIZE_8_BITS, value, prev, prior), "assert_memref")
 
-static rc_trigger_t* find_trigger(rc_runtime_t* runtime, unsigned ach_id)
+static rc_trigger_t* find_trigger(rc_runtime_t* runtime, uint32_t ach_id)
 {
   unsigned i;
   for (i = 0; i < runtime->trigger_count; ++i) {
@@ -141,7 +141,7 @@ static rc_condition_t* find_trigger_cond(rc_trigger_t* trigger, unsigned group_i
   return cond;
 }
 
-static void _assert_hitcount(rc_runtime_t* runtime, unsigned ach_id, unsigned group_idx, unsigned cond_idx, unsigned expected_hits)
+static void _assert_hitcount(rc_runtime_t* runtime, uint32_t ach_id, unsigned group_idx, unsigned cond_idx, uint32_t expected_hits)
 {
   rc_trigger_t* trigger = find_trigger(runtime, ach_id);
   rc_condition_t* cond = find_trigger_cond(trigger, group_idx, cond_idx);
@@ -151,7 +151,7 @@ static void _assert_hitcount(rc_runtime_t* runtime, unsigned ach_id, unsigned gr
 }
 #define assert_hitcount(runtime, ach_id, group_idx, cond_idx, expected_hits) ASSERT_HELPER(_assert_hitcount(runtime, ach_id, group_idx, cond_idx, expected_hits), "assert_hitcount")
 
-static void _assert_cond_memref(rc_runtime_t* runtime, unsigned ach_id, unsigned group_idx, unsigned cond_idx, unsigned expected_value, unsigned expected_prior, char expected_changed)
+static void _assert_cond_memref(rc_runtime_t* runtime, uint32_t ach_id, unsigned group_idx, unsigned cond_idx, uint32_t expected_value, uint32_t expected_prior, uint8_t expected_changed)
 {
   rc_trigger_t* trigger = find_trigger(runtime, ach_id);
   rc_condition_t* cond = find_trigger_cond(trigger, group_idx, cond_idx);
@@ -164,7 +164,7 @@ static void _assert_cond_memref(rc_runtime_t* runtime, unsigned ach_id, unsigned
 #define assert_cond_memref(runtime, ach_id, group_idx, cond_idx, expected_value, expected_prior, expected_changed) \
  ASSERT_HELPER(_assert_cond_memref(runtime, ach_id, group_idx, cond_idx, expected_value, expected_prior, expected_changed), "assert_cond_memref")
 
-static void _assert_cond_memref2(rc_runtime_t* runtime, unsigned ach_id, unsigned group_idx, unsigned cond_idx, unsigned expected_value, unsigned expected_prior, char expected_changed)
+static void _assert_cond_memref2(rc_runtime_t* runtime, uint32_t ach_id, unsigned group_idx, unsigned cond_idx, uint32_t expected_value, uint32_t expected_prior, uint8_t expected_changed)
 {
   rc_trigger_t* trigger = find_trigger(runtime, ach_id);
   rc_condition_t* cond = find_trigger_cond(trigger, group_idx, cond_idx);
@@ -177,7 +177,7 @@ static void _assert_cond_memref2(rc_runtime_t* runtime, unsigned ach_id, unsigne
 #define assert_cond_memref2(runtime, ach_id, group_idx, cond_idx, expected_value, expected_prior, expected_changed) \
  ASSERT_HELPER(_assert_cond_memref2(runtime, ach_id, group_idx, cond_idx, expected_value, expected_prior, expected_changed), "assert_cond_memref2")
 
-static void _assert_achievement_state(rc_runtime_t* runtime, unsigned ach_id, int state)
+static void _assert_achievement_state(rc_runtime_t* runtime, uint32_t ach_id, uint8_t state)
 {
   rc_trigger_t* trigger = find_trigger(runtime, ach_id);
   ASSERT_PTR_NOT_NULL(trigger);
@@ -186,7 +186,7 @@ static void _assert_achievement_state(rc_runtime_t* runtime, unsigned ach_id, in
 }
 #define assert_achievement_state(runtime, ach_id, state) ASSERT_HELPER(_assert_achievement_state(runtime, ach_id, state), "assert_achievement_state")
 
-static rc_lboard_t* find_lboard(rc_runtime_t* runtime, unsigned lboard_id)
+static rc_lboard_t* find_lboard(rc_runtime_t* runtime, uint32_t lboard_id)
 {
   unsigned i;
   for (i = 0; i < runtime->lboard_count; ++i) {
@@ -198,7 +198,7 @@ static rc_lboard_t* find_lboard(rc_runtime_t* runtime, unsigned lboard_id)
   return NULL;
 }
 
-static void _assert_sta_hitcount(rc_runtime_t* runtime, unsigned lboard_id, unsigned group_idx, unsigned cond_idx, unsigned expected_hits)
+static void _assert_sta_hitcount(rc_runtime_t* runtime, uint32_t lboard_id, unsigned group_idx, unsigned cond_idx, uint32_t expected_hits)
 {
   rc_lboard_t* lboard = find_lboard(runtime, lboard_id);
   rc_condition_t* cond = find_trigger_cond(&lboard->start, group_idx, cond_idx);
@@ -208,7 +208,7 @@ static void _assert_sta_hitcount(rc_runtime_t* runtime, unsigned lboard_id, unsi
 }
 #define assert_sta_hitcount(runtime, lboard_id, group_idx, cond_idx, expected_hits) ASSERT_HELPER(_assert_sta_hitcount(runtime, lboard_id, group_idx, cond_idx, expected_hits), "assert_sta_hitcount")
 
-static void _assert_sub_hitcount(rc_runtime_t* runtime, unsigned lboard_id, unsigned group_idx, unsigned cond_idx, unsigned expected_hits)
+static void _assert_sub_hitcount(rc_runtime_t* runtime, uint32_t lboard_id, unsigned group_idx, unsigned cond_idx, uint32_t expected_hits)
 {
   rc_lboard_t* lboard = find_lboard(runtime, lboard_id);
   rc_condition_t* cond = find_trigger_cond(&lboard->submit, group_idx, cond_idx);
@@ -218,7 +218,7 @@ static void _assert_sub_hitcount(rc_runtime_t* runtime, unsigned lboard_id, unsi
 }
 #define assert_sub_hitcount(runtime, lboard_id, group_idx, cond_idx, expected_hits) ASSERT_HELPER(_assert_sub_hitcount(runtime, lboard_id, group_idx, cond_idx, expected_hits), "assert_sub_hitcount")
 
-static void _assert_can_hitcount(rc_runtime_t* runtime, unsigned lboard_id, unsigned group_idx, unsigned cond_idx, unsigned expected_hits)
+static void _assert_can_hitcount(rc_runtime_t* runtime, uint32_t lboard_id, unsigned group_idx, unsigned cond_idx, uint32_t expected_hits)
 {
   rc_lboard_t* lboard = find_lboard(runtime, lboard_id);
   rc_condition_t* cond = find_trigger_cond(&lboard->cancel, group_idx, cond_idx);
@@ -297,7 +297,7 @@ static void reset_runtime(rc_runtime_t* runtime)
 
 static void test_empty()
 {
-  unsigned char buffer[2048];
+  uint8_t buffer[2048];
   rc_runtime_t runtime;
 
   rc_runtime_init(&runtime);
@@ -316,8 +316,8 @@ static void test_empty()
 
 static void test_single_achievement()
 {
-  unsigned char ram[] = { 2, 3, 6 };
-  unsigned char buffer[2048];
+  uint8_t ram[] = { 2, 3, 6 };
+  uint8_t buffer[2048];
   memory_t memory;
   rc_runtime_t runtime;
 
@@ -356,8 +356,8 @@ static void test_single_achievement()
 
 static void test_invalid_marker()
 {
-  unsigned char ram[] = { 2, 3, 6 };
-  unsigned char buffer[2048];
+  uint8_t ram[] = { 2, 3, 6 };
+  uint8_t buffer[2048];
   memory_t memory;
   rc_runtime_t runtime;
 
@@ -400,8 +400,8 @@ static void test_invalid_marker()
 
 static void test_invalid_memref_chunk_id()
 {
-  unsigned char ram[] = { 2, 3, 6 };
-  unsigned char buffer[2048];
+  uint8_t ram[] = { 2, 3, 6 };
+  uint8_t buffer[2048];
   memory_t memory;
   rc_runtime_t runtime;
 
@@ -444,8 +444,8 @@ static void test_invalid_memref_chunk_id()
 
 static void test_modified_data()
 {
-  unsigned char ram[] = { 2, 3, 6 };
-  unsigned char buffer[2048];
+  uint8_t ram[] = { 2, 3, 6 };
+  uint8_t buffer[2048];
   memory_t memory;
   rc_runtime_t runtime;
 
@@ -491,8 +491,8 @@ static void test_modified_data()
 
 static void test_single_achievement_deactivated()
 {
-  unsigned char ram[] = { 2, 3, 6 };
-  unsigned char buffer[2048];
+  uint8_t ram[] = { 2, 3, 6 };
+  uint8_t buffer[2048];
   memory_t memory;
   rc_runtime_t runtime;
 
@@ -545,8 +545,8 @@ static void test_single_achievement_deactivated()
 
 static void test_single_achievement_md5_changed()
 {
-  unsigned char ram[] = { 2, 3, 6 };
-  unsigned char buffer[2048];
+  uint8_t ram[] = { 2, 3, 6 };
+  uint8_t buffer[2048];
   memory_t memory;
   rc_runtime_t runtime;
 
@@ -629,8 +629,8 @@ static void setup_multiple_achievements(rc_runtime_t* runtime, memory_t* memory)
 
 static void test_no_core_group()
 {
-  unsigned char ram[] = { 2, 3, 6 };
-  unsigned char buffer[2048];
+  uint8_t ram[] = { 2, 3, 6 };
+  uint8_t buffer[2048];
   memory_t memory;
   rc_runtime_t runtime;
 
@@ -669,8 +669,8 @@ static void test_no_core_group()
 
 static void test_memref_shared_address()
 {
-  unsigned char ram[] = { 2, 3, 0, 0, 0 };
-  unsigned char buffer[2048];
+  uint8_t ram[] = { 2, 3, 0, 0, 0 };
+  uint8_t buffer[2048];
   memory_t memory;
   rc_runtime_t runtime;
 
@@ -715,9 +715,9 @@ static void test_memref_shared_address()
 
 static void test_memref_indirect()
 {
-  unsigned char ram[] = { 1, 2, 3, 4, 5 };
-  unsigned char buffer1[512];
-  unsigned char buffer2[512];
+  uint8_t ram[] = { 1, 2, 3, 4, 5 };
+  uint8_t buffer1[512];
+  uint8_t buffer2[512];
   memory_t memory;
   rc_runtime_t runtime;
 
@@ -773,9 +773,9 @@ static void test_memref_indirect()
 
 static void test_memref_double_indirect()
 {
-  unsigned char ram[] = { 1, 2, 3, 4, 5 };
-  unsigned char buffer1[512];
-  unsigned char buffer2[512];
+  uint8_t ram[] = { 1, 2, 3, 4, 5 };
+  uint8_t buffer1[512];
+  uint8_t buffer2[512];
   memory_t memory;
   rc_runtime_t runtime;
 
@@ -836,8 +836,8 @@ static void test_memref_double_indirect()
 
 static void test_multiple_achievements()
 {
-  unsigned char ram[] = { 0, 1, 2, 3, 4, 5, 6, 7 };
-  unsigned char buffer[2048];
+  uint8_t ram[] = { 0, 1, 2, 3, 4, 5, 6, 7 };
+  uint8_t buffer[2048];
   memory_t memory;
   rc_runtime_t runtime;
 
@@ -869,8 +869,8 @@ static void test_multiple_achievements()
 
 static void test_multiple_achievements_ignore_triggered_and_inactive()
 {
-  unsigned char ram[] = { 0, 1, 2, 3, 4, 5, 6, 7 };
-  unsigned char buffer[2048];
+  uint8_t ram[] = { 0, 1, 2, 3, 4, 5, 6, 7 };
+  uint8_t buffer[2048];
   memory_t memory;
   rc_runtime_t runtime;
 
@@ -914,8 +914,8 @@ static void test_multiple_achievements_ignore_triggered_and_inactive()
 
 static void test_multiple_achievements_overwrite_waiting()
 {
-  unsigned char ram[] = { 0, 1, 2, 3, 4, 5, 6, 7 };
-  unsigned char buffer[2048];
+  uint8_t ram[] = { 0, 1, 2, 3, 4, 5, 6, 7 };
+  uint8_t buffer[2048];
   memory_t memory;
   rc_runtime_t runtime;
 
@@ -950,8 +950,8 @@ static void test_multiple_achievements_overwrite_waiting()
 
 static void test_multiple_achievements_reactivate_waiting()
 {
-  unsigned char ram[] = { 0, 1, 2, 3, 4, 5, 6, 7 };
-  unsigned char buffer[2048];
+  uint8_t ram[] = { 0, 1, 2, 3, 4, 5, 6, 7 };
+  uint8_t buffer[2048];
   memory_t memory;
   rc_runtime_t runtime;
 
@@ -990,9 +990,9 @@ static void test_multiple_achievements_reactivate_waiting()
 
 static void test_multiple_achievements_paused_and_primed()
 {
-  unsigned char ram[] = { 0, 1, 2, 3, 4, 5, 6, 7 };
-  unsigned char buffer[2048];
-  unsigned char buffer2[2048];
+  uint8_t ram[] = { 0, 1, 2, 3, 4, 5, 6, 7 };
+  uint8_t buffer[2048];
+  uint8_t buffer2[2048];
   memory_t memory;
   rc_runtime_t runtime;
 
@@ -1055,8 +1055,8 @@ static void test_multiple_achievements_paused_and_primed()
 
 static void test_multiple_achievements_deactivated_memrefs()
 {
-  unsigned char ram[] = { 0, 1, 2, 3, 4, 5, 6, 7 };
-  unsigned char buffer[2048];
+  uint8_t ram[] = { 0, 1, 2, 3, 4, 5, 6, 7 };
+  uint8_t buffer[2048];
   memory_t memory;
   rc_runtime_t runtime;
 
@@ -1108,8 +1108,8 @@ static void test_multiple_achievements_deactivated_memrefs()
 
 static void test_multiple_achievements_deactivated_no_memrefs()
 {
-  unsigned char ram[] = { 0, 1, 2, 3, 4, 5, 6, 7 };
-  unsigned char buffer[2048];
+  uint8_t ram[] = { 0, 1, 2, 3, 4, 5, 6, 7 };
+  uint8_t buffer[2048];
   memory_t memory;
   rc_runtime_t runtime;
 
@@ -1161,8 +1161,8 @@ static void test_multiple_achievements_deactivated_no_memrefs()
 
 static void test_single_leaderboard()
 {
-  unsigned char ram[] = { 2, 3, 6 };
-  unsigned char buffer[2048];
+  uint8_t ram[] = { 2, 3, 6 };
+  uint8_t buffer[2048];
   memory_t memory;
   rc_runtime_t runtime;
 
@@ -1209,8 +1209,8 @@ static void test_single_leaderboard()
 
 static void test_multiple_leaderboards()
 {
-  unsigned char ram[] = { 2, 3, 6 };
-  unsigned char buffer[2048];
+  uint8_t ram[] = { 2, 3, 6 };
+  uint8_t buffer[2048];
   memory_t memory;
   rc_runtime_t runtime;
 
@@ -1263,8 +1263,8 @@ static void test_multiple_leaderboards()
 
 static void test_multiple_leaderboards_ignore_inactive()
 {
-  unsigned char ram[] = { 2, 3, 6 };
-  unsigned char buffer[2048];
+  uint8_t ram[] = { 2, 3, 6 };
+  uint8_t buffer[2048];
   memory_t memory;
   rc_runtime_t runtime;
 
@@ -1322,8 +1322,8 @@ static void test_multiple_leaderboards_ignore_inactive()
 
 static void test_multiple_leaderboards_ignore_modified()
 {
-  unsigned char ram[] = { 2, 3, 6 };
-  unsigned char buffer[2048];
+  uint8_t ram[] = { 2, 3, 6 };
+  uint8_t buffer[2048];
   memory_t memory;
   rc_runtime_t runtime;
 
@@ -1380,7 +1380,7 @@ static void test_multiple_leaderboards_ignore_modified()
 
 static void test_rich_presence_none()
 {
-  unsigned char buffer[2048];
+  uint8_t buffer[2048];
   rc_runtime_t runtime;
   rc_runtime_init(&runtime);
 
@@ -1394,7 +1394,7 @@ static void test_rich_presence_none()
 
 static void test_rich_presence_static()
 {
-  unsigned char buffer[2048];
+  uint8_t buffer[2048];
   rc_runtime_t runtime;
   rc_runtime_init(&runtime);
 
@@ -1410,8 +1410,8 @@ static void test_rich_presence_static()
 
 static void test_rich_presence_simple_lookup()
 {
-  unsigned char ram[] = { 0, 1, 2, 3, 4, 5, 6, 7 };
-  unsigned char buffer[2048];
+  uint8_t ram[] = { 0, 1, 2, 3, 4, 5, 6, 7 };
+  uint8_t buffer[2048];
   memory_t memory;
   rc_runtime_t runtime;
 
@@ -1444,8 +1444,8 @@ static void test_rich_presence_simple_lookup()
 
 static void test_rich_presence_tracked_hits()
 {
-  unsigned char ram[] = { 0, 1, 2, 3, 4, 5, 6, 7 };
-  unsigned char buffer[2048];
+  uint8_t ram[] = { 0, 1, 2, 3, 4, 5, 6, 7 };
+  uint8_t buffer[2048];
   memory_t memory;
   rc_runtime_t runtime;
 
@@ -1473,8 +1473,8 @@ static void test_rich_presence_tracked_hits()
 
 static void test_rich_presence_tracked_hits_md5_changed()
 {
-  unsigned char ram[] = { 0, 1, 2, 3, 4, 5, 6, 7 };
-  unsigned char buffer[2048];
+  uint8_t ram[] = { 0, 1, 2, 3, 4, 5, 6, 7 };
+  uint8_t buffer[2048];
   memory_t memory;
   rc_runtime_t runtime;
 
@@ -1503,8 +1503,8 @@ static void test_rich_presence_tracked_hits_md5_changed()
 
 static void test_rich_presence_conditional_display()
 {
-  unsigned char ram[] = { 0, 1, 2, 3, 4, 5, 6, 7 };
-  unsigned char buffer[2048];
+  uint8_t ram[] = { 0, 1, 2, 3, 4, 5, 6, 7 };
+  uint8_t buffer[2048];
   memory_t memory;
   rc_runtime_t runtime;
 
@@ -1533,8 +1533,8 @@ static void test_rich_presence_conditional_display()
 
 static void test_rich_presence_conditional_display_md5_changed()
 {
-  unsigned char ram[] = { 0, 1, 2, 3, 4, 5, 6, 7 };
-  unsigned char buffer[2048];
+  uint8_t ram[] = { 0, 1, 2, 3, 4, 5, 6, 7 };
+  uint8_t buffer[2048];
   memory_t memory;
   rc_runtime_t runtime;
 

--- a/test/rcheevos/test_timing.c
+++ b/test/rcheevos/test_timing.c
@@ -29,7 +29,7 @@ static void _assert_activate_achievement(rc_runtime_t* runtime, unsigned int id,
 
 static void do_timing(void)
 {
-  unsigned char ram[256], last, next, bitcount;
+  uint8_t ram[256], last, next, bitcount;
   memory_t memory;
   int i, j, mask;
   clock_t total_clocks = 0, start, end;

--- a/test/rcheevos/test_trigger.c
+++ b/test/rcheevos/test_trigger.c
@@ -73,7 +73,7 @@ static int evaluate_trigger(rc_trigger_t* self, memory_t* memory) {
 /* ======================================================== */
 
 static void test_alt_groups() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_trigger_t* trigger;
   char buffer[512];
@@ -119,7 +119,7 @@ static void test_alt_groups() {
 }
 
 static void test_empty_core() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_trigger_t* trigger;
   char buffer[512];
@@ -154,7 +154,7 @@ static void test_empty_core() {
 }
 
 static void test_empty_alt() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_trigger_t* trigger;
   char buffer[512];
@@ -183,7 +183,7 @@ static void test_empty_alt() {
 }
 
 static void test_empty_last_alt() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_trigger_t* trigger;
   char buffer[512];
@@ -212,7 +212,7 @@ static void test_empty_last_alt() {
 }
 
 static void test_empty_all_alts() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_trigger_t* trigger;
   char buffer[512];
@@ -233,7 +233,7 @@ static void test_empty_all_alts() {
 }
 
 static void test_resetif_in_alt_group() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_trigger_t* trigger;
   char buffer[1024];
@@ -272,7 +272,7 @@ static void test_resetif_in_alt_group() {
 }
 
 static void test_pauseif_in_alt_group() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_trigger_t* trigger;
   char buffer[1024];
@@ -311,7 +311,7 @@ static void test_pauseif_in_alt_group() {
 }
 
 static void test_pauseif_resetif_in_alt_group() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_trigger_t* trigger;
   char buffer[1024];
@@ -358,7 +358,7 @@ static void test_pauseif_resetif_in_alt_group() {
 }
 
 static void test_pauseif_hitcount_with_reset() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_trigger_t* trigger;
   char buffer[512];
@@ -409,7 +409,7 @@ static void test_pauseif_hitcount_with_reset() {
 }
 
 static void test_measured() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_trigger_t* trigger;
   char buffer[256];
@@ -447,7 +447,7 @@ static void test_measured() {
 }
 
 static void test_measured_as_percent() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_trigger_t* trigger;
   char buffer[256];
@@ -485,7 +485,7 @@ static void test_measured_as_percent() {
 }
 
 static void test_measured_comparison() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_trigger_t* trigger;
   char buffer[256];
@@ -526,7 +526,7 @@ static void test_measured_comparison() {
 }
 
 static void test_measured_addhits() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_trigger_t* trigger;
   char buffer[256];
@@ -586,7 +586,7 @@ static void test_measured_addhits() {
 }
 
 static void test_measured_indirect() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_trigger_t* trigger;
   char buffer[256];
@@ -626,7 +626,7 @@ static void test_measured_indirect() {
 }
 
 static void test_measured_multiple() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_trigger_t* trigger;
   char buffer[512];
@@ -696,7 +696,7 @@ static void test_measured_multiple() {
 }
 
 static void test_measured_multiple_with_hitcount_in_core() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_trigger_t* trigger;
   char buffer[512];
@@ -731,7 +731,7 @@ static void test_measured_multiple_with_hitcount_in_core() {
 }
 
 static void test_measured_while_paused() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_trigger_t* trigger;
   char buffer[512];
@@ -763,7 +763,7 @@ static void test_measured_while_paused() {
 }
 
 static void test_measured_while_paused_multiple() {
-  unsigned char ram[] = {0x00, 0x00, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x00, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_trigger_t* trigger;
   char buffer[512];
@@ -830,7 +830,7 @@ static void test_measured_while_paused_multiple() {
 }
 
 static void test_measured_while_paused_reset_alt() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_trigger_t* trigger;
   char buffer[512];
@@ -872,7 +872,7 @@ static void test_measured_while_paused_reset_alt() {
 }
 
 static void test_measured_while_paused_reset_core() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_trigger_t* trigger;
   char buffer[512];
@@ -914,7 +914,7 @@ static void test_measured_while_paused_reset_core() {
 }
 
 static void test_measured_while_paused_reset_non_hitcount() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_trigger_t* trigger;
   char buffer[512];
@@ -948,7 +948,7 @@ static void test_measured_while_paused_reset_non_hitcount() {
 }
 
 static void test_measured_reset_hitcount() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_trigger_t* trigger;
   char buffer[512];
@@ -995,7 +995,7 @@ static void test_measured_reset_hitcount() {
 }
 
 static void test_measured_reset_comparison() {
-  unsigned char ram[] = {0x00, 0x12, 0x02, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x02, 0xAB, 0x56};
   memory_t memory;
   rc_trigger_t* trigger;
   char buffer[512];
@@ -1045,7 +1045,7 @@ static void test_measured_reset_comparison() {
 }
 
 static void test_measured_if() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_trigger_t* trigger;
   char buffer[256];
@@ -1085,7 +1085,7 @@ static void test_measured_if() {
 }
 
 static void test_measured_if_comparison() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_trigger_t* trigger;
   char buffer[256];
@@ -1133,7 +1133,7 @@ static void test_measured_if_comparison() {
 }
 
 static void test_measured_if_multiple_measured() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_trigger_t* trigger;
   char buffer[512];
@@ -1213,7 +1213,7 @@ static void test_measured_if_multiple_measured() {
 }
 
 static void test_measured_if_multiple_measured_if() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_trigger_t* trigger;
   char buffer[512];
@@ -1272,7 +1272,7 @@ static void test_measured_if_multiple_measured_if() {
 }
 
 static void test_measured_if_while_paused() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_trigger_t* trigger;
   char buffer[512];
@@ -1322,7 +1322,7 @@ static void test_measured_if_while_paused() {
 }
 
 static void test_resetnextif_trigger() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_trigger_t* trigger;
   char buffer[512];
@@ -1382,7 +1382,7 @@ static void test_resetnextif_trigger() {
 }
 
 static void test_evaluate_trigger_inactive() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_trigger_t* trigger;
   char buffer[512];
@@ -1420,7 +1420,7 @@ static void test_evaluate_trigger_inactive() {
 }
 
 static void test_evaluate_trigger_waiting() {
-  unsigned char ram[] = {0x00, 0x12, 0x18, 0xAB, 0x09};
+  uint8_t ram[] = {0x00, 0x12, 0x18, 0xAB, 0x09};
   memory_t memory;
   rc_trigger_t* trigger;
   char buffer[512];
@@ -1460,7 +1460,7 @@ static void test_evaluate_trigger_waiting() {
 }
 
 static void test_evaluate_trigger_reset() {
-  unsigned char ram[] = {0x00, 0x05, 0x10, 0xAB, 0x09};
+  uint8_t ram[] = {0x00, 0x05, 0x10, 0xAB, 0x09};
   memory_t memory;
   rc_trigger_t* trigger;
   char buffer[512];
@@ -1488,7 +1488,7 @@ static void test_evaluate_trigger_reset() {
 }
 
 static void test_evaluate_trigger_reset_next() {
-  unsigned char ram[] = {0x00, 0x05, 0x10, 0xAB, 0x09};
+  uint8_t ram[] = {0x00, 0x05, 0x10, 0xAB, 0x09};
   memory_t memory;
   rc_trigger_t* trigger;
   char buffer[512];
@@ -1543,7 +1543,7 @@ static void test_evaluate_trigger_reset_next() {
 }
 
 static void test_evaluate_trigger_triggered() {
-  unsigned char ram[] = {0x00, 0x05, 0x10, 0xAB, 0x09};
+  uint8_t ram[] = {0x00, 0x05, 0x10, 0xAB, 0x09};
   memory_t memory;
   rc_trigger_t* trigger;
   char buffer[512];
@@ -1579,7 +1579,7 @@ static void test_evaluate_trigger_triggered() {
 }
 
 static void test_evaluate_trigger_paused() {
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   rc_trigger_t* trigger;
   char buffer[512];
@@ -1647,7 +1647,7 @@ static void test_evaluate_trigger_paused() {
 }
 
 static void test_evaluate_trigger_primed() {
-  unsigned char ram[] = {0x00, 0x01, 0x00, 0x01, 0x00};
+  uint8_t ram[] = {0x00, 0x01, 0x00, 0x01, 0x00};
   memory_t memory;
   rc_trigger_t* trigger;
   char buffer[512];
@@ -1688,7 +1688,7 @@ static void test_evaluate_trigger_primed() {
 }
 
 static void test_evaluate_trigger_primed_in_alts() {
-  unsigned char ram[] = {0x01, 0x00, 0x00, 0x00, 0x00};
+  uint8_t ram[] = {0x01, 0x00, 0x00, 0x00, 0x00};
   memory_t memory;
   rc_trigger_t* trigger;
   char buffer[1024];
@@ -1724,7 +1724,7 @@ static void test_evaluate_trigger_primed_in_alts() {
 }
 
 static void test_evaluate_trigger_primed_one_alt() {
-  unsigned char ram[] = {0x00, 0x00, 0x00, 0x00, 0x00};
+  uint8_t ram[] = {0x00, 0x00, 0x00, 0x00, 0x00};
   memory_t memory;
   rc_trigger_t* trigger;
   char buffer[512];
@@ -1756,7 +1756,7 @@ static void test_evaluate_trigger_primed_one_alt() {
 }
 
 static void test_evaluate_trigger_disabled() {
-  unsigned char ram[] = {0x00, 0x00, 0x00, 0x00, 0x00};
+  uint8_t ram[] = {0x00, 0x00, 0x00, 0x00, 0x00};
   memory_t memory;
   rc_trigger_t* trigger;
   char buffer[512];
@@ -1773,7 +1773,7 @@ static void test_evaluate_trigger_disabled() {
 }
 
 static void test_evaluate_trigger_chained_resetnextif() {
-  unsigned char ram[] = {0x00, 0x00, 0x00, 0x00, 0x00};
+  uint8_t ram[] = {0x00, 0x00, 0x00, 0x00, 0x00};
   memory_t memory;
   rc_trigger_t* trigger;
   char buffer[512];

--- a/test/rcheevos/test_value.c
+++ b/test/rcheevos/test_value.c
@@ -6,7 +6,7 @@
 static void test_evaluate_value(const char* memaddr, int expected_value) {
   rc_value_t* self;
   /* bytes 5-8 are the float value for pi */
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56, 0xDB, 0x0F, 0x49, 0x40};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56, 0xDB, 0x0F, 0x49, 0x40};
   memory_t memory;
   char buffer[2048];
   unsigned* overflow;
@@ -59,7 +59,7 @@ static void test_measured_value_target(const char* memaddr, int expected_target)
 
 static void test_evaluate_measured_value_with_pause() {
   rc_value_t* self;
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   char buffer[2048];
   const char* memaddr = "P:0xH0003=hAB_M:0xH0002!=d0xH0002";
@@ -108,7 +108,7 @@ static void test_evaluate_measured_value_with_pause() {
 
 static void test_evaluate_measured_value_with_reset() {
   rc_value_t* self;
-  unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+  uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
   char buffer[2048];
   const char* memaddr = "R:0xH0003=hAB_M:0xH0002!=d0xH0002";

--- a/test/rhash/test_cdreader.c
+++ b/test/rhash/test_cdreader.c
@@ -500,7 +500,7 @@ static void test_determine_sector_size_sync(int sector_size)
 {
   cdrom_t* track_handle;
   const size_t image_size = (size_t)sector_size * 32;
-  unsigned char* image = (unsigned char*)malloc(image_size);
+  uint8_t* image = (uint8_t*)malloc(image_size);
   ASSERT_PTR_NOT_NULL(image);
 
   mock_file_text(0, "game.cue", cue_single_track);
@@ -527,7 +527,7 @@ static void test_determine_sector_size_sync_primary_volume_descriptor(int sector
 {
   cdrom_t* track_handle;
   const size_t image_size = (size_t)sector_size * 32;
-  unsigned char* image = (unsigned char*)malloc(image_size);
+  uint8_t* image = (uint8_t*)malloc(image_size);
   ASSERT_PTR_NOT_NULL(image);
 
   mock_file_text(0, "game.cue", cue_single_track);
@@ -561,7 +561,7 @@ static void test_determine_sector_size_sync_primary_volume_descriptor_index0(int
 
   cdrom_t* track_handle;
   const size_t image_size = (size_t)sector_size * 200;
-  unsigned char* image = (unsigned char*)malloc(image_size);
+  uint8_t* image = (uint8_t*)malloc(image_size);
   ASSERT_PTR_NOT_NULL(image);
 
   mock_file_text(0, "game.cue", cue);
@@ -595,7 +595,7 @@ static void test_determine_sector_size_sync_2048()
   cdrom_t* track_handle;
   const int sector_size = 2048;
   const size_t image_size = (size_t)sector_size * 32;
-  unsigned char* image = (unsigned char*)malloc(image_size);
+  uint8_t* image = (uint8_t*)malloc(image_size);
   ASSERT_PTR_NOT_NULL(image);
 
   mock_file_text(0, "game.cue", cue_single_track);
@@ -623,7 +623,7 @@ static void test_determine_sector_size_sync_primary_volume_descriptor_2048()
   cdrom_t* track_handle;
   const int sector_size = 2048;
   const size_t image_size = (size_t)sector_size * 32;
-  unsigned char* image = (unsigned char*)malloc(image_size);
+  uint8_t* image = (uint8_t*)malloc(image_size);
   ASSERT_PTR_NOT_NULL(image);
 
   mock_file_text(0, "game.cue", cue_single_track);
@@ -657,7 +657,7 @@ static void test_determine_sector_size_sync_primary_volume_descriptor_index0_204
   cdrom_t* track_handle;
   const int sector_size = 2048;
   const size_t image_size = (size_t)sector_size * 200;
-  unsigned char* image = (unsigned char*)malloc(image_size);
+  uint8_t* image = (uint8_t*)malloc(image_size);
   ASSERT_PTR_NOT_NULL(image);
 
   mock_file_text(0, "game.cue", cue);
@@ -699,7 +699,7 @@ static void test_absolute_sector_to_track_sector_cue_pregap()
 
   cdrom_t* track_handle;
   const size_t image_size = (size_t)60 * 200;
-  unsigned char* image = (unsigned char*)malloc(image_size);
+  uint8_t* image = (uint8_t*)malloc(image_size);
   ASSERT_PTR_NOT_NULL(image);
 
   mock_file_text(0, "game.cue", cue);
@@ -746,7 +746,7 @@ static void test_read_sector()
   char buffer[4096];
   cdrom_t* track_handle;
   const size_t image_size = (size_t)2352 * 32;
-  unsigned char* image = (unsigned char*)malloc(image_size);
+  uint8_t* image = (uint8_t*)malloc(image_size);
   int offset, i;
   ASSERT_PTR_NOT_NULL(image);
 

--- a/test/test.c
+++ b/test/test.c
@@ -23,7 +23,7 @@ static void test_lua(void) {
 
     lua_State* L;
     const char* luacheevo = "return { test = function(peek, ud) return peek(0, 4, ud) end }";
-    unsigned char ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
+    uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
     memory_t memory;
     rc_trigger_t* trigger;
     char buffer[2048];


### PR DESCRIPTION
Should have minimal impact on consumers, but ensures certain fields have explicit sizes. Most of these represent the "standard" size for the implicit types.

`unsigned` => `uint32_t`
`unsigned char` => `uint8_t`
`char` => `uint8_t` (when used for boolean or enum storage)
`int` => `int32_t` (when not used as a return value)
