### PR TITLE
prevent double transform of memref chain

### DIFF
--- a/src/rcheevos/operand.c
+++ b/src/rcheevos/operand.c
@@ -465,6 +465,17 @@ int rc_operand_type_is_memref(uint8_t type) {
   }
 }
 
+int rc_operand_type_is_transform(uint8_t type) {
+  switch (type) {
+    case RC_OPERAND_BCD:
+    case RC_OPERAND_INVERTED:
+      return 1;
+
+    default:
+      return 0;
+  }
+}
+
 int rc_operand_is_memref(const rc_operand_t* self) {
   return rc_operand_type_is_memref(self->type);
 }
@@ -603,9 +614,15 @@ void rc_operand_addsource(rc_operand_t* self, rc_parse_state_t* parse, uint8_t n
 
   self->value.memref = (rc_memref_t*)modified_memref;
 
-  /* if adding a constant, change the type to be address (current value) */
-  if (!rc_operand_is_memref(self))
+  if (!rc_operand_is_memref(self)) {
+    /* if adding a constant, change the type to be address (current value) */
     self->type = self->memref_access_type = RC_OPERAND_ADDRESS;
+  }
+  else if (rc_operand_type_is_transform(self->type)) {
+    /* transform is applied in the modified_memref. change the type to be
+     * address (current value) to avoid applying the transform again */
+    self->type = self->memref_access_type = RC_OPERAND_ADDRESS;
+  }
 
   /* result of an AddSource operation is always a 32-bit integer (even if parent or modifier is a float) */
   self->size = RC_MEMSIZE_32_BITS;

--- a/src/rcheevos/rc_internal.h
+++ b/src/rcheevos/rc_internal.h
@@ -352,6 +352,7 @@ int rc_operand_is_float_memref(const rc_operand_t* self);
 int rc_operand_is_float(const rc_operand_t* self);
 int rc_operand_is_recall(const rc_operand_t* self);
 int rc_operand_type_is_memref(uint8_t type);
+int rc_operand_type_is_transform(uint8_t type);
 int rc_operands_are_equal(const rc_operand_t* left, const rc_operand_t* right);
 void rc_operand_addsource(rc_operand_t* self, rc_parse_state_t* parse, uint8_t new_size);
 void rc_operand_set_const(rc_operand_t* self, uint32_t value);

--- a/test/rcheevos/test_rc_validate.c
+++ b/test/rcheevos/test_rc_validate.c
@@ -363,6 +363,7 @@ void test_redundant_conditions() {
   TEST_PARAMS2(test_validate_trigger, "0xH0000<5_0xH0000<3", "Condition 1: Redundant with Condition 2");
   TEST_PARAMS2(test_validate_trigger, "0xH0000=1S0xH0000=1", "Alt1 Condition 1: Redundant with Core Condition 1");
   TEST_PARAMS2(test_validate_trigger, "R:0xH0000=1_0xH0000!=1", "Condition 2: Redundant with Condition 1");
+  TEST_PARAMS2(test_validate_trigger, "R:0xH0000!=1_0xH0000!=0", "Condition 2: Redundant with Condition 1"); /* condition 1 effectively 0xH0000=1 */
   TEST_PARAMS2(test_validate_trigger, "R:0xH0000=1_0xH0000=2", "");
   TEST_PARAMS2(test_validate_trigger, "R:0xH0000=1_T:0xH0000=2", "");
   TEST_PARAMS2(test_validate_trigger, "0xH0000=1_R:0xH0000!=1", "Condition 1: Redundant with Condition 2");


### PR DESCRIPTION
The `modified_memref` chain for "bcd(X) + bcd(Y)" has already performed the BCD conversion, so the condition "bcd(Y) > N" should not apply the BCD transform again after reading the composite value.