### PR TITLE
don't report OrNext chain as conflicting

### DIFF
--- a/src/rcheevos/rc_validate.c
+++ b/src/rcheevos/rc_validate.c
@@ -795,15 +795,22 @@ static int rc_validate_conflicting_conditions(const rc_condset_t* conditions, co
           if (compare_condition->oper != RC_OPERATOR_NONE &&
             !rc_validate_are_operands_equal(&compare_condition->operand2, &condition_chain_iter->operand2))
           {
-            if (compare_condition->operand2.type != condition_chain_iter->operand2.type)
-            {
-              chain_matches = 0;
-              break;
-            }
+            chain_matches = 0;
+            break;
           }
 
           if (!compare_condition->next)
           {
+            chain_matches = 0;
+            break;
+          }
+
+          if (compare_condition->type != RC_CONDITION_ADD_ADDRESS &&
+              compare_condition->type != RC_CONDITION_ADD_SOURCE &&
+              compare_condition->type != RC_CONDITION_SUB_SOURCE &&
+              compare_condition->type != RC_CONDITION_AND_NEXT)
+          {
+            /* things like AddHits and OrNext are hard to definitively detect conflicts. ignore them. */
             chain_matches = 0;
             break;
           }

--- a/test/rcheevos/test_rc_validate.c
+++ b/test/rcheevos/test_rc_validate.c
@@ -342,6 +342,15 @@ void test_conflicting_conditions() {
   TEST_PARAMS2(test_validate_trigger, "P:0xH0000=1_R:0xH0000!=6", "");
   /* PauseIf in alternate group does not affect the ResetIf*/
   TEST_PARAMS2(test_validate_trigger, "P:0xH0000=1SR:0xH0000!=1", "");
+
+  /* cannot determine OrNext conflicts */
+  TEST_PARAMS2(test_validate_trigger, "O:0xH0000=1_0xH0001=1_O:0xH0000=2_0xH0001=2", "");
+  TEST_PARAMS2(test_validate_trigger, "O:0xH0000=1_0xH0001=1_O:0xH0000=1_0xH0001=2", "");
+
+  /* AndNext conflicts are limited to matching the last condition after exactly matching the others */
+  TEST_PARAMS2(test_validate_trigger, "N:0xH0000=1_0xH0001=1_N:0xH0000=2_0xH0001=2", "");
+  TEST_PARAMS2(test_validate_trigger, "N:0xH0000=1_0xH0001=1_N:0xH0000=2_0xH0001=1", ""); /* technically conflicting, but hard to detect */
+  TEST_PARAMS2(test_validate_trigger, "N:0xH0000=1_0xH0001=1_N:0xH0000=1_0xH0001=2", "Condition 4: Conflicts with Condition 2");
 }
 
 void test_redundant_conditions() {


### PR DESCRIPTION
Fixes a bug introduced by #336 where an OrNext chain would be reported as conflicting if the OrNext addresses matched and the last conditions conflicted.
```
OrNext byte 0x1234 = 1
       byte 0x2345 = 2
```
and
```
OrNext byte 0x1234 = 2
       byte 0x2345 = 3
```
Because 0x2345 couldn't be both 2 and 3 at the same time, and both OrNexts were looking at 0x1234, it would be reported as conflicting.