### PR TITLE
Fix warning about hiding previous declaration in rc_client.c

### DIFF
--- a/src/rc_client.c
+++ b/src/rc_client.c
@@ -1947,13 +1947,13 @@ static void rc_client_fetch_game_data_callback(const rc_api_server_response_t* s
       if (!subset->public_.title) {
         const char* core_subset_title = rc_client_subset_extract_title(load_state->game, load_state->game->public_.title);
         if (core_subset_title) {
-           rc_client_subset_info_t* scan = load_state->game->subsets;
-           for (; scan; scan = scan->next) {
-              if (scan->public_.title == load_state->game->public_.title) {
-                 scan->public_.title = core_subset_title;
-                 break;
-              }
-           }
+          scan = load_state->game->subsets;
+          for (; scan; scan = scan->next) {
+            if (scan->public_.title == load_state->game->public_.title) {
+              scan->public_.title = core_subset_title;
+              break;
+            }
+          }
         }
 
         subset->public_.title = rc_buffer_strcpy(&load_state->game->buffer, fetch_game_data_response.title);

--- a/test/Makefile
+++ b/test/Makefile
@@ -110,7 +110,7 @@ endif
 # more strict validation for source files to eliminate warnings/errors in upstream consumers
 # -Wextra includes -Wsign-compare -Wtype-limits -Wimplicit-fallthrough=3 -Wunused-parameter and more
 # -pedantic issues errors when using GNU extensions or other things that are not strictly ISO C
-SRC_CFLAGS=-Wextra -pedantic
+SRC_CFLAGS=-Wextra -Wshadow -pedantic
 # 3DS build (retroarch) doesn't support signed char
 SRC_CFLAGS += -fno-signed-char
 


### PR DESCRIPTION
Ran into this while building Dolphin. There's already a `scan` a few scopes up.

This block was also indented inconsistently for some reason, I've made it consistent with its surroundings.