### PR TITLE
Add hashing for ZX Spectrum

### DIFF
--- a/src/rhash/hash.c
+++ b/src/rhash/hash.c
@@ -3978,6 +3978,10 @@ void rc_hash_initialize_iterator(struct rc_hash_iterator* iterator, const char* 
         {
           iterator->consoles[0] = RC_CONSOLE_THOMSONTO8; /* disk */
         }
+        else if (rc_path_compare_extension(ext, "scl"))
+        {
+          iterator->consoles[0] = RC_CONSOLE_ZX_SPECTRUM;
+        }
         break;
 
       case 't':
@@ -3994,7 +3998,8 @@ void rc_hash_initialize_iterator(struct rc_hash_iterator* iterator, const char* 
         {
           iterator->consoles[0] = RC_CONSOLE_ELEKTOR_TV_GAMES_COMPUTER;
         }
-        else if (rc_path_compare_extension(ext, "tzx"))
+        else if (rc_path_compare_extension(ext, "trd") ||
+                 rc_path_compare_extension(ext, "tzx"))
         {
           iterator->consoles[0] = RC_CONSOLE_ZX_SPECTRUM;
         }
@@ -4030,10 +4035,6 @@ void rc_hash_initialize_iterator(struct rc_hash_iterator* iterator, const char* 
         else if (rc_path_compare_extension(ext, "woz"))
         {
           iterator->consoles[0] = RC_CONSOLE_APPLE_II;
-        }
-        else if (rc_path_compare_extension(ext, "wav"))
-        {
-          iterator->consoles[0] = RC_CONSOLE_ZX_SPECTRUM;
         }
         break;
 

--- a/src/rhash/hash.c
+++ b/src/rhash/hash.c
@@ -3129,6 +3129,7 @@ int rc_hash_generate_from_buffer(char hash[33], uint32_t console_id, const uint8
     case RC_CONSOLE_VIRTUAL_BOY:
     case RC_CONSOLE_WASM4:
     case RC_CONSOLE_WONDERSWAN:
+    case RC_CONSOLE_ZX_SPECTRUM:
       return rc_hash_buffer(hash, buffer, buffer_size);
 
     case RC_CONSOLE_ARDUBOY:
@@ -3427,6 +3428,7 @@ int rc_hash_generate_from_file(char hash[33], uint32_t console_id, const char* p
     case RC_CONSOLE_VIRTUAL_BOY:
     case RC_CONSOLE_WASM4:
     case RC_CONSOLE_WONDERSWAN:
+    case RC_CONSOLE_ZX_SPECTRUM:
       /* generic whole-file hash - don't buffer */
       return rc_hash_whole_file(hash, path);
 
@@ -3593,6 +3595,7 @@ static void rc_hash_initialize_dsk_iterator(struct rc_hash_iterator* iterator, c
   rc_hash_iterator_append_console(iterator, RC_CONSOLE_MSX);
   rc_hash_iterator_append_console(iterator, RC_CONSOLE_AMSTRAD_PC);
   rc_hash_iterator_append_console(iterator, RC_CONSOLE_APPLE_II);
+  rc_hash_iterator_append_console(iterator, RC_CONSOLE_ZX_SPECTRUM);
 }
 
 void rc_hash_initialize_iterator(struct rc_hash_iterator* iterator, const char* path, const uint8_t* buffer, size_t buffer_size)
@@ -3743,6 +3746,10 @@ void rc_hash_initialize_iterator(struct rc_hash_iterator* iterator, const char* 
                  rc_path_compare_extension(ext, "cxi"))
         {
           iterator->consoles[0] = RC_CONSOLE_NINTENDO_3DS;
+        }
+        else if (rc_path_compare_extension(ext, "csw"))
+        {
+          iterator->consoles[0] = RC_CONSOLE_ZX_SPECTRUM;
         }
         break;
 
@@ -3929,6 +3936,10 @@ void rc_hash_initialize_iterator(struct rc_hash_iterator* iterator, const char* 
         {
           iterator->consoles[0] = RC_CONSOLE_ELEKTOR_TV_GAMES_COMPUTER;
         }
+        else if (rc_path_compare_extension(ext, "pzx"))
+        {
+          iterator->consoles[0] = RC_CONSOLE_ZX_SPECTRUM;
+        }
         break;
 
       case 'r':
@@ -3972,6 +3983,7 @@ void rc_hash_initialize_iterator(struct rc_hash_iterator* iterator, const char* 
       case 't':
         if (rc_path_compare_extension(ext, "tap"))
         {
+          /* also Commodore 64 and ZX Spectrum, but all are full file hashes */
           iterator->consoles[0] = RC_CONSOLE_ORIC;
         }
         else if (rc_path_compare_extension(ext, "tic"))
@@ -3981,6 +3993,10 @@ void rc_hash_initialize_iterator(struct rc_hash_iterator* iterator, const char* 
         else if (rc_path_compare_extension(ext, "tvc"))
         {
           iterator->consoles[0] = RC_CONSOLE_ELEKTOR_TV_GAMES_COMPUTER;
+        }
+        else if (rc_path_compare_extension(ext, "tzx"))
+        {
+          iterator->consoles[0] = RC_CONSOLE_ZX_SPECTRUM;
         }
         break;
 
@@ -4014,6 +4030,10 @@ void rc_hash_initialize_iterator(struct rc_hash_iterator* iterator, const char* 
         else if (rc_path_compare_extension(ext, "woz"))
         {
           iterator->consoles[0] = RC_CONSOLE_APPLE_II;
+        }
+        else if (rc_path_compare_extension(ext, "wav"))
+        {
+          iterator->consoles[0] = RC_CONSOLE_ZX_SPECTRUM;
         }
         break;
 

--- a/src/rhash/hash.c
+++ b/src/rhash/hash.c
@@ -3594,8 +3594,8 @@ static void rc_hash_initialize_dsk_iterator(struct rc_hash_iterator* iterator, c
   /* check MSX first, as Apple II isn't supported by RetroArch, and RAppleWin won't use the iterator */
   rc_hash_iterator_append_console(iterator, RC_CONSOLE_MSX);
   rc_hash_iterator_append_console(iterator, RC_CONSOLE_AMSTRAD_PC);
-  rc_hash_iterator_append_console(iterator, RC_CONSOLE_APPLE_II);
   rc_hash_iterator_append_console(iterator, RC_CONSOLE_ZX_SPECTRUM);
+  rc_hash_iterator_append_console(iterator, RC_CONSOLE_APPLE_II);
 }
 
 void rc_hash_initialize_iterator(struct rc_hash_iterator* iterator, const char* path, const uint8_t* buffer, size_t buffer_size)

--- a/test/rhash/test_hash.c
+++ b/test/rhash/test_hash.c
@@ -2493,6 +2493,10 @@ void test_hash(void) {
   TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_WONDERSWAN, "test.ws", 524288, "68f0f13b598e0b66461bc578375c3888");
   TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_WONDERSWAN, "test.wsc", 4194304, "a247ec8a8c42e18fcb80702dfadac14b");
 
+  /* ZX Spectrum */
+  TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_ZX_SPECTRUM, "test.tap", 1596, "714a9f455e616813dd5421c5b347e5e5");
+  TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_ZX_SPECTRUM, "test.tzx", 14971, "93723e6d1100f9d1d448a27cf6618c47");
+
   /* m3u support */
   TEST(test_hash_m3u_buffered);
   TEST(test_hash_m3u_with_comments);


### PR DESCRIPTION
Just do full file hashes (going off all supported extensions in BizHawk: *.tzx, *.tap, *.pzx, *.csw, *.wav, *.dsk)