### PR TITLE
add rc_client_set_filereader and rc_client_get_default_cdreader

### DIFF
--- a/include/rc_client.h
+++ b/include/rc_client.h
@@ -229,6 +229,20 @@ RC_EXPORT rc_client_async_handle_t* RC_CCONV rc_client_begin_identify_and_load_g
     uint32_t console_id, const char* file_path,
     const uint8_t* data, size_t data_size,
     rc_client_callback_t callback, void* callback_userdata);
+
+struct rc_hash_filereader;
+struct rc_hash_cdreader;
+
+/**
+ * Registers a set of functions for performing custom file I/O.
+ */
+RC_EXPORT void RC_CCONV rc_client_set_filereader(rc_client_t* client,
+    const struct rc_hash_filereader* filereader, const struct rc_hash_cdreader* cdreader);
+
+/**
+ * Gets the default set of functions for performing generic CD access for bin/cue or iso files.
+ */
+RC_EXPORT void RC_CCONV rc_client_get_default_cdreader(rc_client_t* client, struct rc_hash_cdreader* cdreader);
 #endif
 
 /**

--- a/include/rc_hash.h
+++ b/include/rc_hash.h
@@ -123,6 +123,15 @@ RC_BEGIN_C_DECLS
   RC_EXPORT void RC_CCONV rc_hash_init_default_cdreader(void);
   RC_EXPORT void RC_CCONV rc_hash_init_custom_cdreader(struct rc_hash_cdreader* reader);
 
+  /* ===================================================== */
+
+  struct rc_hash_readers {
+    struct rc_hash_filereader filereader;
+    struct rc_hash_cdreader cdreader;
+  };
+
+  /* ===================================================== */
+
   /* specifies a function called to obtain a 3DS CIA decryption normal key.
    * this key would be derived from slot0x3DKeyX and the common key specified by the passed index.
    * the normal key should be written in big endian format

--- a/src/rc_client.c
+++ b/src/rc_client.c
@@ -925,7 +925,9 @@ static void rc_client_free_load_state(rc_client_load_state_t* load_state)
     free(load_state->start_session_response);
   }
 
+#ifdef RC_CLIENT_SUPPORTS_HASH
   rc_hash_destroy_iterator(&load_state->hash_iterator);
+#endif
 
   free(load_state);
 }

--- a/src/rc_client.c
+++ b/src/rc_client.c
@@ -925,6 +925,8 @@ static void rc_client_free_load_state(rc_client_load_state_t* load_state)
     free(load_state->start_session_response);
   }
 
+  rc_hash_destroy_iterator(&load_state->hash_iterator);
+
   free(load_state);
 }
 

--- a/src/rc_client_external.h
+++ b/src/rc_client_external.h
@@ -20,6 +20,14 @@ typedef void (RC_CCONV *rc_client_external_set_string_func_t)(const char* value)
 typedef size_t (RC_CCONV *rc_client_external_copy_string_func_t)(char buffer[], size_t buffer_size);
 typedef void (RC_CCONV *rc_client_external_action_func_t)(void);
 
+#ifdef RC_CLIENT_SUPPORTS_HASH
+typedef void (RC_CCONV* rc_client_external_set_filereader_func_t)(const struct rc_hash_filereader* filereader, const struct rc_hash_cdreader* cdreader);
+typedef void (RC_CCONV* rc_client_external_get_cdreader_func_t)(struct rc_hash_cdreader* cdreader);
+#else
+typedef void (RC_CCONV* rc_client_external_set_filereader_func_t)(void* filereader, void* cdreader);
+typedef void (RC_CCONV* rc_client_external_get_cdreader_func_t)(void* cdreader);
+#endif
+
 typedef void (RC_CCONV *rc_client_external_async_handle_func_t)(rc_client_async_handle_t* handle);
 
 typedef rc_client_async_handle_t* (RC_CCONV *rc_client_external_begin_login_func_t)(rc_client_t* client,
@@ -124,9 +132,13 @@ typedef struct rc_client_external_t
   rc_client_external_serialize_progress_func_t serialize_progress;
   rc_client_external_deserialize_progress_func_t deserialize_progress;
 
+  // VERSION 2
+  rc_client_external_set_filereader_func_t set_filereader;
+  rc_client_external_get_cdreader_func_t get_default_cdreader;
+
 } rc_client_external_t;
 
-#define RC_CLIENT_EXTERNAL_VERSION 1
+#define RC_CLIENT_EXTERNAL_VERSION 2
 
 RC_END_C_DECLS
 

--- a/src/rc_client_internal.h
+++ b/src/rc_client_internal.h
@@ -294,7 +294,9 @@ enum {
 };
 
 struct rc_client_load_state_t;
+#ifdef RC_CLIENT_SUPPORTS_HASH
 struct rc_hash_readers;
+#endif
 
 typedef struct rc_client_state_t {
   rc_mutex_t mutex;

--- a/src/rc_client_internal.h
+++ b/src/rc_client_internal.h
@@ -294,6 +294,7 @@ enum {
 };
 
 struct rc_client_load_state_t;
+struct rc_hash_readers;
 
 typedef struct rc_client_state_t {
   rc_mutex_t mutex;
@@ -306,6 +307,9 @@ typedef struct rc_client_state_t {
 #endif
 #ifdef RC_CLIENT_SUPPORTS_RAINTEGRATION
   rc_client_raintegration_t* raintegration;
+#endif
+#ifdef RC_CLIENT_SUPPORTS_HASH
+  struct rc_hash_readers* hash_readers;
 #endif
 
   uint16_t unpaused_frame_decay;
@@ -371,6 +375,12 @@ int rc_value_contains_memref(const rc_value_t* value, const rc_memref_t* memref)
 #ifdef RC_CLIENT_SUPPORTS_HASH
 struct rc_hash_iterator;
 struct rc_hash_iterator* rc_client_get_load_state_hash_iterator(rc_client_t* client);
+
+void rc_hash_fill_filereader_defaults(struct rc_hash_filereader* reader);
+void rc_hash_fill_cdreader_defaults(struct rc_hash_cdreader* reader);
+void rc_hash_swap_filereader(struct rc_hash_filereader** reader);
+void rc_hash_swap_cdreader(struct rc_hash_cdreader** reader);
+
 #endif
 /* end helper functions for unit tests */
 

--- a/src/rc_client_raintegration.c
+++ b/src/rc_client_raintegration.c
@@ -2,6 +2,10 @@
 
 #include "rc_client_internal.h"
 
+#ifdef RC_CLIENT_SUPPORTS_HASH
+#include "rc_hash.h"
+#endif
+
 #include "rapi/rc_api_common.h"
 
 #ifdef RC_CLIENT_SUPPORTS_RAINTEGRATION
@@ -202,6 +206,10 @@ static void rc_client_init_raintegration(rc_client_t* client,
         external_client->set_encore_mode_enabled(rc_client_get_encore_mode_enabled(client));
       if (external_client->set_spectator_mode_enabled)
         external_client->set_spectator_mode_enabled(rc_client_get_spectator_mode_enabled(client));
+#ifdef RC_CLIENT_SUPPORTS_HASH
+      if (external_client->set_filereader && client->state.hash_readers)
+        external_client->set_filereader(&client->state.hash_readers->filereader, &client->state.hash_readers->cdreader);
+#endif
 
       /* attach the external client and call the callback */
       client->state.external_client = external_client;

--- a/src/rcheevos/runtime.c
+++ b/src/rcheevos/runtime.c
@@ -10,7 +10,7 @@
 #define RC_RICHPRESENCE_DISPLAY_BUFFER_SIZE 256
 
 rc_runtime_t* rc_runtime_alloc(void) {
-  rc_runtime_t* self = malloc(sizeof(rc_runtime_t));
+  rc_runtime_t* self = (rc_runtime_t*)malloc(sizeof(rc_runtime_t));
 
   if (self) {
     rc_runtime_init(self);
@@ -834,7 +834,7 @@ void rc_runtime_invalidate_address(rc_runtime_t* self, uint32_t address) {
   }
 }
 
-void rc_runtime_validate_addresses(rc_runtime_t* self, rc_runtime_event_handler_t event_handler, 
+void rc_runtime_validate_addresses(rc_runtime_t* self, rc_runtime_event_handler_t event_handler,
     rc_runtime_validate_address_t validate_handler) {
   rc_memref_t** last_memref = &self->memrefs;
   rc_memref_t* memref = self->memrefs;

--- a/src/rhash/cdreader.c
+++ b/src/rhash/cdreader.c
@@ -895,9 +895,10 @@ void rc_hash_init_default_cdreader(void)
 
 #ifdef RC_CLIENT_SUPPORTS_EXTERNAL
 #include "rc_client.h"
+#else
+typedef struct rc_client_t rc_client_t;
 #endif
 
-typedef struct rc_client_t rc_client_t;
 void rc_client_get_default_cdreader(rc_client_t* client, struct rc_hash_cdreader* cdreader)
 {
 #ifdef RC_CLIENT_SUPPORTS_EXTERNAL

--- a/src/rhash/cdreader.c
+++ b/src/rhash/cdreader.c
@@ -863,6 +863,21 @@ static uint32_t cdreader_first_track_sector(void* track_handle)
   return 0;
 }
 
+void rc_hash_fill_cdreader_defaults(struct rc_hash_cdreader* reader)
+{
+  if (!reader->open_track)
+    reader->open_track = cdreader_open_track;
+
+  if (!reader->read_sector)
+    reader->read_sector = cdreader_read_sector;
+
+  if (!reader->close_track)
+    reader->close_track = cdreader_close_track;
+  
+  if (!reader->first_track_sector)
+    reader->first_track_sector = cdreader_first_track_sector;
+}
+
 void rc_hash_get_default_cdreader(struct rc_hash_cdreader* cdreader)
 {
   cdreader->open_track = cdreader_open_track;
@@ -876,4 +891,17 @@ void rc_hash_init_default_cdreader(void)
   struct rc_hash_cdreader cdreader;
   rc_hash_get_default_cdreader(&cdreader);
   rc_hash_init_custom_cdreader(&cdreader);
+}
+
+typedef struct rc_client_t rc_client_t;
+void rc_client_get_default_cdreader(rc_client_t* client, struct rc_hash_cdreader* cdreader)
+{
+#ifdef RC_CLIENT_SUPPORTS_EXTERNAL
+  if (client->state.external_client && client->state.external_client->get_default_cdreader) {
+    client->state.external_client->get_default_cdreader(cdreader);
+    return;
+  }
+#endif
+
+  rc_hash_get_default_cdreader(cdreader);
 }

--- a/src/rhash/cdreader.c
+++ b/src/rhash/cdreader.c
@@ -894,7 +894,7 @@ void rc_hash_init_default_cdreader(void)
 }
 
 #ifdef RC_CLIENT_SUPPORTS_EXTERNAL
-#include "rc_client.h"
+#include "../src/rc_client_internal.h"
 #else
 typedef struct rc_client_t rc_client_t;
 #endif

--- a/src/rhash/cdreader.c
+++ b/src/rhash/cdreader.c
@@ -893,6 +893,10 @@ void rc_hash_init_default_cdreader(void)
   rc_hash_init_custom_cdreader(&cdreader);
 }
 
+#ifdef RC_CLIENT_SUPPORTS_EXTERNAL
+#include "rc_client.h"
+#endif
+
 typedef struct rc_client_t rc_client_t;
 void rc_client_get_default_cdreader(rc_client_t* client, struct rc_hash_cdreader* cdreader)
 {
@@ -901,6 +905,8 @@ void rc_client_get_default_cdreader(rc_client_t* client, struct rc_hash_cdreader
     client->state.external_client->get_default_cdreader(cdreader);
     return;
   }
+#else
+  (void*)client;
 #endif
 
   rc_hash_get_default_cdreader(cdreader);

--- a/src/rhash/cdreader.c
+++ b/src/rhash/cdreader.c
@@ -906,7 +906,7 @@ void rc_client_get_default_cdreader(rc_client_t* client, struct rc_hash_cdreader
     return;
   }
 #else
-  (void*)client;
+  (void)client;
 #endif
 
   rc_hash_get_default_cdreader(cdreader);

--- a/src/rhash/hash.c
+++ b/src/rhash/hash.c
@@ -144,32 +144,39 @@ void rc_hash_reset_filereader(void)
   filereader = NULL;
 }
 
+void rc_hash_fill_filereader_defaults(struct rc_hash_filereader* reader)
+{
+  if (!reader->open)
+    reader->open = filereader_open;
+
+  if (!reader->seek)
+    reader->seek = filereader_seek;
+
+  if (!reader->tell)
+    reader->tell = filereader_tell;
+
+  if (!reader->read)
+    reader->read = filereader_read;
+
+  if (!reader->close)
+    reader->close = filereader_close;
+}
+
+void rc_hash_swap_filereader(struct rc_hash_filereader** reader)
+{
+  struct rc_hash_filereader* oldreader = filereader;
+  filereader = *reader;
+  *reader = oldreader;
+}
+
 void rc_hash_init_custom_filereader(struct rc_hash_filereader* reader)
 {
-  /* initialize with defaults first */
-  filereader_funcs.open = filereader_open;
-  filereader_funcs.seek = filereader_seek;
-  filereader_funcs.tell = filereader_tell;
-  filereader_funcs.read = filereader_read;
-  filereader_funcs.close = filereader_close;
+  if (reader)
+    memcpy(&filereader_funcs, reader, sizeof(filereader_funcs));
+  else
+    memset(&filereader_funcs, 0, sizeof(filereader_funcs));
 
-  /* hook up any provided custom handlers */
-  if (reader) {
-    if (reader->open)
-      filereader_funcs.open = reader->open;
-
-    if (reader->seek)
-      filereader_funcs.seek = reader->seek;
-
-    if (reader->tell)
-      filereader_funcs.tell = reader->tell;
-
-    if (reader->read)
-      filereader_funcs.read = reader->read;
-
-    if (reader->close)
-      filereader_funcs.close = reader->close;
-  }
+  rc_hash_fill_filereader_defaults(&filereader_funcs);
 
   filereader = &filereader_funcs;
 }
@@ -234,6 +241,13 @@ void rc_hash_init_custom_cdreader(struct rc_hash_cdreader* reader)
   {
     cdreader = NULL;
   }
+}
+
+void rc_hash_swap_cdreader(struct rc_hash_cdreader** reader)
+{
+  struct rc_hash_cdreader* oldreader = cdreader;
+  cdreader = *reader;
+  *reader = oldreader;
 }
 
 static void* rc_cd_open_track(const char* path, uint32_t track)

--- a/test/rhash/mock_filereader.c
+++ b/test/rhash/mock_filereader.c
@@ -94,18 +94,23 @@ static void reset_mock_files()
   mock_cd_tracks = 0;
 }
 
+void get_mock_filereader(struct rc_hash_filereader* reader)
+{
+  reader->open = _mock_file_open;
+  reader->seek = _mock_file_seek;
+  reader->tell = _mock_file_tell;
+  reader->read = _mock_file_read;
+  reader->close = _mock_file_close;
+
+  reset_mock_files();
+}
+
 void init_mock_filereader()
 {
   struct rc_hash_filereader reader;
-  reader.open = _mock_file_open;
-  reader.seek = _mock_file_seek;
-  reader.tell = _mock_file_tell;
-  reader.read = _mock_file_read;
-  reader.close = _mock_file_close;
+  get_mock_filereader(&reader);
 
   rc_hash_init_custom_filereader(&reader);
-
-  reset_mock_files();
 }
 
 void mock_file(int index, const char* filename, const uint8_t* buffer, size_t buffer_size)

--- a/test/rhash/mock_filereader.h
+++ b/test/rhash/mock_filereader.h
@@ -11,6 +11,9 @@ RC_BEGIN_C_DECLS
 void init_mock_filereader();
 void init_mock_cdreader();
 
+struct rc_hash_filereader;
+void get_mock_filereader(struct rc_hash_filereader* reader);
+
 void rc_hash_reset_filereader();
 
 void mock_file(int index, const char* filename, const uint8_t* buffer, size_t buffer_size);


### PR DESCRIPTION
Allows a client to register a custom filereader/cdreader for calculating hashes when calling `rc_client_begin_identify_and_load_game`.

Replaces direct calls to `rc_hash_init_custom_filereader` and `rc_hash_init_custom_cdreader`. Also supports passing the readers through the external interface to the DLL.

https://discord.com/channels/476211979464343552/757767535293890682/1265528322943881306