### PR TITLE
allow client to pass custom errors through http callback

### DIFF
--- a/include/rc_api_request.h
+++ b/include/rc_api_request.h
@@ -56,6 +56,11 @@ typedef struct rc_api_server_response_t {
   int http_status_code;
 } rc_api_server_response_t;
 
+enum {
+  RC_API_SERVER_RESPONSE_CLIENT_ERROR = -1,
+  RC_API_SERVER_RESPONSE_RETRYABLE_CLIENT_ERROR = -2
+};
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
More generic solution for #283

The client can set `rc_api_server_response_t.http_status_code` to `RC_API_SERVER_RESPONSE_CLIENT_ERROR` or `RC_API_SERVER_RESPONSE_RETRYABLE_CLIENT_ERROR` and then put the error message in `rc_api_server_response_t.body`.

`RC_API_SERVER_RESPONSE_RETRYABLE_CLIENT_ERROR` indicates a non-fatal error (such as timeout) that should be retried for critical messages like achievement unlocks.