### PR TITLE
fix logic error hashing small files from CD filesystem

### DIFF
--- a/src/rhash/hash.c
+++ b/src/rhash/hash.c
@@ -511,8 +511,8 @@ static int rc_hash_cd_file(md5_state_t* md5, void* track_handle, uint32_t sector
     verbose_message_callback(message);
   }
 
-  if (size < (unsigned)num_read)
-    size = (unsigned)num_read;
+  if (size < (unsigned)num_read) /* we read a whole sector - only hash the part containing file data */
+    num_read = (size_t)size;
 
   do
   {

--- a/test/rhash/test_hash.c
+++ b/test/rhash/test_hash.c
@@ -1690,7 +1690,7 @@ static void test_hash_psp()
   size_t image_size;
   uint8_t* image = generate_iso9660_bin(160, "TEST", &image_size);
   char hash_file[33], hash_iterator[33];
-  const char* expected_md5 = "80c0b42b2d89d036086869433a176a03";
+  const char* expected_md5 = "27ec2f9b7238b2ef29af31ddd254f201";
 
   generate_iso9660_file(image, "PSP_GAME\\PARAM.SFO", param_sfo, param_sfo_size);
   generate_iso9660_file(image, "PSP_GAME\\SYSDIR\\EBOOT.BIN", eboot_bin, eboot_bin_size);


### PR DESCRIPTION
https://discord.com/channels/310192285306454017/645777658319208448/1197203036334985297

When reading a file smaller than 2048 bytes, the entire sector containing the file was being hashed. This was unintentional.

However, fixing this issue will cause most of the PSP hashes to change. As such, we will need to support both old and new hashes for the ~1000 PSP hashes already in the system.

This function is also used for NeoGeoCD, Dreamcast, PSX, and PS2 hashes, but the likelihood of those having files smaller than 2048 bytes is basically non-existant.