### PR TITLE
add rc_client_get_user_agent_clause

### DIFF
--- a/include/rc_client.h
+++ b/include/rc_client.h
@@ -136,6 +136,11 @@ RC_EXPORT void RC_CCONV rc_client_set_get_time_millisecs_function(rc_client_t* c
  */
 RC_EXPORT void RC_CCONV rc_client_abort_async(rc_client_t* client, rc_client_async_handle_t* async_handle);
 
+/**
+ * Gets a clause that can be added to the User-Agent to identify the version of rcheevos being used.
+ */
+RC_EXPORT size_t RC_CCONV rc_client_get_user_agent_clause(rc_client_t* client, char buffer[], size_t buffer_size);
+
 /*****************************************************************************\
 | Logging                                                                     |
 \*****************************************************************************/

--- a/src/rc_client.c
+++ b/src/rc_client.c
@@ -5596,15 +5596,25 @@ void rc_client_set_host(const rc_client_t* client, const char* hostname)
 
 size_t rc_client_get_user_agent_clause(rc_client_t* client, char buffer[], size_t buffer_size)
 {
+  size_t result;
+
 #ifdef RC_CLIENT_SUPPORTS_EXTERNAL
   if (client && client->state.external_client && client->state.external_client->get_user_agent_clause) {
-    size_t external_len = client->state.external_client->get_user_agent_clause(buffer, buffer_size);
-    if (external_len > 0) {
-      external_len += snprintf(buffer + external_len, buffer_size - external_len, " rc_client/" RCHEEVOS_VERSION_STRING);
-      return external_len;
+    result = client->state.external_client->get_user_agent_clause(buffer, buffer_size);
+    if (result > 0) {
+      result += snprintf(buffer + result, buffer_size - result, " rc_client/" RCHEEVOS_VERSION_STRING);
+      buffer[buffer_size - 1] = '\0';
+      return result;
     }
   }
+#else
+  (void)client;
 #endif
 
-  return snprintf(buffer, buffer_size, "rcheevos/" RCHEEVOS_VERSION_STRING);
+  result = snprintf(buffer, buffer_size, "rcheevos/" RCHEEVOS_VERSION_STRING);
+
+  /* some implementations of snprintf will fill the buffer without null terminating.
+   * make sure the buffer is null terminated */
+  buffer[buffer_size - 1] = '\0';
+  return result;
 }

--- a/src/rc_client.c
+++ b/src/rc_client.c
@@ -5,6 +5,7 @@
 #include "rc_api_user.h"
 #include "rc_consoles.h"
 #include "rc_hash.h"
+#include "rc_version.h"
 
 #include "rapi/rc_api_common.h"
 
@@ -5591,4 +5592,19 @@ void rc_client_set_host(const rc_client_t* client, const char* hostname)
   if (client && client->state.external_client && client->state.external_client->set_host)
     client->state.external_client->set_host(hostname);
 #endif
+}
+
+size_t rc_client_get_user_agent_clause(rc_client_t* client, char buffer[], size_t buffer_size)
+{
+#ifdef RC_CLIENT_SUPPORTS_EXTERNAL
+  if (client && client->state.external_client && client->state.external_client->get_user_agent_clause) {
+    size_t external_len = client->state.external_client->get_user_agent_clause(buffer, buffer_size);
+    if (external_len > 0) {
+      external_len += snprintf(buffer + external_len, buffer_size - external_len, " rc_client/" RCHEEVOS_VERSION_STRING);
+      return external_len;
+    }
+  }
+#endif
+
+  return snprintf(buffer, buffer_size, "rcheevos/" RCHEEVOS_VERSION_STRING);
 }

--- a/src/rc_client_external.h
+++ b/src/rc_client_external.h
@@ -73,6 +73,7 @@ typedef struct rc_client_external_t
   rc_client_external_set_read_memory_func_t set_read_memory;
   rc_client_external_set_get_time_millisecs_func_t set_get_time_millisecs;
   rc_client_external_set_string_func_t set_host;
+  rc_client_external_copy_string_func_t get_user_agent_clause;
 
   rc_client_external_set_int_func_t set_hardcore_enabled;
   rc_client_external_get_int_func_t get_hardcore_enabled;

--- a/test/test_rc_client.c
+++ b/test/test_rc_client.c
@@ -8414,6 +8414,23 @@ static void test_set_encore_mode_disable(void)
   rc_client_destroy(g_client);
 }
 
+static void test_get_user_agent_clause(void)
+{
+  char expected_clause[] = "rcheevos/" RCHEEVOS_VERSION_STRING;
+  char buffer[64];
+
+  g_client = mock_client_not_logged_in();
+  ASSERT_NUM_EQUALS(rc_client_get_user_agent_clause(g_client, buffer, sizeof(buffer)), sizeof(expected_clause) - 1);
+  ASSERT_STR_EQUALS(buffer, expected_clause);
+
+  /* snprintf will return the number of characters it wants, even if the buffer is too small,
+   * but will only fill as much of the buffer is available */
+  ASSERT_NUM_EQUALS(rc_client_get_user_agent_clause(g_client, buffer, 8), sizeof(expected_clause) - 1);
+  ASSERT_STR_EQUALS(buffer, "rcheevo");
+
+  rc_client_destroy(g_client);
+}
+
 /* ----- harness ----- */
 
 void test_client(void) {
@@ -8617,6 +8634,8 @@ void test_client(void) {
   TEST(test_set_hardcore_enable_encore_mode);
   TEST(test_set_encore_mode_enable);
   TEST(test_set_encore_mode_disable);
+
+  TEST(test_get_user_agent_clause);
 
   TEST_SUITE_END();
 }


### PR DESCRIPTION
Helper function that can be used to get a string in the form `rcheevos/11.1` for inclusion in a User-Agent string:
```
MyEmu/1.2 (rcheevos/11.1)
```