### PR TITLE
perform rc_client hash resolution locally, then pass hash to external interface

### DIFF
--- a/src/rc_client.c
+++ b/src/rc_client.c
@@ -2789,8 +2789,6 @@ static rc_client_async_handle_t* rc_client_begin_change_media_internal(rc_client
   return rc_client_async_handle_valid(client, async_handle) ? async_handle : NULL;
 }
 
-#ifdef RC_CLIENT_SUPPORTS_HASH
-
 static rc_client_game_info_t* rc_client_check_pending_media(rc_client_t* client, const rc_client_pending_media_t* media)
 {
   rc_client_game_info_t* game;
@@ -2816,6 +2814,7 @@ static rc_client_game_info_t* rc_client_check_pending_media(rc_client_t* client,
       if (media->hash)
         pending_media->hash = strdup(media->hash);
 
+#ifdef RC_CLIENT_SUPPORTS_HASH
       if (media->file_path)
         pending_media->file_path = strdup(media->file_path);
 
@@ -2830,6 +2829,7 @@ static rc_client_game_info_t* rc_client_check_pending_media(rc_client_t* client,
       } else {
         pending_media->data = NULL;
       }
+#endif
 
       client->state.load->pending_media = pending_media;
     }
@@ -2850,6 +2850,8 @@ static rc_client_game_info_t* rc_client_check_pending_media(rc_client_t* client,
 
   return game;
 }
+
+#ifdef RC_CLIENT_SUPPORTS_HASH
 
 rc_client_async_handle_t* rc_client_begin_change_media(rc_client_t* client, const char* file_path,
     const uint8_t* data, size_t data_size, rc_client_callback_t callback, void* callback_userdata)

--- a/src/rc_client_external.h
+++ b/src/rc_client_external.h
@@ -38,6 +38,8 @@ typedef const rc_client_subset_t* (RC_CCONV *rc_client_external_get_subset_info_
 typedef void (RC_CCONV *rc_client_external_get_user_game_summary_func_t)(rc_client_user_game_summary_t* summary);
 typedef rc_client_async_handle_t* (RC_CCONV *rc_client_external_begin_change_media_func_t)(rc_client_t* client, const char* file_path,
   const uint8_t* data, size_t data_size, rc_client_callback_t callback, void* callback_userdata);
+typedef void (RC_CCONV* rc_client_external_load_game_handoff_func_t)(uint32_t game_id,
+  const char* hash, rc_client_async_handle_t* async_handle, rc_client_callback_t callback, void* callback_userdata);
 
 /* NOTE: rc_client_external_create_achievement_list_func_t returns an internal wrapper structure which contains the public list
  * and a destructor function. */
@@ -124,9 +126,14 @@ typedef struct rc_client_external_t
   rc_client_external_serialize_progress_func_t serialize_progress;
   rc_client_external_deserialize_progress_func_t deserialize_progress;
 
+  rc_client_external_load_game_handoff_func_t load_game_handoff;
+
 } rc_client_external_t;
 
-#define RC_CLIENT_EXTERNAL_VERSION 1
+#define RC_CLIENT_EXTERNAL_VERSION 2
+
+void rc_client_resume_load_game_handoff(rc_client_t* client, uint32_t game_id, const char* hash,
+  rc_client_async_handle_t* async_handle, rc_client_callback_t callback, void* callback_userdata);
 
 RC_END_C_DECLS
 

--- a/src/rc_client_external.h
+++ b/src/rc_client_external.h
@@ -38,8 +38,7 @@ typedef const rc_client_subset_t* (RC_CCONV *rc_client_external_get_subset_info_
 typedef void (RC_CCONV *rc_client_external_get_user_game_summary_func_t)(rc_client_user_game_summary_t* summary);
 typedef rc_client_async_handle_t* (RC_CCONV *rc_client_external_begin_change_media_func_t)(rc_client_t* client, const char* file_path,
   const uint8_t* data, size_t data_size, rc_client_callback_t callback, void* callback_userdata);
-typedef void (RC_CCONV* rc_client_external_load_game_handoff_func_t)(uint32_t game_id,
-  const char* hash, rc_client_callback_t callback, void* callback_userdata);
+typedef void (RC_CCONV* rc_client_external_add_game_hash_func_t)(const char* hash, uint32_t game_id);
 
 /* NOTE: rc_client_external_create_achievement_list_func_t returns an internal wrapper structure which contains the public list
  * and a destructor function. */
@@ -126,14 +125,16 @@ typedef struct rc_client_external_t
   rc_client_external_serialize_progress_func_t serialize_progress;
   rc_client_external_deserialize_progress_func_t deserialize_progress;
 
-  rc_client_external_load_game_handoff_func_t load_game_handoff;
+  /* VERSION 2 */
+  rc_client_external_add_game_hash_func_t add_game_hash;
+  rc_client_external_set_string_func_t load_unknown_game;
 
 } rc_client_external_t;
 
 #define RC_CLIENT_EXTERNAL_VERSION 2
 
-void rc_client_resume_load_game_handoff(rc_client_t* client, uint32_t game_id, const char* hash,
-  rc_client_callback_t callback, void* callback_userdata);
+void rc_client_add_game_hash(rc_client_t* client, const char* hash, uint32_t game_id);
+void rc_client_load_unknown_game(rc_client_t* client, const char* hash);
 
 RC_END_C_DECLS
 

--- a/src/rc_client_external.h
+++ b/src/rc_client_external.h
@@ -39,7 +39,7 @@ typedef void (RC_CCONV *rc_client_external_get_user_game_summary_func_t)(rc_clie
 typedef rc_client_async_handle_t* (RC_CCONV *rc_client_external_begin_change_media_func_t)(rc_client_t* client, const char* file_path,
   const uint8_t* data, size_t data_size, rc_client_callback_t callback, void* callback_userdata);
 typedef void (RC_CCONV* rc_client_external_load_game_handoff_func_t)(uint32_t game_id,
-  const char* hash, rc_client_async_handle_t* async_handle, rc_client_callback_t callback, void* callback_userdata);
+  const char* hash, rc_client_callback_t callback, void* callback_userdata);
 
 /* NOTE: rc_client_external_create_achievement_list_func_t returns an internal wrapper structure which contains the public list
  * and a destructor function. */
@@ -133,7 +133,7 @@ typedef struct rc_client_external_t
 #define RC_CLIENT_EXTERNAL_VERSION 2
 
 void rc_client_resume_load_game_handoff(rc_client_t* client, uint32_t game_id, const char* hash,
-  rc_client_async_handle_t* async_handle, rc_client_callback_t callback, void* callback_userdata);
+  rc_client_callback_t callback, void* callback_userdata);
 
 RC_END_C_DECLS
 

--- a/test/test_rc_client.c
+++ b/test/test_rc_client.c
@@ -1929,6 +1929,60 @@ static void test_load_game_destroy_while_fetching_game_data(void)
   async_api_response("r=patch&u=Username&t=ApiToken&g=1234", patchdata_2ach_1lbd);
 }
 
+static void test_load_unknown_game(void)
+{
+  const char* hash = "0123456789ABCDEFFEDCBA9876543210";
+  g_client = mock_client_logged_in();
+
+  rc_client_load_unknown_game(g_client, hash);
+
+  ASSERT_NUM_EQUALS(rc_client_get_load_game_state(g_client), RC_CLIENT_LOAD_GAME_STATE_DONE);
+  ASSERT_NUM_EQUALS(rc_client_is_game_loaded(g_client), 0);
+
+  ASSERT_PTR_NOT_NULL(g_client->game);
+  ASSERT_PTR_EQUALS(rc_client_get_game_info(g_client), &g_client->game->public_);
+
+  ASSERT_NUM_EQUALS(g_client->game->public_.id, 0);
+  ASSERT_NUM_EQUALS(g_client->game->public_.console_id, RC_CONSOLE_UNKNOWN);
+  ASSERT_STR_EQUALS(g_client->game->public_.title, "Unknown Game");
+  ASSERT_STR_EQUALS(g_client->game->public_.hash, hash);
+  ASSERT_STR_EQUALS(g_client->game->public_.badge_name, "");
+  ASSERT_NUM_EQUALS(g_client->game->subsets->public_.num_achievements, 0);
+  ASSERT_NUM_EQUALS(g_client->game->subsets->public_.num_leaderboards, 0);
+  ASSERT_NUM_EQUALS(g_client->game->subsets->public_.id, 0);
+  ASSERT_STR_EQUALS(g_client->game->subsets->public_.title, "");
+  ASSERT_NUM_EQUALS(g_client->game->subsets->active, 0);
+
+  rc_client_destroy(g_client);
+}
+
+static void test_load_unknown_game_multihash(void)
+{
+  const char* hash = "0123456789ABCDEFFEDCBA9876543210,FEDCBA98765432100123456789ABCDEF";
+  g_client = mock_client_logged_in();
+
+  rc_client_load_unknown_game(g_client, hash);
+
+  ASSERT_NUM_EQUALS(rc_client_get_load_game_state(g_client), RC_CLIENT_LOAD_GAME_STATE_DONE);
+  ASSERT_NUM_EQUALS(rc_client_is_game_loaded(g_client), 0);
+
+  ASSERT_PTR_NOT_NULL(g_client->game);
+  ASSERT_PTR_EQUALS(rc_client_get_game_info(g_client), &g_client->game->public_);
+
+  ASSERT_NUM_EQUALS(g_client->game->public_.id, 0);
+  ASSERT_NUM_EQUALS(g_client->game->public_.console_id, RC_CONSOLE_UNKNOWN);
+  ASSERT_STR_EQUALS(g_client->game->public_.title, "Unknown Game");
+  ASSERT_STR_EQUALS(g_client->game->public_.hash, hash);
+  ASSERT_STR_EQUALS(g_client->game->public_.badge_name, "");
+  ASSERT_NUM_EQUALS(g_client->game->subsets->public_.num_achievements, 0);
+  ASSERT_NUM_EQUALS(g_client->game->subsets->public_.num_leaderboards, 0);
+  ASSERT_NUM_EQUALS(g_client->game->subsets->public_.id, 0);
+  ASSERT_STR_EQUALS(g_client->game->subsets->public_.title, "");
+  ASSERT_NUM_EQUALS(g_client->game->subsets->active, 0);
+
+  rc_client_destroy(g_client);
+}
+
 /* ----- unload game ----- */
 
 static void test_unload_game(void)
@@ -9185,6 +9239,8 @@ void test_client(void) {
   TEST(test_load_game_while_spectating);
   TEST(test_load_game_process_game_data);
   TEST(test_load_game_destroy_while_fetching_game_data);
+  TEST(test_load_unknown_game);
+  TEST(test_load_unknown_game_multihash);
 
   /* unload game */
   TEST(test_unload_game);

--- a/test/test_rc_client.c
+++ b/test/test_rc_client.c
@@ -5,6 +5,7 @@
 #include "rc_api_runtime.h"
 
 #include "../src/rc_client_internal.h"
+#include "../src/rc_client_external.h"
 #include "../src/rc_version.h"
 
 #include "test_framework.h"

--- a/test/test_rc_client_external.c
+++ b/test/test_rc_client_external.c
@@ -317,6 +317,8 @@ static void test_add_game_hash(void)
   ASSERT_NUM_EQUALS(g_client->hashes->game_id, 1234);
 
   ASSERT_STR_EQUALS(g_external_event, "add_game_hash");
+
+  rc_client_destroy(g_client);
 }
 
 /* ----- login ----- */

--- a/test/test_rc_client_external.c
+++ b/test/test_rc_client_external.c
@@ -51,14 +51,6 @@ static void rc_client_callback_expect_success(int result, const char* error_mess
   ASSERT_PTR_EQUALS(callback_userdata, g_callback_userdata);
 }
 
-static void rc_client_callback_expect_login_required(int result, const char* error_message, rc_client_t* client, void* callback_userdata)
-{
-  ASSERT_NUM_EQUALS(result, RC_LOGIN_REQUIRED);
-  ASSERT_STR_EQUALS(error_message, "Login required");
-  ASSERT_PTR_EQUALS(client, g_client);
-  ASSERT_PTR_EQUALS(callback_userdata, g_callback_userdata);
-}
-
 /* ----- settings ----- */
 
 static int rc_client_external_get_int(void)

--- a/test/test_rc_client_external.c
+++ b/test/test_rc_client_external.c
@@ -554,6 +554,7 @@ static void test_identify_and_load_game_handoff(void)
     image, image_size, rc_client_callback_expect_success, g_callback_userdata);
 
   ASSERT_STR_EQUALS(g_external_event, "load_game_handoff");
+  ASSERT_PTR_NULL(g_client->state.load);
 
   /* user data should come from external client. validate structure */
   game = rc_client_get_game_info(g_client);
@@ -563,9 +564,8 @@ static void test_identify_and_load_game_handoff(void)
   ASSERT_STR_EQUALS(game->title, "Game Title");
   ASSERT_STR_EQUALS(game->hash, "GAME_HASH");
   ASSERT_STR_EQUALS(game->badge_name, "BDG001");
-  /* ensure non-external client game was not initialized */
-  ASSERT_PTR_NULL(g_client->game);
-  ASSERT_PTR_NULL(g_client->state.load);
+  /* ensure internal client game was initialized to hold media hashes */
+  ASSERT_PTR_NOT_NULL(g_client->game);
 
   rc_client_destroy(g_client);
   free(image);

--- a/test/test_rc_client_external.c
+++ b/test/test_rc_client_external.c
@@ -527,11 +527,10 @@ static void test_identify_and_load_game(void)
 }
 
 static void rc_client_external_load_game_handoff_success(uint32_t game_id, const char* hash,
-    rc_client_async_handle_t* async_handle, rc_client_callback_t callback, void* callback_userdata)
+    rc_client_callback_t callback, void* callback_userdata)
 {
   ASSERT_NUM_EQUALS(game_id, 1234);
   ASSERT_STR_EQUALS(hash, "6a2305a2b6675a97ff792709be1ca857");
-  ASSERT_PTR_NOT_NULL(async_handle);
   g_external_event = "load_game_handoff";
 
   callback(RC_OK, NULL, g_client, callback_userdata);
@@ -572,11 +571,11 @@ static void test_identify_and_load_game_handoff(void)
 }
 
 static void rc_client_external_load_game_handoff_error(uint32_t game_id, const char* hash,
-  rc_client_async_handle_t* async_handle, rc_client_callback_t callback, void* callback_userdata)
+    rc_client_callback_t callback, void* callback_userdata)
 {
   ASSERT_NUM_EQUALS(game_id, 1234);
   ASSERT_STR_EQUALS(hash, "6a2305a2b6675a97ff792709be1ca857");
-  ASSERT_PTR_NOT_NULL(async_handle);
+
   g_external_event = "load_game_handoff";
 
   callback(RC_LOGIN_REQUIRED, rc_error_str(RC_LOGIN_REQUIRED), g_client, callback_userdata);


### PR DESCRIPTION
Alternate solution to #358.

Allows hash generation to occur in the local environment, and then automatically calls the external methods that accept a hash instead of a buffer. This way, any client-specific hashing logic (such as CHD support) doesn't have to be accessible from the external implementation.

For example, instead of `rc_client_begin_identify_and_load_game` calling through to `external_client->begin_identify_and_load_game`, it generates the hash locally and calls `external_client->begin_load_game`. This change also affects `rc_client_begin_change_media`

Since these changes are all done internally to the `rc_client` functions, no additional work is required in the calling code.

https://discord.com/channels/476211979464343552/757767535293890682/1265528322943881306

