### PR TITLE
Use better Win32 mutexes for rc_mutex_t

### DIFF
--- a/src/rc_client.c
+++ b/src/rc_client.c
@@ -180,7 +180,7 @@ static void rc_client_log_message_va(const rc_client_t* client, const char* form
   if (client->callbacks.log_call) {
     char buffer[2048];
 
-#ifdef __STDC_WANT_SECURE_LIB__
+#ifdef __STDC_SECURE_LIB__
     vsprintf_s(buffer, sizeof(buffer), format, args);
 #elif __STDC_VERSION__ >= 199901L /* vsnprintf requires c99 */
     vsnprintf(buffer, sizeof(buffer), format, args);

--- a/src/rc_compat.c
+++ b/src/rc_compat.c
@@ -59,7 +59,7 @@ int rc_snprintf(char* buffer, size_t size, const char* format, ...)
 
   va_start(args, format);
 
-#ifdef __STDC_WANT_SECURE_LIB__
+#ifdef __STDC_SECURE_LIB__
   result = vsprintf_s(buffer, size, format, args);
 #else
   /* assume buffer is large enough and ignore size */
@@ -74,7 +74,7 @@ int rc_snprintf(char* buffer, size_t size, const char* format, ...)
 
 #endif
 
-#ifndef __STDC_WANT_SECURE_LIB__
+#ifndef __STDC_SECURE_LIB__
 
 struct tm* rc_gmtime_s(struct tm* buf, const time_t* timer)
 {

--- a/src/rc_compat.c
+++ b/src/rc_compat.c
@@ -106,6 +106,7 @@ void rc_mutex_init(rc_mutex_t* mutex)
 void rc_mutex_destroy(rc_mutex_t* mutex)
 {
   /* Nothing to do here */
+  (void)mutex;
 }
 
 void rc_mutex_lock(rc_mutex_t* mutex)

--- a/src/rc_compat.c
+++ b/src/rc_compat.c
@@ -127,6 +127,7 @@ void rc_mutex_lock(rc_mutex_t* mutex)
 void rc_mutex_unlock(rc_mutex_t* mutex)
 {
   if (mutex->owner == GetCurrentThreadId()) {
+    assert(mutex->count > 0);
     if (--mutex->count == 0) {
       mutex->owner = 0;
       ReleaseSRWLockExclusive(&mutex->srw_lock);

--- a/src/rc_compat.h
+++ b/src/rc_compat.h
@@ -97,9 +97,6 @@ RC_BEGIN_C_DECLS
      CRITICAL_SECTION critical_section;
    #endif
    } rc_mutex_t;
- #elif defined(GEKKO)
-  #include <ogcsys.h>
-  typedef mutex_t rc_mutex_t;
  #else
   #include <pthread.h>
   typedef pthread_mutex_t rc_mutex_t;

--- a/src/rc_compat.h
+++ b/src/rc_compat.h
@@ -2,7 +2,9 @@
 #define RC_COMPAT_H
 
 #ifdef _WIN32
- #define WIN32_LEAN_AND_MEAN
+ #ifndef WIN32_LEAN_AND_MEAN
+  #define WIN32_LEAN_AND_MEAN
+ #endif
  #include <windows.h>
 #endif
 

--- a/src/rc_compat.h
+++ b/src/rc_compat.h
@@ -1,6 +1,11 @@
 #ifndef RC_COMPAT_H
 #define RC_COMPAT_H
 
+#ifdef _WIN32
+ #define WIN32_LEAN_AND_MEAN
+ #include <windows.h>
+#endif
+
 #include "rc_export.h"
 
 #include <stdio.h>
@@ -77,21 +82,19 @@ RC_BEGIN_C_DECLS
  #define rc_mutex_lock(mutex)
  #define rc_mutex_unlock(mutex)
 #else
- #if defined(_WIN32)
-  #define WIN32_LEAN_AND_MEAN
-  #include <windows.h>
-  typedef struct rc_mutex_t {
-  #if defined(WINVER) && WINVER >= 0x0600
-    /* Windows Vista and later can use a slim reader/writer (SRW) lock */
-    SRWLOCK srw_lock;
-    /* Current thread owner needs to be tracked (for recursive mutex usage) */
-    DWORD owner;
-    DWORD count;
-  #else
+  #if defined(_WIN32)
+   typedef struct rc_mutex_t {
+   #if defined(WINVER) && WINVER >= 0x0600
+     /* Windows Vista and later can use a slim reader/writer (SRW) lock */
+     SRWLOCK srw_lock;
+     /* Current thread owner needs to be tracked (for recursive mutex usage) */
+     DWORD owner;
+     DWORD count;
+   #else
      /* Pre-Vista must use a critical section */
-    CRITICAL_SECTION critical_section;
-  #endif
-  } rc_mutex_t;
+     CRITICAL_SECTION critical_section;
+   #endif
+   } rc_mutex_t;
  #elif defined(GEKKO)
   #include <ogcsys.h>
   typedef mutex_t rc_mutex_t;

--- a/src/rc_compat.h
+++ b/src/rc_compat.h
@@ -58,7 +58,7 @@ RC_BEGIN_C_DECLS
 
 #endif /* __STDC_VERSION__ < 199901L */
 
-#ifndef __STDC_WANT_SECURE_LIB__
+#ifndef __STDC_SECURE_LIB__
  /* _CRT_SECURE_NO_WARNINGS redefinitions */
  #define strcpy_s(dest, sz, src) strcpy(dest, src)
  #define sscanf_s sscanf

--- a/src/rhash/hash.c
+++ b/src/rhash/hash.c
@@ -78,7 +78,7 @@ static void* filereader_open(const char* path)
     return NULL;
   }
 
- #if defined(__STDC_WANT_SECURE_LIB__)
+ #if defined(__STDC_SECURE_LIB__)
   /* have to use _SH_DENYNO because some cores lock the file while its loaded */
   fp = _wfsopen(wpath, L"rb", _SH_DENYNO);
  #else
@@ -91,7 +91,7 @@ static void* filereader_open(const char* path)
 #else /* !WINVER >= 0x0500 */
 static void* filereader_open(const char* path)
 {
- #if defined(__STDC_WANT_SECURE_LIB__)
+ #if defined(__STDC_SECURE_LIB__)
   #if defined(WINVER)
    /* have to use _SH_DENYNO because some cores lock the file while its loaded */
    return _fsopen(path, "rb", _SH_DENYNO);
@@ -100,7 +100,7 @@ static void* filereader_open(const char* path)
    fopen_s(&fp, path, "rb");
    return fp;
   #endif
- #else /* !__STDC_WANT_SECURE_LIB__ */
+ #else /* !__STDC_SECURE_LIB__ */
   return fopen(path, "rb");
  #endif
 }


### PR DESCRIPTION
https://learn.microsoft.com/en-us/archive/msdn-magazine/2012/november/windows-with-c-the-evolution-of-synchronization-in-windows-and-c

On Windows, a simple Mutex HANDLE (using *Mutex functions) seems like an appropriate implementation for rc_mutex_t. While it does work, it is horribly inefficient and actually overkill, as on Win32, a Mutex is a synchronization object capable of inter-process locking, thus requiring entering kernel code always when using a *Mutex function (going into kernel code implicitly being fairly expensive).

A critical section works similarly, except it is not capable of inter-process locking. This is much better for rc_mutex_t, which is obviously not expecting to be used in a different process. Critical sections are also capable of spinlooping for a little bit of time before trying to acquire the critical section, thus potentially avoiding an expensive system call when contention goes away quickly.

Windows Vista introduced slim reader/writer (SRW) locks. These are very lightweight, mostly implemented in user mode (only going to kernel if it decides it should just outright sleep), and using newer (more efficient) "keyed event objects" (which only have 1 actual kernel object allocated for all objects, only used as a last resort for critical sections due to backwards compatibility reasons). They aren't a direct replacement for critical sections as they are incapable of recursive acquires, but that's easy enough to implement by tracking the current thread owner.

In case code is compiled with Vista or later as the minimum version (WINVER >= 0x0600) then SRW locks will be used, otherwise critical sections will be used.

This commit also does a minor fix in rc_compat.h with libogc mutexes, as previously it was just including pthread.h and typedef'ing rc_mutex_t against pthread_mutex_t. Not sure why this ever compiled exactly (does that indicate GC/Wii can just use pthread mutexes? Or was RC_NO_THREADS actually being defined?), but regardless I've changed it to properly typedef against libogc's mutex_t.