### PR TITLE
prevent warning comparing floats to integer constants

### DIFF
--- a/src/rcheevos/rc_validate.c
+++ b/src/rcheevos/rc_validate.c
@@ -346,6 +346,7 @@ int rc_validate_condset_internal(const rc_condset_t* condset, char result[], con
       const rc_operand_t* operand1 = &cond->operand1;
       const rc_operand_t* operand2 = &cond->operand2;
       uint8_t oper = cond->oper;
+      uint32_t min_val;
 
       if (!is_memref1 && !add_source_max) {
         /* pretend constant was on right side */
@@ -360,7 +361,6 @@ int rc_validate_condset_internal(const rc_condset_t* condset, char result[], con
         }
       }
 
-      uint32_t min_val;
       switch (operand2->type) {
         case RC_OPERAND_CONST:
           min_val = operand2->value.num;

--- a/src/rcheevos/rc_validate.c
+++ b/src/rcheevos/rc_validate.c
@@ -337,48 +337,67 @@ int rc_validate_condset_internal(const rc_condset_t* condset, char result[], con
       return 0;
     }
 
-    /* if either side is a memref, or there's a running add source chain, check for impossible comparisons */
-    if (is_memref1 || is_memref2 || add_source_max) {
+    if (is_memref1 && rc_operand_is_float(&cond->operand1)) {
+      /* if left side is a float, right side will be converted to a float, so don't do range validation */
+    }
+    else if (is_memref1 || is_memref2 || add_source_max) {
+      /* if either side is a memref, or there's a running add source chain, check for impossible comparisons */
       const size_t prefix_length = snprintf(result, result_size, "Condition %d: ", index);
+      const rc_operand_t* operand1 = &cond->operand1;
+      const rc_operand_t* operand2 = &cond->operand2;
+      uint8_t oper = cond->oper;
+
+      if (!is_memref1 && !add_source_max) {
+        /* pretend constant was on right side */
+        operand1 = &cond->operand2;
+        operand2 = &cond->operand1;
+        max = max_val;
+        switch (oper) {
+          case RC_OPERATOR_LT: oper = RC_OPERATOR_GT; break;
+          case RC_OPERATOR_LE: oper = RC_OPERATOR_GE; break;
+          case RC_OPERATOR_GT: oper = RC_OPERATOR_LT; break;
+          case RC_OPERATOR_GE: oper = RC_OPERATOR_LE; break;
+        }
+      }
 
       uint32_t min_val;
-      switch (cond->operand2.type) {
+      switch (operand2->type) {
         case RC_OPERAND_CONST:
-          min_val = cond->operand2.value.num;
+          min_val = operand2->value.num;
           break;
 
         case RC_OPERAND_FP:
-          min_val = (int)cond->operand2.value.dbl;
+          min_val = (int)operand2->value.dbl;
 
           /* cannot compare an integer memory reference to a non-integral floating point value */
-          /* assert: is_memref1 (because operand2==FP means !is_memref2) */
-          if (!add_source_max && !rc_operand_is_float_memref(&cond->operand1) &&
-              (float)min_val != cond->operand2.value.dbl) {
-            snprintf(result + prefix_length, result_size - prefix_length, "Comparison is never true");
-            return 0;
+          if (!add_source_max && !rc_operand_is_float_memref(operand1) &&
+              (float)min_val != operand2->value.dbl) {
+            switch (oper) {
+              case RC_OPERATOR_EQ:
+                snprintf(result + prefix_length, result_size - prefix_length, "Comparison is never true");
+                return 0;
+              case RC_OPERATOR_NE:
+                snprintf(result + prefix_length, result_size - prefix_length, "Comparison is always true");
+                return 0;
+              case RC_OPERATOR_GT: /* value could be greater than floor(float) */
+              case RC_OPERATOR_LE: /* value could be less than or equal to floor(float) */
+                break;
+              case RC_OPERATOR_GE: /* value could be greater than or equal to ceil(float) */
+              case RC_OPERATOR_LT: /* value could be less than ceil(float) */
+                ++min_val;
+                break;
+            }
           }
 
           break;
 
-        default:
+        default: /* right side is memref or add source chain */
           min_val = 0;
-
-          /* cannot compare an integer memory reference to a non-integral floating point value */
-          /* assert: is_memref2 (because operand1==FP means !is_memref1) */
-          if (cond->operand1.type == RC_OPERAND_FP && !add_source_max && !rc_operand_is_float_memref(&cond->operand2) &&
-              (float)((int)cond->operand1.value.dbl) != cond->operand1.value.dbl) {
-            snprintf(result + prefix_length, result_size - prefix_length, "Comparison is never true");
-            return 0;
-          }
-
           break;
       }
 
-      if (rc_operand_is_float(&cond->operand2) && rc_operand_is_float(&cond->operand1)) {
-        /* both sides are floats, don't validate range*/
-      } else if (!rc_validate_range(min_val, max_val, cond->oper, max, result + prefix_length, result_size - prefix_length)) {
+      if (!rc_validate_range(min_val, max_val, oper, max, result + prefix_length, result_size - prefix_length))
         return 0;
-      }
     }
 
     add_source_max = 0;
@@ -801,8 +820,7 @@ static int rc_validate_trigger_internal(const rc_trigger_t* trigger, char result
   const rc_condset_t* alt;
   int index;
 
-  if (!trigger->alternative)
-  {
+  if (!trigger->alternative) {
     if (!rc_validate_condset_internal(trigger->requirement, result, result_size, console_id, max_address))
       return 0;
 

--- a/src/rcheevos/value.c
+++ b/src/rcheevos/value.c
@@ -683,9 +683,14 @@ static int rc_typed_value_compare_floats(float f1, float f2, char oper) {
 }
 
 int rc_typed_value_compare(const rc_typed_value_t* value1, const rc_typed_value_t* value2, char oper) {
-  rc_typed_value_t converted_value2;
-  if (value2->type != value1->type)
-    value2 = rc_typed_value_convert_into(&converted_value2, value2, value1->type);
+  rc_typed_value_t converted_value;
+  if (value2->type != value1->type) {
+    /* if either side is a float, convert both sides to float. otherwise, assume the signed-ness of the left side. */
+    if (value2->type == RC_VALUE_TYPE_FLOAT)
+      value1 = rc_typed_value_convert_into(&converted_value, value1, value2->type);
+    else
+      value2 = rc_typed_value_convert_into(&converted_value, value2, value1->type);
+  }
 
   switch (value1->type) {
     case RC_VALUE_TYPE_UNSIGNED:

--- a/test/rcheevos/test_condset.c
+++ b/test/rcheevos/test_condset.c
@@ -2207,6 +2207,20 @@ static void test_addsource_float_first() {
   /* float(4) + float(4) + float(4) + 1 == 5.5 */
   assert_parse_condset(&condset, &memrefs, buffer, "A:fF0004_A:fF0004_A:fF0004_1=f5.5");
 
+  /* +1 (int) will convert the intermediate value to an integer
+   *    (1.5 + 1.5 + 1.5) => 4.5 => 4 + 1 = 5
+   * which will not equal 5.5, so logic will fail. */
+
+  /* sum is not correct */
+  assert_evaluate_condset(condset, memrefs, &memory, 0);
+
+  /* float(4) + float(4) + float(4) + 1.0 == 5.5 */
+  assert_parse_condset(&condset, &memrefs, buffer, "A:fF0004_A:fF0004_A:fF0004_f1.0=f5.5");
+
+  /* +1.0 (float) will not convert the intermediate value to an integer
+   *    (1.5 + 1.5 + 1.5) => 4.5 + 1.0 = 5.5
+   * which will equal 5.5, so logic will succeed. */
+
   /* sum is correct */
   assert_evaluate_condset(condset, memrefs, &memory, 1);
 }

--- a/test/rcheevos/test_rc_validate.c
+++ b/test/rcheevos/test_rc_validate.c
@@ -267,11 +267,11 @@ void test_float_comparisons() {
   TEST_PARAMS2(test_validate_trigger, "fF1234=2", "");
   TEST_PARAMS2(test_validate_trigger, "0xX1234=2", "");
   TEST_PARAMS2(test_validate_trigger, "0xX1234=f2.3", "Condition 1: Comparison is never true"); /* non integral comparison */
-  TEST_PARAMS2(test_validate_trigger, "0xX1234!=f2.3", "Condition 1: Comparison is never true"); /* non integral comparison */
-  TEST_PARAMS2(test_validate_trigger, "0xX1234<f2.3", "Condition 1: Comparison is never true"); /* non integral comparison */
-  TEST_PARAMS2(test_validate_trigger, "0xX1234<=f2.3", "Condition 1: Comparison is never true"); /* non integral comparison */
-  TEST_PARAMS2(test_validate_trigger, "0xX1234>f2.3", "Condition 1: Comparison is never true"); /* non integral comparison */
-  TEST_PARAMS2(test_validate_trigger, "0xX1234>=f2.3", "Condition 1: Comparison is never true"); /* non integral comparison */
+  TEST_PARAMS2(test_validate_trigger, "0xX1234!=f2.3", "Condition 1: Comparison is always true"); /* non integral comparison */
+  TEST_PARAMS2(test_validate_trigger, "0xX1234<f2.3", ""); /* will be converted to < 3 */
+  TEST_PARAMS2(test_validate_trigger, "0xX1234<=f2.3", ""); /* will be converted to <= 2 */
+  TEST_PARAMS2(test_validate_trigger, "0xX1234>f2.3", ""); /* will be converted to > 2 */
+  TEST_PARAMS2(test_validate_trigger, "0xX1234>=f2.3", ""); /* will be converted to >= 3 */
   TEST_PARAMS2(test_validate_trigger, "0xX1234=f2.0", ""); /* float can be converted to int without loss of data*/
   TEST_PARAMS2(test_validate_trigger, "0xH1234=f2.3", "Condition 1: Comparison is never true");
   TEST_PARAMS2(test_validate_trigger, "0xH1234=f300.0", "Condition 1: Comparison is never true"); /* value out of range */
@@ -285,6 +285,16 @@ void test_float_comparisons() {
   TEST_PARAMS2(test_validate_trigger, "fM1234>f-2.3", "");
   TEST_PARAMS2(test_validate_trigger, "I:0xX2345_fM1234>f1.0", "");
   TEST_PARAMS2(test_validate_trigger, "I:0xX2345_fM1234>f-1.0", "");
+  TEST_PARAMS2(test_validate_trigger, "fF1234>=f0.0", ""); /* explicit float comparison can be negative */
+  TEST_PARAMS2(test_validate_trigger, "fM1234>=f0.0", "");
+  TEST_PARAMS2(test_validate_trigger, "fB1234>=f0.0", "");
+  TEST_PARAMS2(test_validate_trigger, "fF1234>=0", ""); /* implicit float comparison can be negative */
+  TEST_PARAMS2(test_validate_trigger, "fM1234>=0", "");
+  TEST_PARAMS2(test_validate_trigger, "fB1234>=0", "");
+  TEST_PARAMS2(test_validate_trigger, "0xH1234>=f0.1", ""); /* 0 can be less than 0.1 */
+  TEST_PARAMS2(test_validate_trigger, "0xH1234>=f255.1", "Condition 1: Comparison is never true"); /* 255 cannot be >= 255.1 */
+  TEST_PARAMS2(test_validate_trigger, "f0.1<=0xH1234", ""); /* 0 can be less than 0.1 */
+  TEST_PARAMS2(test_validate_trigger, "f255.1<=0xH1234", "Condition 1: Comparison is never true"); /* 255 cannot be >= 255.1 */
 }
 
 void test_conflicting_conditions() {


### PR DESCRIPTION
https://discord.com/channels/310192285306454017/1149693430306447380/1215563178209968139

The logical construct "float(0x1234) >= 0" should not generate a warning indicating it is always true because floats can be negative. This was correctly handled for "float(0x1234) >= 0.0"

I've also modified the warning for things like "byte(0x1234) >= 0.1" so it doesn't return "comparison is always true" as well.