### PR TITLE
if first chain is not a chain, it can't match second chain

### DIFF
--- a/src/rcheevos/rc_validate.c
+++ b/src/rcheevos/rc_validate.c
@@ -777,9 +777,9 @@ static int rc_validate_conflicting_conditions(const rc_condset_t* conditions, co
 
       /* if combining conditions exist, make sure the same combining conditions exist in the
        * compare logic. conflicts can only occur if the combinining conditions match. */
+      int chain_matches = 1;
       if (condition_chain_start != condition)
       {
-        int chain_matches = 1;
         const rc_condition_t* condition_chain_iter = condition_chain_start;
         while (condition_chain_iter != condition)
         {
@@ -818,14 +818,14 @@ static int rc_validate_conflicting_conditions(const rc_condset_t* conditions, co
           compare_condition = compare_condition->next;
           condition_chain_iter = condition_chain_iter->next;
         }
+      }
 
-        /* combining field didn't match, or there's more unmatched combining fields. ignore this condition */
-        if (!chain_matches || rc_validate_is_combining_condition(compare_condition))
-        {
-          while (compare_condition->next && rc_validate_is_combining_condition(compare_condition))
-            compare_condition = compare_condition->next;
-          continue;
-        }
+      /* combining field didn't match, or there's more unmatched combining fields. ignore this condition */
+      if (!chain_matches || rc_validate_is_combining_condition(compare_condition))
+      {
+        while (compare_condition->next && rc_validate_is_combining_condition(compare_condition))
+          compare_condition = compare_condition->next;
+        continue;
       }
 
       if (compare_condition->required_hits)

--- a/src/rcheevos/rc_validate.c
+++ b/src/rcheevos/rc_validate.c
@@ -726,6 +726,7 @@ static int rc_validate_conflicting_conditions(const rc_condset_t* conditions, co
   const rc_condition_t* condition;
   const rc_condition_t* condition_chain_start;
   int overlap;
+  int chain_matches;
 
   /* empty group */
   if (conditions == NULL || compare_conditions == NULL)
@@ -777,7 +778,7 @@ static int rc_validate_conflicting_conditions(const rc_condset_t* conditions, co
 
       /* if combining conditions exist, make sure the same combining conditions exist in the
        * compare logic. conflicts can only occur if the combinining conditions match. */
-      int chain_matches = 1;
+      chain_matches = 1;
       if (condition_chain_start != condition)
       {
         const rc_condition_t* condition_chain_iter = condition_chain_start;

--- a/test/rcheevos/test_rc_validate.c
+++ b/test/rcheevos/test_rc_validate.c
@@ -347,6 +347,9 @@ void test_conflicting_conditions() {
   TEST_PARAMS2(test_validate_trigger, "O:0xH0000=1_0xH0001=1_O:0xH0000=2_0xH0001=2", "");
   TEST_PARAMS2(test_validate_trigger, "O:0xH0000=1_0xH0001=1_O:0xH0000=1_0xH0001=2", "");
 
+  /* cannot determine AddSource conflicts */
+  TEST_PARAMS2(test_validate_trigger, "d0xH1234>0_A:0xH2345_0>d0xH1234", "");
+
   /* AndNext conflicts are limited to matching the last condition after exactly matching the others */
   TEST_PARAMS2(test_validate_trigger, "N:0xH0000=1_0xH0001=1_N:0xH0000=2_0xH0001=2", "");
   TEST_PARAMS2(test_validate_trigger, "N:0xH0000=1_0xH0001=1_N:0xH0000=2_0xH0001=1", ""); /* technically conflicting, but hard to detect */

--- a/test/rcheevos/test_rc_validate.c
+++ b/test/rcheevos/test_rc_validate.c
@@ -388,6 +388,7 @@ void test_redundant_conditions() {
   TEST_PARAMS2(test_validate_trigger, "0xH0000=1S0xH0000!=0S0xH0001=2", "Alt1 Condition 1: Redundant with Core Condition 1");
   TEST_PARAMS2(test_validate_trigger, "0xH0000!=0S0xH0000=1S0xH0001=2", ""); /* more restrictive alt 1 is not redundant with core */
   TEST_PARAMS2(test_validate_trigger, "0xH0000!=0S0xH0000!=0S0xH0001=2", "Alt1 Condition 1: Redundant with Core Condition 1");
+  TEST_PARAMS2(test_validate_trigger, "R:0xH0000<10_N:0xH0001=2_R:0xH0000<20", ""); /* AndNext should prevent condition 3 being compared directly to condition 1 */
 }
 
 void test_redundant_hitcounts() {

--- a/test/rcheevos/test_value.c
+++ b/test/rcheevos/test_value.c
@@ -692,6 +692,7 @@ void test_value(void) {
   TEST_PARAMS2(test_evaluate_value, "K:5_A:1_C:{recall}=6_B:1_C:{recall}=4_M:0=1", 2);
   TEST_PARAMS2(test_evaluate_value, "A:{recall}_M:1", 1); /* Using recall without remember. 0 + 1 = 1*/
   TEST_PARAMS2(test_evaluate_value, "K:{recall}^255_M:{recall}", 255); /* Using recall in first remember. 0x00^0xFF = 0xFF  */
+  TEST_PARAMS2(test_evaluate_value, "A:1_K:2_M:{recall}", 3); /* Remembered value includes AddSource chain  */
 
   /* pause and reset affect hit count */
   TEST(test_evaluate_measured_value_with_pause);


### PR DESCRIPTION
fixes https://github.com/RetroAchievements/RAIntegration/issues/1120

When comparing two chains, if the first chain is not actually a chain, it would ignore the second chain being a chain, so only the last condition of the secondary chain would be checked for conflicts. The correct solution is to never match a chain to a non-chain.