### PR TITLE
Add Gamecube to hash initialize iterator for iso format

### DIFF
--- a/src/rhash/hash.c
+++ b/src/rhash/hash.c
@@ -3736,6 +3736,7 @@ void rc_hash_initialize_iterator(struct rc_hash_iterator* iterator, const char* 
           iterator->consoles[1] = RC_CONSOLE_PSP;
           iterator->consoles[2] = RC_CONSOLE_3DO;
           iterator->consoles[3] = RC_CONSOLE_SEGA_CD; /* ASSERT: handles both Sega CD and Saturn */
+          iterator->consoles[4] = RC_CONSOLE_GAMECUBE;
           need_path = 1;
         }
         break;

--- a/test/rhash/test_hash.c
+++ b/test/rhash/test_hash.c
@@ -874,13 +874,32 @@ static void test_hash_gamecube()
 {
   size_t image_size;
   uint8_t* image = generate_gamecube_iso(32, &image_size);
+  char hash_file[33], hash_iterator[33];
+  const char* expected_md5 = "c7803b704fa43d22d8f6e55f4789cb45";
+
   mock_file(0, "test.iso", image, image_size);
-  char hash[33];
-  int result = rc_hash_generate_from_file(hash, RC_CONSOLE_GAMECUBE, "test.iso");
+
+  /* test file hash */
+  int result_file = rc_hash_generate_from_file(hash_file, RC_CONSOLE_GAMECUBE, "test.iso");
+
+  /* test file identification from iterator */
+  int result_iterator;
+  struct rc_hash_iterator iterator;
+
+  rc_hash_initialize_iterator(&iterator, "test.iso", NULL, 0);
+  result_iterator = rc_hash_iterate(hash_iterator, &iterator);
+  rc_hash_destroy_iterator(&iterator);
+
+  /* cleanup */
   free(image);
 
-  ASSERT_NUM_EQUALS(result, 1);
-  ASSERT_STR_EQUALS(hash, "c7803b704fa43d22d8f6e55f4789cb45");
+  /* validation */
+  ASSERT_NUM_EQUALS(result_file, 1);
+  ASSERT_STR_EQUALS(hash_file, expected_md5);
+
+  ASSERT_NUM_EQUALS(result_iterator, 1);
+  ASSERT_STR_EQUALS(hash_iterator, expected_md5);
+
   ASSERT_NUM_EQUALS(image_size, 32 * 1024 * 1024);
 }
 


### PR DESCRIPTION
Just to add Gamecube now for 'iso' format in hash initialization for iterator. Thanks in advance for this merge. Tested in pixL (new retro OS ;-)