### PR TITLE
report 0x0xADDR as invalid

### DIFF
--- a/src/rcheevos/memref.c
+++ b/src/rcheevos/memref.c
@@ -107,7 +107,12 @@ int rc_parse_memref(const char** memaddr, uint8_t* size, uint32_t* address) {
       /* case 'y': case 'Y': 64 bit? */
       /* case 'z': case 'Z': 128 bit? */
 
-      case '0': case '1': case '2': case '3': case '4':
+      case '0':
+        if (*aux == 'x') /* user mistyped an extra 0x: 0x0xabcd */
+          return RC_INVALID_MEMORY_OPERAND;
+        /* fallthrough */
+
+      case '1': case '2': case '3': case '4':
       case '5': case '6': case '7': case '8': case '9':
       case 'a': case 'b': case 'c': case 'd': case 'e': case 'f':
       case 'A': case 'B': case 'C': case 'D': case 'E': case 'F':

--- a/src/rcheevos/richpresence.c
+++ b/src/rcheevos/richpresence.c
@@ -580,11 +580,19 @@ void rc_parse_richpresence_internal(rc_richpresence_t* self, const char* script,
           *nextdisplay = rc_parse_richpresence_display_internal(ptr + 1, endline, parse, firstlookup);
           if (parse->offset < 0)
             return;
+
           trigger = &((*nextdisplay)->trigger);
           rc_parse_trigger_internal(trigger, &line, parse);
           trigger->memrefs = 0;
           if (parse->offset < 0)
             return;
+
+          if (line != ptr) {
+            /* incomplete read */
+            parse->offset = RC_INVALID_OPERATOR;
+            return;
+          }
+
           if (parse->buffer)
             nextdisplay = &((*nextdisplay)->next);
         }

--- a/test/rcheevos/test_operand.c
+++ b/test/rcheevos/test_operand.c
@@ -187,6 +187,9 @@ static void test_parse_memory_references() {
   TEST_PARAMS4(test_parse_operand, "0xHABCD", RC_OPERAND_ADDRESS, RC_MEMSIZE_8_BITS, 0xABCDU);
   TEST_PARAMS4(test_parse_operand, "0xhabcd", RC_OPERAND_ADDRESS, RC_MEMSIZE_8_BITS, 0xABCDU);
   TEST_PARAMS4(test_parse_operand, "fFABCD", RC_OPERAND_ADDRESS, RC_MEMSIZE_FLOAT, 0xABCDU);
+
+  /* doubled up prefix */
+  TEST_PARAMS3(test_parse_error_operand, "0x0xH1234", 0, RC_INVALID_MEMORY_OPERAND);
 }
 
 static void test_parse_delta_memory_references() {

--- a/test/rcheevos/test_richpresence.c
+++ b/test/rcheevos/test_richpresence.c
@@ -394,6 +394,9 @@ static void test_conditional_display_invalid() {
   int lines_read = 0;
   ASSERT_NUM_EQUALS(rc_richpresence_size_lines("Display:\n?I:0x0x0000=1?True\nFalse\n", &lines_read), RC_INVALID_MEMORY_OPERAND);
   ASSERT_NUM_EQUALS(lines_read, 2);
+
+  ASSERT_NUM_EQUALS(rc_richpresence_size_lines("Display:\n?0x0000=1 0x0001=2?True\nFalse\n", &lines_read), RC_INVALID_OPERATOR);
+  ASSERT_NUM_EQUALS(lines_read, 2);
 }
 
 static void test_macro_value_adjusted_negative() {

--- a/test/rcheevos/test_richpresence.c
+++ b/test/rcheevos/test_richpresence.c
@@ -390,6 +390,12 @@ static void test_conditional_display_unnecessary_measured_indirect() {
   assert_richpresence_output(richpresence, &memory, "True");
 }
 
+static void test_conditional_display_invalid() {
+  int lines_read = 0;
+  ASSERT_NUM_EQUALS(rc_richpresence_size_lines("Display:\n?I:0x0x0000=1?True\nFalse\n", &lines_read), RC_INVALID_MEMORY_OPERAND);
+  ASSERT_NUM_EQUALS(lines_read, 2);
+}
+
 static void test_macro_value_adjusted_negative() {
   uint8_t ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
   memory_t memory;
@@ -524,6 +530,10 @@ static void test_macro_value_remember_recall() {
 
   ram[2] = 0;
   assert_richpresence_output(richpresence, &memory, "Result is 3");
+}
+
+static void test_macro_value_invalid() {
+  ASSERT_NUM_EQUALS(rc_richpresence_size("Format:Points\nFormatType=VALUE\n\nDisplay:\n@Points(0x0x0001) Points"), RC_INVALID_MEMORY_OPERAND);
 }
 
 static void test_macro_hundreds() {
@@ -1342,6 +1352,7 @@ void test_richpresence(void) {
   TEST(test_conditional_display_indirect);
   TEST(test_conditional_display_unnecessary_measured);
   TEST(test_conditional_display_unnecessary_measured_indirect);
+  TEST(test_conditional_display_invalid);
 
   /* value macros */
   TEST(test_macro_value);
@@ -1355,6 +1366,7 @@ void test_richpresence(void) {
   TEST(test_macro_value_divide_by_zero);
   TEST(test_macro_value_divide_by_self);
   TEST(test_macro_value_remember_recall);
+  TEST(test_macro_value_invalid);
 
   /* hundreds macro */
   TEST(test_macro_hundreds);


### PR DESCRIPTION
There are currently 21 achievement sets with rich presence containing memory reads in the form `0x0xADDR`. 

This currently "works" because the leading `0x` is discarded https://github.com/RetroAchievements/rcheevos/blob/6fba22f49d3915a9184fafca8a7dcdc918542286/src/rcheevos/memref.c#L79-L83

Then it does a hex parse of the remaining string  https://github.com/RetroAchievements/rcheevos/blob/6fba22f49d3915a9184fafca8a7dcdc918542286/src/rcheevos/memref.c#L141

which detects and ignores the second `0x`.

While this doesn't generate an error in the existing runtime, it does cause issues with some external parsers, and should be reported as an error. This PR causes it to be reported as an error.

The rich presence scripts for the following games should be updated to prevent the error from being reported after this code is published.

```
> select ID from GameData where RichPresencePatch like '%0x0x%';
+-------+
| ID    |
+-------+
|  1234 |
|  1572 |
|  2689 |
|  2739 |
|  2831 |
|  3217 |
|  5323 |
|  5376 |
|  6762 |
|  9088 |
|  9966 |
| 10173 |
| 10481 |
| 13049 |
| 13431 |
| 14117 |
| 16276 |
| 20812 |
| 26986 |
| 28593 |
| 28618 |
+-------+
```

There are no occurrences of the pattern in existing achievement or leaderboard definitions.

Also now reporting an error when RP conditionals don't full parse: https://discord.com/channels/310192285306454017/1314383114960633918/1314760614803017778