### PR TITLE
fix infinite loop if reset occurs just prior to a ping while progress indicator is on screen

### DIFF
--- a/src/rc_client.c
+++ b/src/rc_client.c
@@ -3570,8 +3570,10 @@ static void rc_client_award_achievement(rc_client_t* client, rc_client_achieveme
   callback_data->client = client;
   callback_data->id = achievement->public_.id;
   callback_data->hardcore = client->state.hardcore;
-  callback_data->game_hash = client->game->public_.hash;
   callback_data->unlock_time = achievement->public_.unlock_time;
+
+  if (client->game) /* may be NULL if this gets called while unloading the game (from another thread - events are raised outside the lock) */
+    callback_data->game_hash = client->game->public_.hash;
 
   RC_CLIENT_LOG_INFO_FORMATTED(client, "Awarding achievement %u: %s", achievement->public_.id, achievement->public_.title);
   rc_client_award_achievement_server_call(callback_data);


### PR DESCRIPTION
When calling `rc_client_reset` with a progress indicator on screen, the progress indicator is immediately hidden and the scheduled event to hide it is removed from the queue. This is done by changing it's scheduled time to 0. Since the queue is sorted, the scan to remove the item stops as soon as an item is found with a higher scheduled time. As a result, if the event is not the first item in the queue, it's not removed. Instead, it gets reinserted as the first item, pointing at the previous first item, which is still pointing at the chain that is pointing at it. The next time the queue is updated, there's a potential infinite loop as it looks for a place to insert the new item.