### PR TITLE
Ignore directory records when hashing ZIP

### DIFF
--- a/src/rhash/hash.c
+++ b/src/rhash/hash.c
@@ -834,11 +834,17 @@ static int rc_hash_zip_file(md5_state_t* md5, void* file_handle)
     uint32_t filename_len  = RC_ZIP_READ_LE16(cdir + 0x1C);
     int32_t  extra_len     = RC_ZIP_READ_LE16(cdir + 0x1E);
     int32_t  comment_len   = RC_ZIP_READ_LE16(cdir + 0x20);
+    int32_t  external_attr = RC_ZIP_READ_LE16(cdir + 0x26);
     uint64_t local_hdr_ofs = RC_ZIP_READ_LE32(cdir + 0x2A);
     cdir_entry_len = cdirhdr_size + filename_len + extra_len + comment_len;
 
     if (signature != 0x02014b50) /* expected central directory entry signature */
       break;
+
+    /* Ignore records describing a directory (we only hash file records) */
+    name = (cdir + cdirhdr_size);
+    if (name[filename_len - 1] == '/' || name[filename_len - 1] == '\\' || (external_attr & 0x10))
+        continue;
 
     /* Handle Zip64 fields */
     if (decomp_size == 0xFFFFFFFF || comp_size == 0xFFFFFFFF || local_hdr_ofs == 0xFFFFFFFF)
@@ -893,7 +899,7 @@ static int rc_hash_zip_file(md5_state_t* md5, void* file_handle)
     hashindex++;
 
     /* Convert and store the file name in the hash data buffer */
-    for (name = (cdir + cdirhdr_size), name_end = name + filename_len; name != name_end; name++)
+    for (name_end = name + filename_len; name != name_end; name++)
     {
       *(hashdata++) =
         (*name == '\\' ? '/' : /* convert back-slashes to regular slashes */

--- a/test/rhash/test_hash.c
+++ b/test/rhash/test_hash.c
@@ -891,7 +891,7 @@ static void test_hash_msdos_dosz()
   size_t image_size;
   uint8_t* image = generate_zip_file(&image_size);
   char hash_file[33], hash_iterator[33];
-  const char* expected_md5 = "4cef392530883f23ccebf413f1898023";
+  const char* expected_md5 = "59a255662262f5ada32791b8c36e8ea7";
 
   mock_file(0, "game.dosz", image, image_size);
 
@@ -940,7 +940,7 @@ static void test_hash_msdos_dosz_with_dosc()
   size_t image_size;
   uint8_t* image = generate_zip_file(&image_size);
   char hash_dosc[33];
-  const char* expected_dosc_md5 = "b22fae2e4e4c17b9c9c4b094b86aeb1e";
+  const char* expected_dosc_md5 = "dd0c0b0c170c30722784e5e962764c35";
 
   /* Add main dosz file and overlay dosc file which will get hashed together */
   mock_file(0, "game.dosz", image, image_size);


### PR DESCRIPTION
Because ZIP tools are free to leave out records of non-empty directories we need to ignore them because otherwise ZIP files with equal content might hash different depending on the used ZIP tool.

Improvement for #304