### PR TITLE
add RC_CLIENT_SUPPORTS_HASH compilation option

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -85,6 +85,25 @@ jobs:
       run: make ARCH=x64 BUILD=c89 HAVE_LUA=1 valgrind
       working-directory: test
 
+  linux-x64-nohash:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install valgrind gcc-multilib # bits/libc-header-start.h
+    - name: Build
+      run: make ARCH=x64 BUILD=c89 HAVE_HASH=0 test
+      working-directory: test
+    - name: Run tests
+      run: ./test
+      working-directory: test
+    - name: Valgrind
+      run: make ARCH=x64 BUILD=c89 HAVE_HASH=0 valgrind
+      working-directory: test
+
   windows-x64-msbuild:
     runs-on: windows-latest
     steps:

--- a/include/rc_client.h
+++ b/include/rc_client.h
@@ -283,6 +283,12 @@ RC_EXPORT rc_client_async_handle_t* RC_CCONV rc_client_begin_change_media(rc_cli
     const uint8_t* data, size_t data_size, rc_client_callback_t callback, void* callback_userdata);
 #endif
 
+/**
+ * Changes the active disc in a multi-disc game.
+ */
+RC_EXPORT rc_client_async_handle_t* RC_CCONV rc_client_begin_change_media_from_hash(rc_client_t* client, const char* hash,
+    rc_client_callback_t callback, void* callback_userdata);
+
 /*****************************************************************************\
 | Subsets                                                                     |
 \*****************************************************************************/

--- a/include/rc_client.h
+++ b/include/rc_client.h
@@ -221,6 +221,7 @@ RC_EXPORT void RC_CCONV rc_client_get_user_game_summary(const rc_client_t* clien
 | Game                                                                        |
 \*****************************************************************************/
 
+#ifdef RC_CLIENT_SUPPORTS_HASH
 /**
  * Start loading an unidentified game.
  */
@@ -228,6 +229,7 @@ RC_EXPORT rc_client_async_handle_t* RC_CCONV rc_client_begin_identify_and_load_g
     uint32_t console_id, const char* file_path,
     const uint8_t* data, size_t data_size,
     rc_client_callback_t callback, void* callback_userdata);
+#endif
 
 /**
  * Start loading a game.
@@ -273,11 +275,13 @@ RC_EXPORT const rc_client_game_t* RC_CCONV rc_client_get_game_info(const rc_clie
  */
 RC_EXPORT int RC_CCONV rc_client_game_get_image_url(const rc_client_game_t* game, char buffer[], size_t buffer_size);
 
+#ifdef RC_CLIENT_SUPPORTS_HASH
 /**
  * Changes the active disc in a multi-disc game.
  */
 RC_EXPORT rc_client_async_handle_t* RC_CCONV rc_client_begin_change_media(rc_client_t* client, const char* file_path,
     const uint8_t* data, size_t data_size, rc_client_callback_t callback, void* callback_userdata);
+#endif
 
 /*****************************************************************************\
 | Subsets                                                                     |

--- a/src/rc_client.c
+++ b/src/rc_client.c
@@ -41,16 +41,17 @@ typedef struct rc_client_generic_callback_data_t {
   rc_client_async_handle_t async_handle;
 } rc_client_generic_callback_data_t;
 
-#ifdef RC_CLIENT_SUPPORTS_HASH
 typedef struct rc_client_pending_media_t
 {
+#ifdef RC_CLIENT_SUPPORTS_HASH
   const char* file_path;
   uint8_t* data;
   size_t data_size;
+#endif
+  const char* hash;
   rc_client_callback_t callback;
   void* callback_userdata;
 } rc_client_pending_media_t;
-#endif
 
 typedef struct rc_client_load_state_t
 {
@@ -64,8 +65,8 @@ typedef struct rc_client_load_state_t
 
 #ifdef RC_CLIENT_SUPPORTS_HASH
   rc_hash_iterator_t hash_iterator;
-  rc_client_pending_media_t* pending_media;
 #endif
+  rc_client_pending_media_t* pending_media;
 
   rc_api_start_session_response_t *start_session_response;
 
@@ -1410,6 +1411,18 @@ static void rc_client_apply_unlocks(rc_client_subset_info_t* subset, rc_api_unlo
   }
 }
 
+static void rc_client_free_pending_media(rc_client_pending_media_t* pending_media)
+{
+  if (pending_media->hash)
+    free((void*)pending_media->hash);
+#ifdef RC_CLIENT_SUPPORTS_HASH
+  if (pending_media->data)
+    free(pending_media->data);
+  free((void*)pending_media->file_path);
+#endif
+  free(pending_media);
+}
+
 static void rc_client_activate_game(rc_client_load_state_t* load_state, rc_api_start_session_response_t *start_session_response)
 {
   rc_client_t* client = load_state->client;
@@ -1449,7 +1462,6 @@ static void rc_client_activate_game(rc_client_load_state_t* load_state, rc_api_s
         load_state->callback(RC_ABORTED, "The requested game is no longer active", client, load_state->callback_userdata);
     }
     else {
-#ifdef RC_CLIENT_SUPPORTS_HASH
       /* if a change media request is pending, kick it off */
       rc_client_pending_media_t* pending_media;
 
@@ -1459,14 +1471,18 @@ static void rc_client_activate_game(rc_client_load_state_t* load_state, rc_api_s
       rc_mutex_unlock(&load_state->client->state.mutex);
 
       if (pending_media) {
-        rc_client_begin_change_media(client, pending_media->file_path,
-          pending_media->data, pending_media->data_size, pending_media->callback, pending_media->callback_userdata);
-        if (pending_media->data)
-          free(pending_media->data);
-        free((void*)pending_media->file_path);
-        free(pending_media);
-      }
+        if (pending_media->hash) {
+          rc_client_begin_change_media_from_hash(client, pending_media->hash,
+            pending_media->callback, pending_media->callback_userdata);
+        } else {
+#ifdef RC_CLIENT_SUPPORTS_HASH
+          rc_client_begin_change_media(client, pending_media->file_path,
+            pending_media->data, pending_media->data_size,
+            pending_media->callback, pending_media->callback_userdata);
 #endif
+        }
+        rc_client_free_pending_media(pending_media);
+      }
 
       /* client->game must be set before calling this function so it can query the console_id */
       rc_client_validate_addresses(load_state->game, client);
@@ -2474,10 +2490,10 @@ void rc_client_unload_game(rc_client_t* client)
   }
 }
 
-#ifdef RC_CLIENT_SUPPORTS_HASH
-
-static void rc_client_change_media(rc_client_t* client, const rc_client_game_hash_t* game_hash, rc_client_callback_t callback, void* callback_userdata)
+static void rc_client_change_media_internal(rc_client_t* client, const rc_client_game_hash_t* game_hash, rc_client_callback_t callback, void* callback_userdata)
 {
+  client->game->public_.hash = game_hash->hash;
+
   if (game_hash->game_id == client->game->public_.id) {
     RC_CLIENT_LOG_INFO_FORMATTED(client, "Switching to valid media for game %u: %s", game_hash->game_id, game_hash->hash);
   }
@@ -2485,13 +2501,19 @@ static void rc_client_change_media(rc_client_t* client, const rc_client_game_has
     RC_CLIENT_LOG_INFO(client, "Switching to unknown media");
   }
   else if (game_hash->game_id == 0) {
+    if (client->state.hardcore) {
+      RC_CLIENT_LOG_WARN_FORMATTED(client, "Disabling hardcore for unidentified media: %s", game_hash->hash);
+      rc_client_set_hardcore_enabled(client, 0);
+      callback(RC_HARDCORE_DISABLED, "Hardcore disabled. Unidentified media inserted.", client, callback_userdata);
+      return;
+    }
+
     RC_CLIENT_LOG_INFO_FORMATTED(client, "Switching to unrecognized media: %s", game_hash->hash);
   }
   else {
     RC_CLIENT_LOG_INFO_FORMATTED(client, "Switching to known media for game %u: %s", game_hash->game_id, game_hash->hash);
   }
 
-  client->game->public_.hash = game_hash->hash;
   callback(RC_OK, NULL, client, callback_userdata);
 }
 
@@ -2523,21 +2545,64 @@ static void rc_client_identify_changed_media_callback(const rc_api_server_respon
   else {
     load_state->hash->game_id = resolve_hash_response.game_id;
 
-    if (resolve_hash_response.game_id == 0 && client->state.hardcore) {
-      RC_CLIENT_LOG_WARN_FORMATTED(client, "Disabling hardcore for unidentified media: %s", load_state->hash->hash);
-      rc_client_set_hardcore_enabled(client, 0);
-      client->game->public_.hash = load_state->hash->hash; /* do still update the loaded hash */
-      load_state->callback(RC_HARDCORE_DISABLED, "Hardcore disabled. Unidentified media inserted.", client, load_state->callback_userdata);
-    }
-    else {
+    if (resolve_hash_response.game_id != 0) {
       RC_CLIENT_LOG_INFO_FORMATTED(client, "Identified game: %u (%s)", load_state->hash->game_id, load_state->hash->hash);
-      rc_client_change_media(client, load_state->hash, load_state->callback, load_state->callback_userdata);
     }
+
+    rc_client_change_media_internal(client, load_state->hash, load_state->callback, load_state->callback_userdata);
   }
 
   free(load_state);
   rc_api_destroy_resolve_hash_response(&resolve_hash_response);
 }
+
+static rc_client_async_handle_t* rc_client_begin_change_media_internal(rc_client_t* client,
+    rc_client_game_info_t* game, rc_client_game_hash_t* game_hash, rc_client_callback_t callback, void* callback_userdata)
+{
+  rc_client_load_state_t* callback_data;
+  rc_client_async_handle_t* async_handle;
+  rc_api_resolve_hash_request_t resolve_hash_request;
+  rc_api_request_t request;
+  int result;
+
+  if (game_hash->game_id != RC_CLIENT_UNKNOWN_GAME_ID) {
+    rc_client_change_media_internal(client, game_hash, callback, callback_userdata);
+    return NULL;
+  }
+
+  /* call the server to make sure the hash is valid for the loaded game */
+  memset(&resolve_hash_request, 0, sizeof(resolve_hash_request));
+  resolve_hash_request.game_hash = game_hash->hash;
+
+  result = rc_api_init_resolve_hash_request(&request, &resolve_hash_request);
+  if (result != RC_OK) {
+    callback(result, rc_error_str(result), client, callback_userdata);
+    return NULL;
+  }
+
+  callback_data = (rc_client_load_state_t*)calloc(1, sizeof(rc_client_load_state_t));
+  if (!callback_data) {
+    callback(RC_OUT_OF_MEMORY, rc_error_str(RC_OUT_OF_MEMORY), client, callback_userdata);
+    return NULL;
+  }
+
+  callback_data->callback = callback;
+  callback_data->callback_userdata = callback_userdata;
+  callback_data->client = client;
+  callback_data->hash = game_hash;
+  callback_data->game = game;
+
+  async_handle = &callback_data->async_handle;
+  rc_client_begin_async(client, async_handle);
+  client->callbacks.server_call(&request, rc_client_identify_changed_media_callback, callback_data, client);
+
+  rc_api_destroy_request(&request);
+
+  /* if handle is no longer valid, the async operation completed synchronously */
+  return rc_client_async_handle_valid(client, async_handle) ? async_handle : NULL;
+}
+
+#ifdef RC_CLIENT_SUPPORTS_HASH
 
 rc_client_async_handle_t* rc_client_begin_change_media(rc_client_t* client, const char* file_path,
     const uint8_t* data, size_t data_size, rc_client_callback_t callback, void* callback_userdata)
@@ -2569,12 +2634,8 @@ rc_client_async_handle_t* rc_client_begin_change_media(rc_client_t* client, cons
     if (game->public_.console_id == 0) {
       /* still waiting for game data */
       pending_media = client->state.load->pending_media;
-      if (pending_media) {
-        if (pending_media->data)
-          free(pending_media->data);
-        free((void*)pending_media->file_path);
-        free(pending_media);
-      }
+      if (pending_media)
+        rc_client_free_pending_media(pending_media);
 
       pending_media = (rc_client_pending_media_t*)calloc(1, sizeof(*pending_media));
       if (!pending_media) {
@@ -2661,56 +2722,79 @@ rc_client_async_handle_t* rc_client_begin_change_media(rc_client_t* client, cons
     rc_mutex_unlock(&client->state.mutex);
 
     if (!result) {
-      rc_client_change_media(client, game_hash, callback, callback_userdata);
+      rc_client_change_media_internal(client, game_hash, callback, callback_userdata);
       return NULL;
     }
   }
 
-  if (game_hash->game_id != RC_CLIENT_UNKNOWN_GAME_ID) {
-    rc_client_change_media(client, game_hash, callback, callback_userdata);
-    return NULL;
-  }
-  else {
-    /* call the server to make sure the hash is valid for the loaded game */
-    rc_client_load_state_t* callback_data;
-    rc_client_async_handle_t* async_handle;
-    rc_api_resolve_hash_request_t resolve_hash_request;
-    rc_api_request_t request;
-    int result;
-
-    memset(&resolve_hash_request, 0, sizeof(resolve_hash_request));
-    resolve_hash_request.game_hash = game_hash->hash;
-
-    result = rc_api_init_resolve_hash_request(&request, &resolve_hash_request);
-    if (result != RC_OK) {
-      callback(result, rc_error_str(result), client, callback_userdata);
-      return NULL;
-    }
-
-    callback_data = (rc_client_load_state_t*)calloc(1, sizeof(rc_client_load_state_t));
-    if (!callback_data) {
-      callback(RC_OUT_OF_MEMORY, rc_error_str(RC_OUT_OF_MEMORY), client, callback_userdata);
-      return NULL;
-    }
-
-    callback_data->callback = callback;
-    callback_data->callback_userdata = callback_userdata;
-    callback_data->client = client;
-    callback_data->hash = game_hash;
-    callback_data->game = game;
-
-    async_handle = &callback_data->async_handle;
-    rc_client_begin_async(client, async_handle);
-    client->callbacks.server_call(&request, rc_client_identify_changed_media_callback, callback_data, client);
-
-    rc_api_destroy_request(&request);
-
-    /* if handle is no longer valid, the async operation completed synchronously */
-    return rc_client_async_handle_valid(client, async_handle) ? async_handle : NULL;
-  }
+  return rc_client_begin_change_media_internal(client, game, game_hash, callback, callback_userdata);
 }
 
 #endif /* RC_CLIENT_SUPPORTS_HASH */
+
+rc_client_async_handle_t* rc_client_begin_change_media_from_hash(rc_client_t* client, const char* hash,
+    rc_client_callback_t callback, void* callback_userdata)
+{
+  rc_client_game_hash_t* game_hash;
+  rc_client_game_info_t* game;
+  rc_client_pending_media_t* pending_media = NULL;
+
+  if (!client) {
+    callback(RC_INVALID_STATE, "client is required", client, callback_userdata);
+    return NULL;
+  }
+
+  if (!hash || !hash[0]) {
+    callback(RC_INVALID_STATE, "hash is required", client, callback_userdata);
+    return NULL;
+  }
+
+#ifdef RC_CLIENT_SUPPORTS_EXTERNAL
+  if (client->state.external_client && client->state.external_client->begin_change_media_from_hash) {
+    return client->state.external_client->begin_change_media_from_hash(client, hash, callback, callback_userdata);
+  }
+#endif
+
+  rc_mutex_lock(&client->state.mutex);
+  if (client->state.load) {
+    game = client->state.load->game;
+    if (game->public_.console_id == 0) {
+      /* still waiting for game data */
+      pending_media = client->state.load->pending_media;
+      if (pending_media)
+        rc_client_free_pending_media(pending_media);
+
+      pending_media = (rc_client_pending_media_t*)calloc(1, sizeof(*pending_media));
+      if (!pending_media) {
+        rc_mutex_unlock(&client->state.mutex);
+        callback(RC_OUT_OF_MEMORY, rc_error_str(RC_OUT_OF_MEMORY), client, callback_userdata);
+        return NULL;
+      }
+
+      pending_media->hash = strdup(hash);
+      pending_media->callback = callback;
+      pending_media->callback_userdata = callback_userdata;
+
+      client->state.load->pending_media = pending_media;
+    }
+  } else {
+    game = client->game;
+  }
+  rc_mutex_unlock(&client->state.mutex);
+
+  if (!game) {
+    callback(RC_NO_GAME_LOADED, rc_error_str(RC_NO_GAME_LOADED), client, callback_userdata);
+    return NULL;
+  }
+
+  /* still waiting for game data */
+  if (pending_media)
+    return NULL;
+
+  /* check to see if we've already hashed this file. */
+  game_hash = rc_client_find_game_hash(client, hash);
+  return rc_client_begin_change_media_internal(client, game, game_hash, callback, callback_userdata);
+}
 
 const rc_client_game_t* rc_client_get_game_info(const rc_client_t* client)
 {

--- a/src/rc_client.c
+++ b/src/rc_client.c
@@ -4,7 +4,6 @@
 #include "rc_api_runtime.h"
 #include "rc_api_user.h"
 #include "rc_consoles.h"
-
 #include "rc_hash.h"
 #include "rc_version.h"
 

--- a/src/rc_client_external.h
+++ b/src/rc_client_external.h
@@ -99,6 +99,7 @@ typedef struct rc_client_external_t
   rc_client_external_action_func_t unload_game;
   rc_client_external_get_user_game_summary_func_t get_user_game_summary;
   rc_client_external_begin_change_media_func_t begin_change_media;
+  rc_client_external_begin_load_game_func_t begin_change_media_from_hash;
 
   rc_client_external_create_achievement_list_func_t create_achievement_list;
   rc_client_external_get_int_func_t has_achievements;

--- a/src/rc_client_internal.h
+++ b/src/rc_client_internal.h
@@ -368,8 +368,10 @@ int rc_value_contains_memref(const rc_value_t* value, const rc_memref_t* memref)
 /* end runtime.c internals */
 
 /* helper functions for unit tests */
+#ifdef RC_CLIENT_SUPPORTS_HASH
 struct rc_hash_iterator;
 struct rc_hash_iterator* rc_client_get_load_state_hash_iterator(rc_client_t* client);
+#endif
 /* end helper functions for unit tests */
 
 enum {

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,8 +1,9 @@
 # supported parameters
 #  ARCH          architecture - "x86" or "x64" [detected if not set]
-#  BUILD         use flags for specified upstream consumer - "c89" or "retroarch" [default to "c89]
+#  BUILD         use flags for specified upstream consumer - "c89" or "retroarch" [default to "c89"]
 #  DEBUG         if set to anything, builds with DEBUG symbols
 #  HAVE_LUA      if set to anything, includes the lua functionality
+#  HAVE_HASH     if set to 0, excludes the hash functionality
 
 RC_SRC=../src
 RC_CHEEVOS_SRC=$(RC_SRC)/rcheevos
@@ -39,7 +40,6 @@ endif
 # source files
 OBJ=$(RC_SRC)/rc_compat.o \
     $(RC_SRC)/rc_client.o \
-    $(RC_SRC)/rc_libretro.o \
     $(RC_SRC)/rc_util.o \
     $(RC_SRC)/rc_version.o \
     $(RC_CHEEVOS_SRC)/alloc.o \
@@ -56,9 +56,6 @@ OBJ=$(RC_SRC)/rc_compat.o \
     $(RC_CHEEVOS_SRC)/runtime_progress.o \
     $(RC_CHEEVOS_SRC)/trigger.o \
     $(RC_CHEEVOS_SRC)/value.o \
-    $(RC_HASH_SRC)/aes.o \
-    $(RC_HASH_SRC)/cdreader.o \
-    $(RC_HASH_SRC)/hash.o \
     $(RC_HASH_SRC)/md5.o \
     $(RC_URL_SRC)/url.o \
     $(RC_API_SRC)/rc_api_common.o \
@@ -80,17 +77,12 @@ OBJ=$(RC_SRC)/rc_compat.o \
     rcheevos/test_trigger.o \
     rcheevos/test_value.o \
     rurl/test_url.o \
-    rhash/data.o \
-    rhash/mock_filereader.o \
-    rhash/test_cdreader.o \
-    rhash/test_hash.o \
     rapi/test_rc_api_common.o \
     rapi/test_rc_api_editor.o \
     rapi/test_rc_api_info.o \
     rapi/test_rc_api_runtime.o \
     rapi/test_rc_api_user.o \
     test_rc_client.o \
-    test_rc_libretro.o \
     test.o
 
 # compile flags
@@ -135,6 +127,22 @@ else ifeq ($(BUILD), retroarch)
     OBJ += test_rc_client_external.o
 else
     $(error unknown BUILD "$(BUILD)")
+endif
+
+# support for building without hash subdirectory
+ifeq ($(HAVE_HASH), 0)
+    EXTRA += |NO_HASH
+else
+    CFLAGS += -DRC_CLIENT_SUPPORTS_HASH
+    OBJ += $(RC_HASH_SRC)/aes.o \
+           $(RC_HASH_SRC)/cdreader.o \
+           $(RC_HASH_SRC)/hash.o \
+           $(RC_SRC)/rc_libretro.o \
+           rhash/data.o \
+           rhash/mock_filereader.o \
+           rhash/test_cdreader.o \
+           rhash/test_hash.o \
+           test_rc_libretro.o
 endif
 
 # LUA support

--- a/test/rcheevos-test.vcxproj
+++ b/test/rcheevos-test.vcxproj
@@ -74,7 +74,7 @@
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)..\include;$(ProjectDir)..\src\rcheevos;$(ProjectDir)lua\src</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
-      <PreprocessorDefinitions>_MBCS;RC_CLIENT_SUPPORTS_RAINTEGRATION;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;RC_CLIENT_SUPPORTS_RAINTEGRATION;RC_CLIENT_SUPPORTS_HASH;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -88,7 +88,7 @@
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)..\include;$(ProjectDir)..\src\rcheevos;$(ProjectDir)lua\src</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
-      <PreprocessorDefinitions>_MBCS;RC_CLIENT_SUPPORTS_RAINTEGRATION;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;RC_CLIENT_SUPPORTS_RAINTEGRATION;RC_CLIENT_SUPPORTS_HASH;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -104,7 +104,7 @@
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)..\include;$(ProjectDir)..\src\rcheevos;$(ProjectDir)lua\src</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
-      <PreprocessorDefinitions>_MBCS;RC_CLIENT_SUPPORTS_RAINTEGRATION;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;RC_CLIENT_SUPPORTS_RAINTEGRATION;RC_CLIENT_SUPPORTS_HASH;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
@@ -122,7 +122,7 @@
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)..\include;$(ProjectDir)..\src\rcheevos;$(ProjectDir)lua\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
-      <PreprocessorDefinitions>_MBCS;RC_CLIENT_SUPPORTS_RAINTEGRATION;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;RC_CLIENT_SUPPORTS_RAINTEGRATION;RC_CLIENT_SUPPORTS_HASH;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>

--- a/test/rcheevos-test.vcxproj.filters
+++ b/test/rcheevos-test.vcxproj.filters
@@ -307,6 +307,7 @@
       <Filter>tests</Filter>
     </ClCompile>
     <ClCompile Include="..\src\rc_version.c" />
+    <ClCompile Include="..\src\rhash\aes.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\include\rcheevos.h">
@@ -396,5 +397,6 @@
     <ClInclude Include="..\src\rc_client_external.h">
       <Filter>src</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\rhash\aes.h" />
   </ItemGroup>
 </Project>

--- a/test/test.c
+++ b/test/test.c
@@ -108,7 +108,6 @@ int main(void) {
   test_runtime_progress();
 
   test_consoleinfo();
-  test_rc_libretro();
   test_rc_validate();
 
   test_lua();
@@ -129,8 +128,12 @@ int main(void) {
   test_client_raintegration();
 #endif
 
+#ifdef RC_CLIENT_SUPPORTS_HASH
+  /* no direct compile option for hash suport, so leverage RC_CLIENT_SUPPORTS_HASH */
+  test_rc_libretro(); /* libretro extensions require hash support */
   test_cdreader();
   test_hash();
+#endif
 #endif
 
   TEST_FRAMEWORK_SHUTDOWN();

--- a/test/test.c
+++ b/test/test.c
@@ -129,7 +129,7 @@ int main(void) {
 #endif
 
 #ifdef RC_CLIENT_SUPPORTS_HASH
-  /* no direct compile option for hash suport, so leverage RC_CLIENT_SUPPORTS_HASH */
+  /* no direct compile option for hash support, so leverage RC_CLIENT_SUPPORTS_HASH */
   test_rc_libretro(); /* libretro extensions require hash support */
   test_cdreader();
   test_hash();

--- a/test/test_rc_client.c
+++ b/test/test_rc_client.c
@@ -1,15 +1,18 @@
 #include "rc_client.h"
 
 #include "rc_consoles.h"
-#include "rc_hash.h"
 #include "rc_internal.h"
 #include "rc_api_runtime.h"
 
 #include "../src/rc_client_internal.h"
 #include "../src/rc_version.h"
 
-#include "rhash/data.h"
 #include "test_framework.h"
+
+#ifdef RC_CLIENT_SUPPORTS_HASH
+#include "rc_hash.h"
+#include "rhash/data.h"
+#endif
 
 #if defined(_WIN32)
 #include <Windows.h>
@@ -2008,6 +2011,8 @@ static void test_unload_game_while_starting_session(void)
   rc_client_destroy(g_client);
 }
 
+#ifdef RC_CLIENT_SUPPORTS_HASH
+
 /* ----- identify and load game ----- */
 
 static void rc_client_callback_expect_data_or_file_path_required(int result, const char* error_message, rc_client_t* client, void* callback_data)
@@ -2943,6 +2948,8 @@ static void test_change_media_client_error(void)
   rc_client_destroy(g_client);
   free(image);
 }
+
+#endif
 
 /* ----- get game image ----- */
 
@@ -8798,6 +8805,7 @@ void test_client(void) {
   TEST(test_unload_game_while_fetching_game_data);
   TEST(test_unload_game_while_starting_session);
 
+#ifdef RC_CLIENT_SUPPORTS_HASH
   /* identify and load game */
   TEST(test_identify_and_load_game_required_fields);
   TEST(test_identify_and_load_game_console_specified);
@@ -8825,6 +8833,7 @@ void test_client(void) {
   TEST(test_change_media_while_loading_later);
   TEST(test_change_media_async_aborted);
   TEST(test_change_media_client_error);
+#endif
 
   /* game */
   TEST(test_game_get_image_url);

--- a/test/test_rc_client_external.c
+++ b/test/test_rc_client_external.c
@@ -463,6 +463,8 @@ static const rc_client_game_t* rc_client_external_get_game_info(void)
   return (const rc_client_game_t*)game;
 }
 
+#ifdef RC_CLIENT_SUPPORTS_HASH
+
 static void assert_identify_and_load_game(rc_client_t* client,
     uint32_t console_id, const char* file_path, const uint8_t* data, size_t data_size)
 {
@@ -515,6 +517,8 @@ static void test_identify_and_load_game(void)
   rc_client_destroy(g_client);
   free(image);
 }
+
+#endif /* RC_CLIENT_SUPPORTS_HASH */
 
 static void assert_load_game(rc_client_t* client, const char* hash)
 {
@@ -589,6 +593,8 @@ static void test_get_user_game_summary(void)
   rc_client_destroy(g_client);
 }
 
+#ifdef RC_CLIENT_SUPPORTS_HASH
+
 static void assert_change_media(rc_client_t* client, const char* file_path, const uint8_t* data, size_t data_size)
 {
   ASSERT_PTR_EQUALS(client, g_client);
@@ -623,6 +629,8 @@ static void test_change_media(void)
   rc_client_destroy(g_client);
   free(image);
 }
+
+#endif
 
 typedef struct v1_rc_client_subset_t {
   uint32_t id;
@@ -1213,10 +1221,14 @@ void test_client_external(void) {
   TEST(test_logout);
 
   /* load game */
+#ifdef RC_CLIENT_SUPPORTS_HASH
   TEST(test_identify_and_load_game);
+#endif
   TEST(test_load_game);
   TEST(test_get_user_game_summary);
+#ifdef RC_CLIENT_SUPPORTS_HASH
   TEST(test_change_media);
+#endif
   TEST(test_load_subset);
 
   TEST(test_unload_game);

--- a/test/test_rc_client_external.c
+++ b/test/test_rc_client_external.c
@@ -632,6 +632,35 @@ static void test_change_media(void)
 
 #endif
 
+static void assert_change_media_from_hash(rc_client_t* client, const char* hash)
+{
+  ASSERT_PTR_EQUALS(client, g_client);
+  ASSERT_STR_EQUALS(hash, "6a2305a2b6675a97ff792709be1ca857");
+}
+
+static rc_client_async_handle_t* rc_client_external_begin_change_media_from_hash(rc_client_t* client, const char* hash,
+    rc_client_callback_t callback, void* callback_userdata)
+{
+  assert_change_media_from_hash(client, hash);
+
+  g_external_event = "change_media_from_hash";
+
+  callback(RC_OK, NULL, client, callback_userdata);
+  return NULL;
+}
+
+static void test_change_media_from_hash(void)
+{
+  g_client = mock_client_with_external();
+  g_client->state.external_client->begin_change_media_from_hash = rc_client_external_begin_change_media_from_hash;
+
+  rc_client_begin_change_media_from_hash(g_client, "6a2305a2b6675a97ff792709be1ca857", rc_client_callback_expect_success, g_callback_userdata);
+
+  ASSERT_STR_EQUALS(g_external_event, "change_media_from_hash");
+
+  rc_client_destroy(g_client);
+}
+
 typedef struct v1_rc_client_subset_t {
   uint32_t id;
   const char* title;
@@ -1229,6 +1258,7 @@ void test_client_external(void) {
 #ifdef RC_CLIENT_SUPPORTS_HASH
   TEST(test_change_media);
 #endif
+  TEST(test_change_media_from_hash);
   TEST(test_load_subset);
 
   TEST(test_unload_game);


### PR DESCRIPTION
Without defining it, `rc_client` can be built without needing to pull in the `rhash` subfolder (except md5.c). `rhash` can still be used directly without defining it.

Existing clients requiring the functionality (via `rc_client_begin_identify_and_load_game`) must add `RC_CLIENT_SUPPORTS_HASH` to their build process.