### PR TITLE
Fixes for Access Violations with Recall Operand

### DIFF
--- a/src/rcheevos/rc_validate.c
+++ b/src/rcheevos/rc_validate.c
@@ -708,6 +708,8 @@ static int rc_validate_are_operands_equal(const rc_operand_t* oper1, const rc_op
     return (oper1->value.num == oper2->value.num);
   case RC_OPERAND_FP:
     return (oper1->value.dbl == oper2->value.dbl);
+  case RC_OPERAND_RECALL:
+    return (oper2->type == RC_OPERAND_RECALL);
   default:
     return (oper1->value.memref->address == oper2->value.memref->address && oper1->size == oper2->size);
   }

--- a/src/rcheevos/runtime_progress.c
+++ b/src/rcheevos/runtime_progress.c
@@ -210,6 +210,7 @@ static int rc_runtime_progress_is_indirect_memref(rc_operand_t* oper)
   {
     case RC_OPERAND_CONST:
     case RC_OPERAND_FP:
+    case RC_OPERAND_RECALL:
     case RC_OPERAND_LUA:
       return 0;
 


### PR DESCRIPTION
Adds fixes for two cases where Recall was treated as a memref. Resulting code accessing memref data could try to access memory it was not supposed to, leading to access violation exceptions.