### PR TITLE
add avatar_url to login response, achievement_info response, and leaderboard_info responses

### DIFF
--- a/include/rc_api_info.h
+++ b/include/rc_api_info.h
@@ -33,6 +33,8 @@ rc_api_fetch_achievement_info_request_t;
 typedef struct rc_api_achievement_awarded_entry_t {
   /* The user associated to the entry */
   const char* username;
+  /* A URL to the user's avatar image */
+  const char* avatar_url;
   /* When the achievement was awarded */
   time_t awarded;
 }
@@ -88,6 +90,8 @@ rc_api_fetch_leaderboard_info_request_t;
 typedef struct rc_api_lboard_info_entry_t {
   /* The user associated to the entry */
   const char* username;
+  /* A URL to the user's avatar image */
+  const char* avatar_url;
   /* The rank of the entry */
   uint32_t rank;
   /* The index of the entry */

--- a/include/rc_api_user.h
+++ b/include/rc_api_user.h
@@ -40,6 +40,8 @@ typedef struct rc_api_login_response_t {
   uint32_t num_unread_messages;
   /* The preferred name to display for the player */
   const char* display_name;
+  /* A URL to the user's avatar image */
+  const char* avatar_url;
 
   /* Common server-provided response information */
   rc_api_response_t response;

--- a/include/rc_client.h
+++ b/include/rc_client.h
@@ -188,6 +188,7 @@ typedef struct rc_client_user_t {
   uint32_t score;
   uint32_t score_softcore;
   uint32_t num_unread_messages;
+  const char* avatar_url;
 } rc_client_user_t;
 
 /**

--- a/src/rapi/rc_api_common.c
+++ b/src/rapi/rc_api_common.c
@@ -1270,3 +1270,19 @@ int rc_api_init_fetch_image_request(rc_api_request_t* request, const rc_api_fetc
 
   return builder.result;
 }
+
+const char* rc_api_build_avatar_url(rc_buffer_t* buffer, const char* username) {
+  rc_api_fetch_image_request_t image_request;
+  rc_api_request_t request;
+  int result;
+
+  memset(&image_request, 0, sizeof(image_request));
+  image_request.image_type = RC_IMAGE_TYPE_USER;
+  image_request.image_name = username;
+
+  result = rc_api_init_fetch_image_request(&request, &image_request);
+  if (result == RC_OK)
+    return rc_buffer_strcpy(buffer, request.url);
+
+  return NULL;
+}

--- a/src/rapi/rc_api_common.h
+++ b/src/rapi/rc_api_common.h
@@ -77,6 +77,8 @@ void rc_url_builder_append_str_param(rc_api_url_builder_t* builder, const char* 
 void rc_api_url_build_dorequest_url(rc_api_request_t* request);
 int rc_api_url_build_dorequest(rc_api_url_builder_t* builder, const char* api, const char* username, const char* api_token);
 
+const char* rc_api_build_avatar_url(rc_buffer_t* buffer, const char* username);
+
 RC_END_C_DECLS
 
 #endif /* RC_API_COMMON_H */

--- a/src/rapi/rc_api_info.c
+++ b/src/rapi/rc_api_info.c
@@ -73,7 +73,8 @@ int rc_api_process_fetch_achievement_info_server_response(rc_api_fetch_achieveme
 
   rc_json_field_t entry_fields[] = {
     RC_JSON_NEW_FIELD("User"),
-    RC_JSON_NEW_FIELD("DateAwarded")
+    RC_JSON_NEW_FIELD("DateAwarded"),
+    RC_JSON_NEW_FIELD("AvatarUrl")
   };
 
   memset(response, 0, sizeof(*response));
@@ -115,6 +116,10 @@ int rc_api_process_fetch_achievement_info_server_response(rc_api_fetch_achieveme
       if (!rc_json_get_required_unum(&timet, &response->response, &entry_fields[1], "DateAwarded"))
         return RC_MISSING_VALUE;
       entry->awarded = (time_t)timet;
+
+      rc_json_get_optional_string(&entry->avatar_url, &response->response, &entry_fields[2], "AvatarUrl", NULL);
+      if (!entry->avatar_url)
+        entry->avatar_url = rc_api_build_avatar_url(&response->response.buffer, entry->username);
 
       ++entry;
     }
@@ -191,13 +196,6 @@ int rc_api_process_fetch_leaderboard_info_server_response(rc_api_fetch_leaderboa
     RC_JSON_NEW_FIELD("LBUpdated"),
     RC_JSON_NEW_FIELD("Entries"), /* array */
     RC_JSON_NEW_FIELD("TotalEntries")
-    /* unused fields
-    RC_JSON_NEW_FIELD("GameTitle"),
-    RC_JSON_NEW_FIELD("ConsoleID"),
-    RC_JSON_NEW_FIELD("ConsoleName"),
-    RC_JSON_NEW_FIELD("ForumTopicID"),
-    RC_JSON_NEW_FIELD("GameIcon")
-     * unused fields */
   };
 
   rc_json_field_t entry_fields[] = {
@@ -205,7 +203,8 @@ int rc_api_process_fetch_leaderboard_info_server_response(rc_api_fetch_leaderboa
     RC_JSON_NEW_FIELD("Rank"),
     RC_JSON_NEW_FIELD("Index"),
     RC_JSON_NEW_FIELD("Score"),
-    RC_JSON_NEW_FIELD("DateSubmitted")
+    RC_JSON_NEW_FIELD("DateSubmitted"),
+    RC_JSON_NEW_FIELD("AvatarUrl")
   };
 
   memset(response, 0, sizeof(*response));
@@ -280,6 +279,10 @@ int rc_api_process_fetch_leaderboard_info_server_response(rc_api_fetch_leaderboa
       if (!rc_json_get_required_unum(&timet, &response->response, &entry_fields[4], "DateSubmitted"))
         return RC_MISSING_VALUE;
       entry->submitted = (time_t)timet;
+
+      rc_json_get_optional_string(&entry->avatar_url, &response->response, &entry_fields[5], "AvatarUrl", NULL);
+      if (!entry->avatar_url)
+        entry->avatar_url = rc_api_build_avatar_url(&response->response.buffer, entry->username);
 
       ++entry;
     }

--- a/src/rapi/rc_api_user.c
+++ b/src/rapi/rc_api_user.c
@@ -53,7 +53,7 @@ int rc_api_process_login_server_response(rc_api_login_response_t* response, cons
     RC_JSON_NEW_FIELD("Score"),
     RC_JSON_NEW_FIELD("SoftcoreScore"),
     RC_JSON_NEW_FIELD("Messages"),
-    RC_JSON_NEW_FIELD("DisplayName")
+    RC_JSON_NEW_FIELD("AvatarUrl")
   };
 
   memset(response, 0, sizeof(*response));
@@ -72,7 +72,14 @@ int rc_api_process_login_server_response(rc_api_login_response_t* response, cons
   rc_json_get_optional_unum(&response->score_softcore, &fields[6], "SoftcoreScore", 0);
   rc_json_get_optional_unum(&response->num_unread_messages, &fields[7], "Messages", 0);
 
-  rc_json_get_optional_string(&response->display_name, &response->response, &fields[8], "DisplayName", response->username);
+  /* For the highest level of backwards compatibility, we have decided to just send the
+   * display_name back to the client as the "case-corrected username", and allow it to
+   * be used as the Username field for the other APIs. */
+  response->display_name = response->username;
+
+  rc_json_get_optional_string(&response->avatar_url, &response->response, &fields[8], "AvatarUrl", NULL);
+  if (!response->avatar_url)
+    response->avatar_url = rc_api_build_avatar_url(&response->response.buffer, response->username);
 
   return RC_OK;
 }

--- a/src/rc_client.c
+++ b/src/rc_client.c
@@ -702,6 +702,7 @@ static void rc_client_login_callback(const rc_api_server_response_t* server_resp
     else
       client->user.display_name = rc_buffer_strcpy(&client->state.buffer, login_response.display_name);
 
+    client->user.avatar_url = rc_buffer_strcpy(&client->state.buffer, login_response.avatar_url);
     client->user.token = rc_buffer_strcpy(&client->state.buffer, login_response.api_token);
     client->user.score = login_response.score;
     client->user.score_softcore = login_response.score_softcore;
@@ -896,6 +897,11 @@ int rc_client_user_get_image_url(const rc_client_user_t* user, char buffer[], si
 {
   if (!user)
     return RC_INVALID_STATE;
+
+  if (user->avatar_url) {
+    snprintf(buffer, buffer_size, "%s", user->avatar_url);
+    return RC_OK;
+  }
 
   return rc_client_get_image_url(buffer, buffer_size, RC_IMAGE_TYPE_USER, user->display_name);
 }

--- a/test/rapi/test_rc_api_info.c
+++ b/test/rapi/test_rc_api_info.c
@@ -86,7 +86,7 @@ static void test_process_fetch_achievement_info_response() {
   rc_api_achievement_awarded_entry_t* entry;
   const char* server_response = "{\"Success\":true,\"AchievementID\":1234,\"Response\":{"
 	  "\"NumEarned\":17,\"GameID\":2345,\"TotalPlayers\":25,"
-	  "\"RecentWinner\":[{\"User\":\"Player1\",\"DateAwarded\":1615654895},"
+	  "\"RecentWinner\":[{\"User\":\"Player1\",\"DateAwarded\":1615654895,\"AvatarUrl\":\"http://host/UserPic/PLAYER1.png\"},"
                         "{\"User\":\"Player2\",\"DateAwarded\":1600604303}]"
 	  "}}";
 
@@ -104,9 +104,11 @@ static void test_process_fetch_achievement_info_response() {
   entry = &fetch_achievement_info_response.recently_awarded[0];
   ASSERT_STR_EQUALS(entry->username, "Player1");
   ASSERT_NUM_EQUALS(entry->awarded, 1615654895);
+  ASSERT_STR_EQUALS(entry->avatar_url, "http://host/UserPic/PLAYER1.png");
   entry = &fetch_achievement_info_response.recently_awarded[1];
   ASSERT_STR_EQUALS(entry->username, "Player2");
   ASSERT_NUM_EQUALS(entry->awarded, 1600604303);
+  ASSERT_STR_EQUALS(entry->avatar_url, "https://media.retroachievements.org/UserPic/Player2.png");
 
   rc_api_destroy_fetch_achievement_info_response(&fetch_achievement_info_response);
 }
@@ -186,7 +188,7 @@ static void test_process_fetch_leaderboard_info_response() {
 	  "\"LowerIsBetter\":1,\"LBTitle\":\"Title\",\"LBDesc\":\"Description\",\"LBFormat\":\"TIME\","
 	  "\"LBMem\":\"STA:0xH0000=1::CAN:1=1::SUB:0xH0000=2::VAL:b0x 0004\",\"LBAuthor\":null,"
 	  "\"LBCreated\":\"2013-10-20 22:12:21\",\"LBUpdated\":\"2021-06-14 08:18:19\",\"TotalEntries\":12,"
-	  "\"Entries\":[{\"User\":\"Player1\",\"Score\":8765,\"Rank\":1,\"Index\":5,\"DateSubmitted\":1615654895},"
+	  "\"Entries\":[{\"User\":\"Player1\",\"Score\":8765,\"Rank\":1,\"Index\":5,\"DateSubmitted\":1615654895,\"AvatarUrl\":\"http://host/UserPic/PLAYER1.png\"},"
                    "{\"User\":\"Player2\",\"Score\":7654,\"Rank\":2,\"Index\":6,\"DateSubmitted\":1600604303}]"
 	  "}}";
 
@@ -213,12 +215,14 @@ static void test_process_fetch_leaderboard_info_response() {
   ASSERT_STR_EQUALS(entry->username, "Player1");
   ASSERT_NUM_EQUALS(entry->score, 8765);
   ASSERT_NUM_EQUALS(entry->submitted, 1615654895);
+  ASSERT_STR_EQUALS(entry->avatar_url, "http://host/UserPic/PLAYER1.png");
   entry = &fetch_leaderboard_info_response.entries[1];
   ASSERT_NUM_EQUALS(entry->rank, 2);
   ASSERT_NUM_EQUALS(entry->index, 6);
   ASSERT_STR_EQUALS(entry->username, "Player2");
   ASSERT_NUM_EQUALS(entry->score, 7654);
   ASSERT_NUM_EQUALS(entry->submitted, 1600604303);
+  ASSERT_STR_EQUALS(entry->avatar_url, "https://media.retroachievements.org/UserPic/Player2.png");
 
   rc_api_destroy_fetch_leaderboard_info_response(&fetch_leaderboard_info_response);
 }

--- a/test/rapi/test_rc_api_user.c
+++ b/test/rapi/test_rc_api_user.c
@@ -294,19 +294,20 @@ static void test_process_login_response_success()
 static void test_process_login_response_unique_display_name()
 {
   rc_api_login_response_t login_response;
-  const char* server_response = "{\"Success\":true,\"User\":\"USER\",\"DisplayName\":\"Gaming Hero\",\"Token\":\"ApiTOKEN\",\"Score\":1234,\"SoftcoreScore\":789,\"Messages\":2}";
+  const char* server_response = "{\"Success\":true,\"User\":\"GamingHero\",\"AvatarUrl\":\"http://host/UserPic/USER.png\",\"Token\":\"ApiTOKEN\",\"Score\":1234,\"SoftcoreScore\":789,\"Messages\":2}";
 
   memset(&login_response, 0, sizeof(login_response));
 
   ASSERT_NUM_EQUALS(rc_api_process_login_response(&login_response, server_response), RC_OK);
   ASSERT_NUM_EQUALS(login_response.response.succeeded, 1);
   ASSERT_PTR_NULL(login_response.response.error_message);
-  ASSERT_STR_EQUALS(login_response.username, "USER");
+  ASSERT_STR_EQUALS(login_response.username, "GamingHero");
   ASSERT_STR_EQUALS(login_response.api_token, "ApiTOKEN");
   ASSERT_NUM_EQUALS(login_response.score, 1234);
   ASSERT_NUM_EQUALS(login_response.score_softcore, 789);
   ASSERT_NUM_EQUALS(login_response.num_unread_messages, 2);
-  ASSERT_STR_EQUALS(login_response.display_name, "Gaming Hero");
+  ASSERT_STR_EQUALS(login_response.display_name, "GamingHero");
+  ASSERT_STR_EQUALS(login_response.avatar_url, "http://host/UserPic/USER.png");
 
   rc_api_destroy_login_response(&login_response);
 }

--- a/test/test_rc_client.c
+++ b/test/test_rc_client.c
@@ -635,6 +635,7 @@ static rc_client_t* mock_client_logged_in(void)
   client->user.display_name = "DisplayName";
   client->user.token = "ApiToken";
   client->user.score = 12345;
+  client->user.avatar_url = "http://host/UserPic/Username.png";
   client->state.user = RC_CLIENT_USER_STATE_LOGGED_IN;
 
   return client;
@@ -717,15 +718,16 @@ static void test_login_with_token(void)
   g_client = mock_client_not_logged_in();
   reset_mock_api_handlers();
   mock_api_response("r=login2&u=User&t=ApiToken",
-	  "{\"Success\":true,\"User\":\"User\",\"DisplayName\":\"Display\",\"Token\":\"ApiToken\",\"Score\":12345,\"Messages\":2}");
+	  "{\"Success\":true,\"User\":\"User\",\"AvatarUrl\":\"http://host/UserPic/USER.png\",\"Token\":\"ApiToken\",\"Score\":12345,\"Messages\":2}");
 
   rc_client_begin_login_with_token(g_client, "User", "ApiToken", rc_client_callback_expect_success, g_callback_userdata);
 
   user = rc_client_get_user_info(g_client);
   ASSERT_PTR_NOT_NULL(user);
   ASSERT_STR_EQUALS(user->username, "User");
-  ASSERT_STR_EQUALS(user->display_name, "Display");
+  ASSERT_STR_EQUALS(user->display_name, "User");
   ASSERT_STR_EQUALS(user->token, "ApiToken");
+  ASSERT_STR_EQUALS(user->avatar_url, "http://host/UserPic/USER.png");
   ASSERT_NUM_EQUALS(user->score, 12345);
   ASSERT_NUM_EQUALS(user->num_unread_messages, 2);
 
@@ -1088,9 +1090,10 @@ static void test_user_get_image_url(void)
 {
   char buffer[256];
   g_client = mock_client_game_loaded(patchdata_2ach_1lbd, no_unlocks);
+  ASSERT_STR_EQUALS(g_client->user.avatar_url, "http://host/UserPic/Username.png");
 
   ASSERT_NUM_EQUALS(rc_client_user_get_image_url(rc_client_get_user_info(g_client), buffer, sizeof(buffer)), RC_OK);
-  ASSERT_STR_EQUALS(buffer, "https://media.retroachievements.org/UserPic/DisplayName.png");
+  ASSERT_STR_EQUALS(buffer, "http://host/UserPic/Username.png");
 
   rc_client_destroy(g_client);
 }


### PR DESCRIPTION
Provides plumbing to support https://github.com/RetroAchievements/RAWeb/pull/3017

`rc_api_process_login_server_response`, `rc_api_process_fetch_achievement_info_server_response`, and `rc_api_process_fetch_leaderboard_info_server_response` now return `avatar_url` fields beside the `username` field. These should be used instead of calling `rc_api_init_fetch_image_request` with the `username`, as the avatar URL for a user who has changed their display name will not match and the default avatar image will be downloaded instead.

`rc_client_user_get_image_url` will automatically leverage the new `avatar_url` data. Clients using `rc_api_init_fetch_image_request` directly to fetch user images for any purpose should switch to use the `avatar_url` value instead.

If the server doesn't provide an `avatar_url` (for the brief period until the above PR is deployed), it will be constructed in the same manner as was previously handled by `rc_api_init_fetch_image_request`.

