### PR TITLE
use modified memref chain for mathematic rich presence macro values

### DIFF
--- a/include/rc_runtime_types.h
+++ b/include/rc_runtime_types.h
@@ -417,7 +417,7 @@ struct rc_richpresence_display_part_t {
   rc_richpresence_display_part_t* next;
   const char* text;
   rc_richpresence_lookup_t* lookup;
-  rc_memref_value_t* value;
+  rc_operand_t value;
   uint8_t display_type;
 };
 

--- a/src/rcheevos/operand.c
+++ b/src/rcheevos/operand.c
@@ -486,7 +486,7 @@ int rc_operand_is_float(const rc_operand_t* self) {
   return rc_operand_is_float_memref(self);
 }
 
-uint32_t rc_transform_operand_value(uint32_t value, const rc_operand_t* self) {
+static uint32_t rc_transform_operand_value(uint32_t value, const rc_operand_t* self) {
   switch (self->type)
   {
     case RC_OPERAND_BCD:

--- a/src/rcheevos/rc_internal.h
+++ b/src/rcheevos/rc_internal.h
@@ -31,6 +31,7 @@ typedef struct __rc_value_type_enum_t { uint8_t value; } __rc_value_type_enum_t;
 typedef struct __rc_memref_type_enum_t { uint8_t value; } __rc_memref_type_enum_t;
 typedef struct __rc_condition_enum_t { uint8_t value; } __rc_condition_enum_t;
 typedef struct __rc_condition_enum_str_t { uint8_t value; } __rc_condition_enum_str_t;
+typedef struct __rc_condset_list_t { rc_condset_t* first_condset; } __rc_condset_list_t;
 typedef struct __rc_operator_enum_t { uint8_t value; } __rc_operator_enum_t;
 typedef struct __rc_operator_enum_str_t { uint8_t value; } __rc_operator_enum_str_t;
 typedef struct __rc_operand_memref_t { rc_operand_t operand; } __rc_operand_memref_t; /* requires &rc_operand_t to be the same as &rc_operand_t.value.memref */
@@ -38,6 +39,10 @@ typedef struct __rc_memref_list_t { rc_memref_t* first_memref; } __rc_memref_lis
 typedef struct __rc_value_list_t { rc_value_t* first_value; } __rc_value_list_t;
 typedef struct __rc_trigger_state_enum_t { uint8_t value; } __rc_trigger_state_enum_t;
 typedef struct __rc_lboard_state_enum_t { uint8_t value; } __rc_lboard_state_enum_t;
+typedef struct __rc_richpresence_display_list_t { rc_richpresence_display_t* first_display; } __rc_richpresence_display_list_t;
+typedef struct __rc_richpresence_display_part_list_t { rc_richpresence_display_part_t* display; } __rc_richpresence_display_part_list_t;
+typedef struct __rc_richpresence_lookup_list_t { rc_richpresence_lookup_t* first_lookup; } __rc_richpresence_lookup_list_t;
+typedef struct __rc_format_enum_t { uint8_t value; } __rc_format_enum_t;
 
 #define RC_ALLOW_ALIGN(T) struct __align_ ## T { uint8_t ch; T t; };
 
@@ -103,6 +108,7 @@ typedef struct {
       __rc_memref_type_enum_t memref_type;
       __rc_condition_enum_t condition;
       __rc_condition_enum_str_t condition_str;
+      __rc_condset_list_t condset_list;
       __rc_operator_enum_t oper;
       __rc_operator_enum_str_t oper_str;
       __rc_operand_memref_t operand_memref;
@@ -110,6 +116,10 @@ typedef struct {
       __rc_value_list_t value_list;
       __rc_trigger_state_enum_t trigger_state;
       __rc_lboard_state_enum_t lboard_state;
+      __rc_richpresence_display_list_t richpresence_display_list;
+      __rc_richpresence_display_part_list_t richpresence_display_part_list;
+      __rc_richpresence_lookup_list_t richpresence_lookup_list;
+      __rc_format_enum_t format;
     } natvis_extension;
   } objs;
 }
@@ -201,6 +211,8 @@ void rc_init_parse_state(rc_parse_state_t* parse, void* buffer, lua_State* L, in
 void rc_init_parse_state_memrefs(rc_parse_state_t* parse, rc_memref_t** memrefs);
 void rc_init_parse_state_variables(rc_parse_state_t* parse, rc_value_t** variables);
 void rc_destroy_parse_state(rc_parse_state_t* parse);
+void rc_copy_memrefs_into_parse_state(rc_parse_state_t* parse, rc_memref_t* memrefs);
+void rc_sync_operand(rc_operand_t* operand, rc_parse_state_t* parse, const rc_memref_t* memrefs);
 
 void* rc_alloc(void* pointer, int32_t* offset, uint32_t size, uint32_t alignment, rc_scratch_t* scratch, uint32_t scratch_object_pointer_offset);
 void* rc_alloc_scratch(void* pointer, int32_t* offset, uint32_t size, uint32_t alignment, rc_scratch_t* scratch, uint32_t scratch_object_pointer_offset);
@@ -274,7 +286,7 @@ void rc_parse_value_internal(rc_value_t* self, const char** memaddr, rc_parse_st
 int rc_evaluate_value_typed(rc_value_t* self, rc_typed_value_t* value, rc_peek_t peek, void* ud, lua_State* L);
 void rc_reset_value(rc_value_t* self);
 int rc_value_from_hits(rc_value_t* self);
-rc_value_t* rc_alloc_helper_variable(const char* memaddr, size_t memaddr_len, rc_parse_state_t* parse);
+rc_value_t* rc_alloc_variable(const char* memaddr, size_t memaddr_len, rc_parse_state_t* parse);
 void rc_update_variables(rc_value_t* variable, rc_peek_t peek, void* ud, lua_State* L);
 
 void rc_typed_value_convert(rc_typed_value_t* value, char new_type);

--- a/src/rcheevos/rc_runtime_types.natvis
+++ b/src/rcheevos/rc_runtime_types.natvis
@@ -98,6 +98,7 @@
     </Type>
     <Type Name="rc_memref_t">
         <DisplayString Condition="value.memref_type==RC_MEMREF_TYPE_MODIFIED_MEMREF">{*(rc_modified_memref_t*)&amp;value}</DisplayString>
+        <DisplayString Condition="value.memref_type==RC_MEMREF_TYPE_VALUE">{*(rc_value_t*)&amp;value}</DisplayString>
         <DisplayString Condition="value.size==RC_MEMSIZE_VARIABLE">var</DisplayString>
         <DisplayString>{*((__rc_memsize_enum_func_t*)&amp;value.size)}({address,x})</DisplayString>
         <Expand>
@@ -109,6 +110,7 @@
     </Type>
     <Type Name="__rc_operand_memref_t">
         <DisplayString Condition="operand.value.memref->value.memref_type==RC_MEMREF_TYPE_MODIFIED_MEMREF">... {*((__rc_memsize_enum_func_t*)&amp;operand.size)} {operand.value.memref->address,x}</DisplayString>
+        <DisplayString Condition="operand.value.memref->value.memref_type==RC_MEMREF_TYPE_VALUE">value {((rc_value_t*)operand.value.memref)->name,s}</DisplayString>
         <DisplayString>{*((__rc_memsize_enum_func_t*)&amp;operand.size)} {operand.value.memref->address,x}</DisplayString>
         <Expand>
             <Item Name="[rc_modified_memref_t]" Condition="operand.value.memref->value.memref_type==RC_MEMREF_TYPE_MODIFIED_MEMREF">(rc_modified_memref_t*)&amp;operand.value</Item>
@@ -256,6 +258,16 @@
             </LinkedListItems>
         </Expand>
     </Type>
+    <Type Name="__rc_condset_list_t">
+        <DisplayString Condition="first_condset==0">{{}}</DisplayString>
+        <Expand>
+            <LinkedListItems>
+                <HeadPointer>first_condset</HeadPointer>
+                <NextPointer>next</NextPointer>
+                <ValueNode>this</ValueNode>
+            </LinkedListItems>
+        </Expand>
+    </Type>
     <Type Name="rc_modified_memref_t">
         <DisplayString Condition="modifier_type==RC_OPERATOR_INDIRECT_READ">$({parent} + {modifier})</DisplayString>
         <DisplayString Condition="modifier_type==RC_OPERATOR_SUB_PARENT">({modifier} - {parent})</DisplayString>
@@ -284,12 +296,8 @@
             <Item Name="has_hits">*((__rc_bool_enum_t*)&amp;has_hits)</Item>
             <Item Name="has_required_hits">*((__rc_bool_enum_t*)&amp;has_required_hits)</Item>
             <Item Name="measured_as_percent">*((__rc_bool_enum_t*)&amp;measured_as_percent)</Item>
-            <Item Name="requirement">*requirement</Item>
-            <LinkedListItems>
-                <HeadPointer>alternative</HeadPointer>
-                <NextPointer>next</NextPointer>
-                <ValueNode>this</ValueNode>
-            </LinkedListItems>
+            <Item Name="requirement">requirement</Item>
+            <Item Name="alternative">*((__rc_condset_list_t*)&amp;alternative)</Item>
         </Expand>
     </Type>
     <Type Name="rc_value_t">
@@ -332,6 +340,109 @@
             </LinkedListItems>
         </Expand>
     </Type>
+    <Type Name="__rc_format_enum_t">
+        <DisplayString Condition="value==RC_FORMAT_FRAMES">{RC_FORMAT_FRAMES}</DisplayString>
+        <DisplayString Condition="value==RC_FORMAT_SECONDS">{RC_FORMAT_SECONDS}</DisplayString>
+        <DisplayString Condition="value==RC_FORMAT_CENTISECS">{RC_FORMAT_CENTISECS}</DisplayString>
+        <DisplayString Condition="value==RC_FORMAT_SCORE">{RC_FORMAT_SCORE}</DisplayString>
+        <DisplayString Condition="value==RC_FORMAT_VALUE">{RC_FORMAT_VALUE}</DisplayString>
+        <DisplayString Condition="value==RC_FORMAT_MINUTES">{RC_FORMAT_MINUTES}</DisplayString>
+        <DisplayString Condition="value==RC_FORMAT_SECONDS_AS_MINUTES">{RC_FORMAT_SECONDS_AS_MINUTES}</DisplayString>
+        <DisplayString Condition="value==RC_FORMAT_FLOAT1">{RC_FORMAT_FLOAT1}</DisplayString>
+        <DisplayString Condition="value==RC_FORMAT_FLOAT2">{RC_FORMAT_FLOAT2}</DisplayString>
+        <DisplayString Condition="value==RC_FORMAT_FLOAT3">{RC_FORMAT_FLOAT3}</DisplayString>
+        <DisplayString Condition="value==RC_FORMAT_FLOAT4">{RC_FORMAT_FLOAT4}</DisplayString>
+        <DisplayString Condition="value==RC_FORMAT_FLOAT5">{RC_FORMAT_FLOAT5}</DisplayString>
+        <DisplayString Condition="value==RC_FORMAT_FLOAT6">{RC_FORMAT_FLOAT6}</DisplayString>
+        <DisplayString Condition="value==RC_FORMAT_FIXED1">{RC_FORMAT_FIXED1}</DisplayString>
+        <DisplayString Condition="value==RC_FORMAT_FIXED2">{RC_FORMAT_FIXED2}</DisplayString>
+        <DisplayString Condition="value==RC_FORMAT_FIXED3">{RC_FORMAT_FIXED3}</DisplayString>
+        <DisplayString Condition="value==RC_FORMAT_TENS">{RC_FORMAT_TENS}</DisplayString>
+        <DisplayString Condition="value==RC_FORMAT_HUNDREDS">{RC_FORMAT_HUNDREDS}</DisplayString>
+        <DisplayString Condition="value==RC_FORMAT_THOUSANDS">{RC_FORMAT_THOUSANDS}</DisplayString>
+        <DisplayString Condition="value==101">RC_FORMAT_STRING (101)</DisplayString>
+        <DisplayString Condition="value==102">RC_FORMAT_LOOKUP (102)</DisplayString>
+        <DisplayString Condition="value==103">RC_FORMAT_UNKNOWN_MACRO (103)</DisplayString>
+        <DisplayString Condition="value==104">RC_FORMAT_ASCIICHAR (104)</DisplayString>
+        <DisplayString Condition="value==105">RC_FORMAT_UNICODECHAR (105)</DisplayString>
+        <DisplayString>unknown ({value})</DisplayString>
+    </Type>
+    <Type Name="rc_richpresence_display_part_t">
+        <DisplayString Condition="display_type==101">{text,s}</DisplayString>
+        <DisplayString Condition="display_type==103">[Unknown macro]{text,sb}</DisplayString>
+        <DisplayString Condition="lookup==0">@{text,sb}({value,na})</DisplayString>
+        <DisplayString>@{lookup->name,sb}({value,na})</DisplayString>
+        <Expand>
+            <Item Name="text" Condition="display_type==101||display_type==103">text</Item>
+            <Item Name="lookup" Condition="display_type!=101&amp;&amp;display_type!=103">lookup</Item>
+            <Item Name="value" Condition="display_type!=101&amp;&amp;display_type!=103">value</Item>
+            <Item Name="display_type">*((__rc_format_enum_t*)&amp;display_type)</Item>
+        </Expand>
+    </Type>
+    <Type Name="__rc_richpresence_display_part_list_t">
+        <DisplayString Condition="display->next->next!=0">{display,na} {display->next,na} {display->next->next,na}</DisplayString>
+        <DisplayString Condition="display->next!=0">{display,na} {display->next,na}</DisplayString>
+        <DisplayString>{display,na}</DisplayString>
+        <Expand>
+            <LinkedListItems>
+                <HeadPointer>display</HeadPointer>
+                <NextPointer>next</NextPointer>
+                <ValueNode>this</ValueNode>
+            </LinkedListItems>
+        </Expand>
+    </Type>
+    <Type Name="rc_richpresence_display_t">
+        <Expand>
+            <Item Name="displays">*((__rc_richpresence_display_part_list_t*)&amp;display)</Item>
+            <Item Name="trigger">trigger</Item>
+        </Expand>
+    </Type>
+    <Type Name="__rc_richpresence_display_list_t">
+        <DisplayString Condition="first_display==0">{{NULL}}</DisplayString>
+        <DisplayString>{(void*)&amp;first_display,na}</DisplayString>
+        <Expand>
+            <LinkedListItems>
+                <HeadPointer>first_display</HeadPointer>
+                <NextPointer>next</NextPointer>
+                <ValueNode>this</ValueNode>
+            </LinkedListItems>
+        </Expand>
+    </Type>
+    <Type Name="rc_richpresence_lookup_item_t">
+        <DisplayString Condition="first==last">{first}: {label,na}</DisplayString>
+        <DisplayString>{first}-{last}: {label,na}</DisplayString>
+    </Type>
+    <Type Name="rc_richpresence_lookup_t">
+        <DisplayString>{name,na}</DisplayString>
+        <Expand>
+            <Item Name="name">name</Item>
+            <Item Name="format">*((__rc_format_enum_t*)&amp;format)</Item>
+            <Item Name="default_label" Condition="format>101">default_label</Item>
+            <TreeItems>
+                <HeadPointer>root</HeadPointer>
+                <LeftPointer>left</LeftPointer>
+                <RightPointer>right</RightPointer>
+                <ValueNode>this</ValueNode>
+            </TreeItems>
+        </Expand>
+    </Type>
+    <Type Name="__rc_richpresence_lookup_list_t">
+        <DisplayString Condition="first_lookup==0">{{NULL}}</DisplayString>
+        <DisplayString>{(void*)&amp;first_lookup,na}</DisplayString>
+        <Expand>
+            <LinkedListItems>
+                <HeadPointer>first_lookup</HeadPointer>
+                <NextPointer>next</NextPointer>
+                <ValueNode>this</ValueNode>
+            </LinkedListItems>
+        </Expand>
+    </Type>
+    <Type Name="rc_richpresence_t">
+        <Expand>
+            <Item Name="displays">((__rc_richpresence_display_list_t*)&amp;first_display)</Item>
+            <Item Name="lookups">((__rc_richpresence_lookup_list_t*)&amp;first_lookup)</Item>
+        </Expand>
+    </Type>
     <Type Name="__rc_value_list_t">
         <DisplayString Condition="first_value==0">{{NULL}}</DisplayString>
         <DisplayString>{(void*)&amp;first_value,na}</DisplayString>
@@ -356,6 +467,25 @@
             <Item Name="is_value">*((__rc_bool_enum_t*)&amp;is_value)</Item>
             <Item Name="has_required_hits">*((__rc_bool_enum_t*)&amp;has_required_hits)</Item>
             <Item Name="measured_as_percent">*((__rc_bool_enum_t*)&amp;measured_as_percent)</Item>
+        </Expand>
+    </Type>
+    <Type Name="rc_buffer_chunk_t">
+        <DisplayString>{{used={write-start} size={end-start}}}</DisplayString>
+        <Expand>
+            <Item Name="[size]">end-start</Item>
+            <Item Name="[used]">write-start</Item>
+            <Item Name="[available]">end-write</Item>
+            <Item Name="next">next</Item>
+        </Expand>
+    </Type>
+    <Type Name="rc_buffer_t">
+        <DisplayString></DisplayString>
+        <Expand>
+            <LinkedListItems>
+                <HeadPointer>&amp;chunk</HeadPointer>
+                <NextPointer>next</NextPointer>
+                <ValueNode>this</ValueNode>
+            </LinkedListItems>
         </Expand>
     </Type>
     <Type Name="__rc_runtime_trigger_list_t">

--- a/src/rcheevos/value.c
+++ b/src/rcheevos/value.c
@@ -369,7 +369,7 @@ void rc_init_parse_state_variables(rc_parse_state_t* parse, rc_value_t** variabl
   *variables = 0;
 }
 
-rc_value_t* rc_alloc_helper_variable(const char* memaddr, size_t memaddr_len, rc_parse_state_t* parse)
+rc_value_t* rc_alloc_variable(const char* memaddr, size_t memaddr_len, rc_parse_state_t* parse)
 {
   rc_value_t** variables = parse->variables;
   rc_value_t* value;


### PR DESCRIPTION
Avoids the overhead of creating a value object for macro parameters that are simple mathematic expressions:
```
@Score(0xH1234*100_0xH1235)
```

Would create:
```
AddSource byte 0x1234 * 100
Measured  byte 0x1235
```

Which would intrinsically have a modified memref chain of "byte 0x1234 * 100 + byte 0x1235". This updates the logic so the macro can reference the chain directly without needing to define the conditions or the condition container.

More complex parameters (i.e. something counting hits or something with a PauseIf) would still need to generate the more complex container.