### PR TITLE
Create overloads for API init functions to specify custom hosts.

### DIFF
--- a/include/rc_api_editor.h
+++ b/include/rc_api_editor.h
@@ -43,6 +43,7 @@ typedef struct rc_api_fetch_code_notes_response_t {
 rc_api_fetch_code_notes_response_t;
 
 RC_EXPORT int RC_CCONV rc_api_init_fetch_code_notes_request(rc_api_request_t* request, const rc_api_fetch_code_notes_request_t* api_params);
+RC_EXPORT int RC_CCONV rc_api_init_fetch_code_notes_request_hosted(rc_api_request_t* request, const rc_api_fetch_code_notes_request_t* api_params, const rc_api_host_t* host);
 /* [deprecated] use rc_api_process_fetch_code_notes_server_response instead */
 RC_EXPORT int RC_CCONV rc_api_process_fetch_code_notes_response(rc_api_fetch_code_notes_response_t* response, const char* server_response);
 RC_EXPORT int RC_CCONV rc_api_process_fetch_code_notes_server_response(rc_api_fetch_code_notes_response_t* response, const rc_api_server_response_t* server_response);
@@ -77,6 +78,7 @@ typedef struct rc_api_update_code_note_response_t {
 rc_api_update_code_note_response_t;
 
 RC_EXPORT int RC_CCONV rc_api_init_update_code_note_request(rc_api_request_t* request, const rc_api_update_code_note_request_t* api_params);
+RC_EXPORT int RC_CCONV rc_api_init_update_code_note_request_hosted(rc_api_request_t* request, const rc_api_update_code_note_request_t* api_params, const rc_api_host_t* host);
 /* [deprecated] use rc_api_process_update_code_note_server_response instead */
 RC_EXPORT int RC_CCONV rc_api_process_update_code_note_response(rc_api_update_code_note_response_t* response, const char* server_response);
 RC_EXPORT int RC_CCONV rc_api_process_update_code_note_server_response(rc_api_update_code_note_response_t* response, const rc_api_server_response_t* server_response);
@@ -126,6 +128,7 @@ typedef struct rc_api_update_achievement_response_t {
 rc_api_update_achievement_response_t;
 
 RC_EXPORT int RC_CCONV rc_api_init_update_achievement_request(rc_api_request_t* request, const rc_api_update_achievement_request_t* api_params);
+RC_EXPORT int RC_CCONV rc_api_init_update_achievement_request_hosted(rc_api_request_t* request, const rc_api_update_achievement_request_t* api_params, const rc_api_host_t* host);
 /* [deprecated] use rc_api_process_update_achievement_server_response instead */
 RC_EXPORT int RC_CCONV rc_api_process_update_achievement_response(rc_api_update_achievement_response_t* response, const char* server_response);
 RC_EXPORT int RC_CCONV rc_api_process_update_achievement_server_response(rc_api_update_achievement_response_t* response, const rc_api_server_response_t* server_response);
@@ -177,6 +180,7 @@ typedef struct rc_api_update_leaderboard_response_t {
 rc_api_update_leaderboard_response_t;
 
 RC_EXPORT int RC_CCONV rc_api_init_update_leaderboard_request(rc_api_request_t* request, const rc_api_update_leaderboard_request_t* api_params);
+RC_EXPORT int RC_CCONV rc_api_init_update_leaderboard_request_hosted(rc_api_request_t* request, const rc_api_update_leaderboard_request_t* api_params, const rc_api_host_t* host);
 /* [deprecated] use rc_api_process_update_leaderboard_server_response instead */
 RC_EXPORT int RC_CCONV rc_api_process_update_leaderboard_response(rc_api_update_leaderboard_response_t* response, const char* server_response);
 RC_EXPORT int RC_CCONV rc_api_process_update_leaderboard_server_response(rc_api_update_leaderboard_response_t* response, const rc_api_server_response_t* server_response);
@@ -208,6 +212,7 @@ typedef struct rc_api_fetch_badge_range_response_t {
 rc_api_fetch_badge_range_response_t;
 
 RC_EXPORT int RC_CCONV rc_api_init_fetch_badge_range_request(rc_api_request_t* request, const rc_api_fetch_badge_range_request_t* api_params);
+RC_EXPORT int RC_CCONV rc_api_init_fetch_badge_range_request_hosted(rc_api_request_t* request, const rc_api_fetch_badge_range_request_t* api_params, const rc_api_host_t* host);
 /* [deprecated] use rc_api_process_fetch_badge_range_server_response instead */
 RC_EXPORT int RC_CCONV rc_api_process_fetch_badge_range_response(rc_api_fetch_badge_range_response_t* response, const char* server_response);
 RC_EXPORT int RC_CCONV rc_api_process_fetch_badge_range_server_response(rc_api_fetch_badge_range_response_t* response, const rc_api_server_response_t* server_response);
@@ -249,6 +254,7 @@ typedef struct rc_api_add_game_hash_response_t {
 rc_api_add_game_hash_response_t;
 
 RC_EXPORT int RC_CCONV rc_api_init_add_game_hash_request(rc_api_request_t* request, const rc_api_add_game_hash_request_t* api_params);
+RC_EXPORT int RC_CCONV rc_api_init_add_game_hash_request_hosted(rc_api_request_t* request, const rc_api_add_game_hash_request_t* api_params, const rc_api_host_t* host);
 /* [deprecated] use rc_api_process_add_game_hash_server_response instead */
 RC_EXPORT int RC_CCONV rc_api_process_add_game_hash_response(rc_api_add_game_hash_response_t* response, const char* server_response);
 RC_EXPORT int RC_CCONV rc_api_process_add_game_hash_server_response(rc_api_add_game_hash_response_t* response, const rc_api_server_response_t* server_response);

--- a/include/rc_api_info.h
+++ b/include/rc_api_info.h
@@ -64,6 +64,7 @@ typedef struct rc_api_fetch_achievement_info_response_t {
 rc_api_fetch_achievement_info_response_t;
 
 RC_EXPORT int RC_CCONV rc_api_init_fetch_achievement_info_request(rc_api_request_t* request, const rc_api_fetch_achievement_info_request_t* api_params);
+RC_EXPORT int RC_CCONV rc_api_init_fetch_achievement_info_request_hosted(rc_api_request_t* request, const rc_api_fetch_achievement_info_request_t* api_params, const rc_api_host_t* host);
 /* [deprecated] use rc_api_process_fetch_achievement_info_server_response instead */
 RC_EXPORT int RC_CCONV rc_api_process_fetch_achievement_info_response(rc_api_fetch_achievement_info_response_t* response, const char* server_response);
 RC_EXPORT int RC_CCONV rc_api_process_fetch_achievement_info_server_response(rc_api_fetch_achievement_info_response_t* response, const rc_api_server_response_t* server_response);
@@ -142,6 +143,7 @@ typedef struct rc_api_fetch_leaderboard_info_response_t {
 rc_api_fetch_leaderboard_info_response_t;
 
 RC_EXPORT int RC_CCONV rc_api_init_fetch_leaderboard_info_request(rc_api_request_t* request, const rc_api_fetch_leaderboard_info_request_t* api_params);
+RC_EXPORT int RC_CCONV rc_api_init_fetch_leaderboard_info_request_hosted(rc_api_request_t* request, const rc_api_fetch_leaderboard_info_request_t* api_params, const rc_api_host_t* host);
 /* [deprecated] use rc_api_process_fetch_leaderboard_info_server_response instead */
 RC_EXPORT int RC_CCONV rc_api_process_fetch_leaderboard_info_response(rc_api_fetch_leaderboard_info_response_t* response, const char* server_response);
 RC_EXPORT int RC_CCONV rc_api_process_fetch_leaderboard_info_server_response(rc_api_fetch_leaderboard_info_response_t* response, const rc_api_server_response_t* server_response);
@@ -182,6 +184,7 @@ typedef struct rc_api_fetch_games_list_response_t {
 rc_api_fetch_games_list_response_t;
 
 RC_EXPORT int RC_CCONV rc_api_init_fetch_games_list_request(rc_api_request_t* request, const rc_api_fetch_games_list_request_t* api_params);
+RC_EXPORT int RC_CCONV rc_api_init_fetch_games_list_request_hosted(rc_api_request_t* request, const rc_api_fetch_games_list_request_t* api_params, const rc_api_host_t* host);
 /* [deprecated] use rc_api_process_fetch_games_list_server_response instead */
 RC_EXPORT int RC_CCONV rc_api_process_fetch_games_list_response(rc_api_fetch_games_list_response_t* response, const char* server_response);
 RC_EXPORT int RC_CCONV rc_api_process_fetch_games_list_server_response(rc_api_fetch_games_list_response_t* response, const rc_api_server_response_t* server_response);
@@ -226,6 +229,7 @@ typedef struct rc_api_fetch_game_titles_response_t {
 rc_api_fetch_game_titles_response_t;
 
 RC_EXPORT int RC_CCONV rc_api_init_fetch_game_titles_request(rc_api_request_t* request, const rc_api_fetch_game_titles_request_t* api_params);
+RC_EXPORT int RC_CCONV rc_api_init_fetch_game_titles_request_hosted(rc_api_request_t* request, const rc_api_fetch_game_titles_request_t* api_params, const rc_api_host_t* host);
 RC_EXPORT int RC_CCONV rc_api_process_fetch_game_titles_server_response(rc_api_fetch_game_titles_response_t* response, const rc_api_server_response_t* server_response);
 RC_EXPORT void RC_CCONV rc_api_destroy_fetch_game_titles_response(rc_api_fetch_game_titles_response_t* response);
 

--- a/include/rc_api_request.h
+++ b/include/rc_api_request.h
@@ -9,6 +9,17 @@
 RC_BEGIN_C_DECLS
 
 /**
+ * Information about the server being connected to.
+ */
+typedef struct rc_api_host_t {
+  /* The host name for the API calls (retroachievements.org) */
+  const char* host;
+  /* The host name for media URLs (media.retroachievements.org) */
+  const char* media_host;
+}
+rc_api_host_t;
+
+/**
  * A constructed request to send to the retroachievements server.
  */
 typedef struct rc_api_request_t {
@@ -42,7 +53,9 @@ rc_api_response_t;
 
 RC_EXPORT void RC_CCONV rc_api_destroy_request(rc_api_request_t* request);
 
+/* [deprecated] use rc_api_init_*_hosted instead */
 RC_EXPORT void RC_CCONV rc_api_set_host(const char* hostname);
+/* [deprecated] use rc_api_init_*_hosted instead */
 RC_EXPORT void RC_CCONV rc_api_set_image_host(const char* hostname);
 
 typedef struct rc_api_server_response_t {

--- a/include/rc_api_runtime.h
+++ b/include/rc_api_runtime.h
@@ -28,6 +28,7 @@ rc_api_fetch_image_request_t;
 #define RC_IMAGE_TYPE_USER 4
 
 RC_EXPORT int RC_CCONV rc_api_init_fetch_image_request(rc_api_request_t* request, const rc_api_fetch_image_request_t* api_params);
+RC_EXPORT int RC_CCONV rc_api_init_fetch_image_request_hosted(rc_api_request_t* request, const rc_api_fetch_image_request_t* api_params, const rc_api_host_t* host);
 
 /* --- Resolve Hash --- */
 
@@ -57,6 +58,8 @@ typedef struct rc_api_resolve_hash_response_t {
 rc_api_resolve_hash_response_t;
 
 RC_EXPORT int RC_CCONV rc_api_init_resolve_hash_request(rc_api_request_t* request, const rc_api_resolve_hash_request_t* api_params);
+RC_EXPORT int RC_CCONV rc_api_init_resolve_hash_request_hosted(rc_api_request_t* request, const rc_api_resolve_hash_request_t* api_params, const rc_api_host_t* host);
+/* [deprecated] use rc_api_process_resolve_hash_server_response instead */
 RC_EXPORT int RC_CCONV rc_api_process_resolve_hash_response(rc_api_resolve_hash_response_t* response, const char* server_response);
 RC_EXPORT int RC_CCONV rc_api_process_resolve_hash_server_response(rc_api_resolve_hash_response_t* response, const rc_api_server_response_t* server_response);
 RC_EXPORT void RC_CCONV rc_api_destroy_resolve_hash_response(rc_api_resolve_hash_response_t* response);
@@ -201,6 +204,8 @@ typedef struct rc_api_fetch_game_data_response_t {
 rc_api_fetch_game_data_response_t;
 
 RC_EXPORT int RC_CCONV rc_api_init_fetch_game_data_request(rc_api_request_t* request, const rc_api_fetch_game_data_request_t* api_params);
+RC_EXPORT int RC_CCONV rc_api_init_fetch_game_data_request_hosted(rc_api_request_t* request, const rc_api_fetch_game_data_request_t* api_params, const rc_api_host_t* host);
+/* [deprecated] use rc_api_process_fetch_game_data_server_response instead */
 RC_EXPORT int RC_CCONV rc_api_process_fetch_game_data_response(rc_api_fetch_game_data_response_t* response, const char* server_response);
 RC_EXPORT int RC_CCONV rc_api_process_fetch_game_data_server_response(rc_api_fetch_game_data_response_t* response, const rc_api_server_response_t* server_response);
 RC_EXPORT void RC_CCONV rc_api_destroy_fetch_game_data_response(rc_api_fetch_game_data_response_t* response);
@@ -236,6 +241,8 @@ typedef struct rc_api_ping_response_t {
 rc_api_ping_response_t;
 
 RC_EXPORT int RC_CCONV rc_api_init_ping_request(rc_api_request_t* request, const rc_api_ping_request_t* api_params);
+RC_EXPORT int RC_CCONV rc_api_init_ping_request_hosted(rc_api_request_t* request, const rc_api_ping_request_t* api_params, const rc_api_host_t* host);
+/* [deprecated] use rc_api_process_ping_server_response instead */
 RC_EXPORT int RC_CCONV rc_api_process_ping_response(rc_api_ping_response_t* response, const char* server_response);
 RC_EXPORT int RC_CCONV rc_api_process_ping_server_response(rc_api_ping_response_t* response, const rc_api_server_response_t* server_response);
 RC_EXPORT void RC_CCONV rc_api_destroy_ping_response(rc_api_ping_response_t* response);
@@ -281,6 +288,8 @@ typedef struct rc_api_award_achievement_response_t {
 rc_api_award_achievement_response_t;
 
 RC_EXPORT int RC_CCONV rc_api_init_award_achievement_request(rc_api_request_t* request, const rc_api_award_achievement_request_t* api_params);
+RC_EXPORT int RC_CCONV rc_api_init_award_achievement_request_hosted(rc_api_request_t* request, const rc_api_award_achievement_request_t* api_params, const rc_api_host_t* host);
+/* [deprecated] use rc_api_process_award_achievement_server_response instead */
 RC_EXPORT int RC_CCONV rc_api_process_award_achievement_response(rc_api_award_achievement_response_t* response, const char* server_response);
 RC_EXPORT int RC_CCONV rc_api_process_award_achievement_server_response(rc_api_award_achievement_response_t* response, const rc_api_server_response_t* server_response);
 RC_EXPORT void RC_CCONV rc_api_destroy_award_achievement_response(rc_api_award_achievement_response_t* response);
@@ -341,6 +350,8 @@ typedef struct rc_api_submit_lboard_entry_response_t {
 rc_api_submit_lboard_entry_response_t;
 
 RC_EXPORT int RC_CCONV rc_api_init_submit_lboard_entry_request(rc_api_request_t* request, const rc_api_submit_lboard_entry_request_t* api_params);
+RC_EXPORT int RC_CCONV rc_api_init_submit_lboard_entry_request_hosted(rc_api_request_t* request, const rc_api_submit_lboard_entry_request_t* api_params, const rc_api_host_t* host);
+/* [deprecated] use rc_api_process_submit_lboard_entry_server_response instead */
 RC_EXPORT int RC_CCONV rc_api_process_submit_lboard_entry_response(rc_api_submit_lboard_entry_response_t* response, const char* server_response);
 RC_EXPORT int RC_CCONV rc_api_process_submit_lboard_entry_server_response(rc_api_submit_lboard_entry_response_t* response, const rc_api_server_response_t* server_response);
 RC_EXPORT void RC_CCONV rc_api_destroy_submit_lboard_entry_response(rc_api_submit_lboard_entry_response_t* response);

--- a/include/rc_api_user.h
+++ b/include/rc_api_user.h
@@ -49,6 +49,7 @@ typedef struct rc_api_login_response_t {
 rc_api_login_response_t;
 
 RC_EXPORT int RC_CCONV rc_api_init_login_request(rc_api_request_t* request, const rc_api_login_request_t* api_params);
+RC_EXPORT int RC_CCONV rc_api_init_login_request_hosted(rc_api_request_t* request, const rc_api_login_request_t* api_params, const rc_api_host_t* host);
 /* [deprecated] use rc_api_process_login_server_response instead */
 RC_EXPORT int RC_CCONV rc_api_process_login_response(rc_api_login_response_t* response, const char* server_response);
 RC_EXPORT int RC_CCONV rc_api_process_login_server_response(rc_api_login_response_t* response, const rc_api_server_response_t* server_response);
@@ -107,6 +108,7 @@ typedef struct rc_api_start_session_response_t {
 rc_api_start_session_response_t;
 
 RC_EXPORT int RC_CCONV rc_api_init_start_session_request(rc_api_request_t* request, const rc_api_start_session_request_t* api_params);
+RC_EXPORT int RC_CCONV rc_api_init_start_session_request_hosted(rc_api_request_t* request, const rc_api_start_session_request_t* api_params, const rc_api_host_t* host);
 /* [deprecated] use rc_api_process_start_session_server_response instead */
 RC_EXPORT int RC_CCONV rc_api_process_start_session_response(rc_api_start_session_response_t* response, const char* server_response);
 RC_EXPORT int RC_CCONV rc_api_process_start_session_server_response(rc_api_start_session_response_t* response, const rc_api_server_response_t* server_response);
@@ -144,6 +146,7 @@ typedef struct rc_api_fetch_user_unlocks_response_t {
 rc_api_fetch_user_unlocks_response_t;
 
 RC_EXPORT int RC_CCONV rc_api_init_fetch_user_unlocks_request(rc_api_request_t* request, const rc_api_fetch_user_unlocks_request_t* api_params);
+RC_EXPORT int RC_CCONV rc_api_init_fetch_user_unlocks_request_hosted(rc_api_request_t* request, const rc_api_fetch_user_unlocks_request_t* api_params, const rc_api_host_t* host);
 /* [deprecated] use rc_api_process_fetch_user_unlocks_server_response instead */
 RC_EXPORT int RC_CCONV rc_api_process_fetch_user_unlocks_response(rc_api_fetch_user_unlocks_response_t* response, const char* server_response);
 RC_EXPORT int RC_CCONV rc_api_process_fetch_user_unlocks_server_response(rc_api_fetch_user_unlocks_response_t* response, const rc_api_server_response_t* server_response);

--- a/include/rc_client.h
+++ b/include/rc_client.h
@@ -121,7 +121,7 @@ RC_EXPORT void* RC_CCONV rc_client_get_userdata(const rc_client_t* client);
 /**
  * Sets the name of the server to use.
  */
-RC_EXPORT void RC_CCONV rc_client_set_host(const rc_client_t* client, const char* hostname);
+RC_EXPORT void RC_CCONV rc_client_set_host(rc_client_t* client, const char* hostname);
 
 typedef uint64_t rc_clock_t;
 typedef rc_clock_t (RC_CCONV *rc_get_time_millisecs_func_t)(const rc_client_t* client);

--- a/src/rapi/rc_api_common.c
+++ b/src/rapi/rc_api_common.c
@@ -1173,9 +1173,9 @@ int rc_api_url_build_dorequest(rc_api_url_builder_t* builder, const char* api, c
 
 /* --- Set Host --- */
 
-static void rc_api_update_host(char** host, const char* hostname) {
+static void rc_api_update_host(const char** host, const char* hostname) {
   if (*host != NULL)
-    free(*host);
+    free((void*)*host);
 
   if (hostname != NULL) {
     if (strstr(hostname, "://")) {

--- a/src/rapi/rc_api_common.c
+++ b/src/rapi/rc_api_common.c
@@ -13,8 +13,7 @@
 #define RETROACHIEVEMENTS_IMAGE_HOST "https://media.retroachievements.org"
 #define RETROACHIEVEMENTS_HOST_NONSSL "http://retroachievements.org"
 #define RETROACHIEVEMENTS_IMAGE_HOST_NONSSL "http://media.retroachievements.org"
-static char* g_host = NULL;
-static char* g_imagehost = NULL;
+rc_api_host_t g_host = { NULL, NULL };
 
 /* --- rc_json --- */
 
@@ -1133,21 +1132,25 @@ void rc_url_builder_append_str_param(rc_api_url_builder_t* builder, const char* 
   rc_url_builder_append_encoded_str(builder, value);
 }
 
-void rc_api_url_build_dorequest_url(rc_api_request_t* request) {
+void rc_api_url_build_dorequest_url(rc_api_request_t* request, const rc_api_host_t* host) {
   #define DOREQUEST_ENDPOINT "/dorequest.php"
   rc_buffer_init(&request->buffer);
 
-  if (!g_host) {
+  if (!host || !host->host) {
     request->url = RETROACHIEVEMENTS_HOST DOREQUEST_ENDPOINT;
   }
   else {
     const size_t endpoint_len = sizeof(DOREQUEST_ENDPOINT);
-    const size_t host_len = strlen(g_host);
-    const size_t url_len = host_len + endpoint_len;
+    const size_t host_len = strlen(host->host);
+    const size_t protocol_len = (strstr(host->host, "://")) ? 0 : 7;
+    const size_t url_len = protocol_len + host_len + endpoint_len;
     uint8_t* url = rc_buffer_reserve(&request->buffer, url_len);
 
-    memcpy(url, g_host, host_len);
-    memcpy(url + host_len, DOREQUEST_ENDPOINT, endpoint_len);
+    if (protocol_len)
+      memcpy(url, "http://", protocol_len);
+
+    memcpy(url + protocol_len, host->host, host_len);
+    memcpy(url + protocol_len + host_len, DOREQUEST_ENDPOINT, endpoint_len);
     rc_buffer_consume(&request->buffer, url, url + url_len);
 
     request->url = (char*)url;
@@ -1205,7 +1208,7 @@ void rc_api_set_host(const char* hostname) {
   if (hostname && strcmp(hostname, RETROACHIEVEMENTS_HOST) == 0)
     hostname = NULL;
 
-  rc_api_update_host(&g_host, hostname);
+  rc_api_update_host(&g_host.host, hostname);
 
   if (!hostname) {
     /* also clear out the image hostname */
@@ -1219,24 +1222,45 @@ void rc_api_set_host(const char* hostname) {
 }
 
 void rc_api_set_image_host(const char* hostname) {
-  rc_api_update_host(&g_imagehost, hostname);
+  rc_api_update_host(&g_host.media_host, hostname);
 }
 
 /* --- Fetch Image --- */
 
 int rc_api_init_fetch_image_request(rc_api_request_t* request, const rc_api_fetch_image_request_t* api_params) {
+  return rc_api_init_fetch_image_request_hosted(request, api_params, &g_host);
+}
+
+int rc_api_init_fetch_image_request_hosted(rc_api_request_t* request, const rc_api_fetch_image_request_t* api_params, const rc_api_host_t* host) {
   rc_api_url_builder_t builder;
 
   rc_buffer_init(&request->buffer);
   rc_url_builder_init(&builder, &request->buffer, 64);
 
-  if (g_imagehost) {
-    rc_url_builder_append(&builder, g_imagehost, strlen(g_imagehost));
+  if (host && host->media_host) {
+    /* custom media host provided */
+    if (!strstr(host->host, "://"))
+      rc_url_builder_append(&builder, "http://", 7);
+    rc_url_builder_append(&builder, host->media_host, strlen(host->media_host));
   }
-  else if (g_host) {
-    rc_url_builder_append(&builder, g_host, strlen(g_host));
+  else if (host && host->host) {
+    if (strcmp(host->host, RETROACHIEVEMENTS_HOST_NONSSL) == 0) {
+      /* if host specifically set to non-ssl host, and no media host provided, use non-ssl media host */
+      rc_url_builder_append(&builder, RETROACHIEVEMENTS_IMAGE_HOST_NONSSL, sizeof(RETROACHIEVEMENTS_IMAGE_HOST_NONSSL) - 1);
+    }
+    else if (strcmp(host->host, RETROACHIEVEMENTS_HOST) == 0) {
+      /* if host specifically set to ssl host, and no media host provided, use media host */
+      rc_url_builder_append(&builder, RETROACHIEVEMENTS_IMAGE_HOST, sizeof(RETROACHIEVEMENTS_IMAGE_HOST) - 1);
+    }
+    else {
+      /* custom host and no media host provided. assume custom host is also media host */
+      if (!strstr(host->host, "://"))
+        rc_url_builder_append(&builder, "http://", 7);
+      rc_url_builder_append(&builder, host->host, strlen(host->host));
+    }
   }
   else {
+    /* no custom host provided */
     rc_url_builder_append(&builder, RETROACHIEVEMENTS_IMAGE_HOST, sizeof(RETROACHIEVEMENTS_IMAGE_HOST) - 1);
   }
 

--- a/src/rapi/rc_api_common.c
+++ b/src/rapi/rc_api_common.c
@@ -1204,6 +1204,10 @@ static void rc_api_update_host(char** host, const char* hostname) {
   }
 }
 
+const char* rc_api_default_host(void) {
+  return RETROACHIEVEMENTS_HOST;
+}
+
 void rc_api_set_host(const char* hostname) {
   if (hostname && strcmp(hostname, RETROACHIEVEMENTS_HOST) == 0)
     hostname = NULL;

--- a/src/rapi/rc_api_common.h
+++ b/src/rapi/rc_api_common.h
@@ -76,6 +76,7 @@ void rc_url_builder_append_num_param(rc_api_url_builder_t* builder, const char* 
 void rc_url_builder_append_unum_param(rc_api_url_builder_t* builder, const char* param, uint32_t value);
 void rc_url_builder_append_str_param(rc_api_url_builder_t* builder, const char* param, const char* value);
 
+const char* rc_api_default_host(void);
 void rc_api_url_build_dorequest_url(rc_api_request_t* request, const rc_api_host_t* host);
 int rc_api_url_build_dorequest(rc_api_url_builder_t* builder, const char* api, const char* username, const char* api_token);
 

--- a/src/rapi/rc_api_common.h
+++ b/src/rapi/rc_api_common.h
@@ -24,6 +24,8 @@ void rc_url_builder_init(rc_api_url_builder_t* builder, rc_buffer_t* buffer, siz
 void rc_url_builder_append(rc_api_url_builder_t* builder, const char* data, size_t len);
 const char* rc_url_builder_finalize(rc_api_url_builder_t* builder);
 
+extern rc_api_host_t g_host;
+
 #define RC_JSON_NEW_FIELD(n) {NULL,NULL,n,sizeof(n)-1,0}
 
 typedef struct rc_json_field_t {
@@ -74,7 +76,7 @@ void rc_url_builder_append_num_param(rc_api_url_builder_t* builder, const char* 
 void rc_url_builder_append_unum_param(rc_api_url_builder_t* builder, const char* param, uint32_t value);
 void rc_url_builder_append_str_param(rc_api_url_builder_t* builder, const char* param, const char* value);
 
-void rc_api_url_build_dorequest_url(rc_api_request_t* request);
+void rc_api_url_build_dorequest_url(rc_api_request_t* request, const rc_api_host_t* host);
 int rc_api_url_build_dorequest(rc_api_url_builder_t* builder, const char* api, const char* username, const char* api_token);
 
 const char* rc_api_build_avatar_url(rc_buffer_t* buffer, uint32_t image_type, const char* username);

--- a/src/rapi/rc_api_editor.c
+++ b/src/rapi/rc_api_editor.c
@@ -11,9 +11,15 @@
 /* --- Fetch Code Notes --- */
 
 int rc_api_init_fetch_code_notes_request(rc_api_request_t* request, const rc_api_fetch_code_notes_request_t* api_params) {
+  return rc_api_init_fetch_code_notes_request_hosted(request, api_params, &g_host);
+}
+
+int rc_api_init_fetch_code_notes_request_hosted(rc_api_request_t* request,
+                                                const rc_api_fetch_code_notes_request_t* api_params,
+                                                const rc_api_host_t* host) {
   rc_api_url_builder_t builder;
 
-  rc_api_url_build_dorequest_url(request);
+  rc_api_url_build_dorequest_url(request, host);
 
   if (api_params->game_id == 0)
     return RC_INVALID_STATE;
@@ -130,9 +136,15 @@ void rc_api_destroy_fetch_code_notes_response(rc_api_fetch_code_notes_response_t
 /* --- Update Code Note --- */
 
 int rc_api_init_update_code_note_request(rc_api_request_t* request, const rc_api_update_code_note_request_t* api_params) {
+  return rc_api_init_update_code_note_request_hosted(request, api_params, &g_host);
+}
+
+int rc_api_init_update_code_note_request_hosted(rc_api_request_t* request,
+                                                const rc_api_update_code_note_request_t* api_params,
+                                                const rc_api_host_t* host) {
   rc_api_url_builder_t builder;
 
-  rc_api_url_build_dorequest_url(request);
+  rc_api_url_build_dorequest_url(request, host);
 
   if (api_params->game_id == 0)
     return RC_INVALID_STATE;
@@ -202,12 +214,18 @@ static const char* rc_type_string(uint32_t type) {
 }
 
 int rc_api_init_update_achievement_request(rc_api_request_t* request, const rc_api_update_achievement_request_t* api_params) {
+  return rc_api_init_update_achievement_request_hosted(request, api_params, &g_host);
+}
+
+int rc_api_init_update_achievement_request_hosted(rc_api_request_t* request,
+                                                  const rc_api_update_achievement_request_t* api_params,
+                                                  const rc_api_host_t* host) {
   rc_api_url_builder_t builder;
   char buffer[33];
   md5_state_t md5;
   md5_byte_t hash[16];
 
-  rc_api_url_build_dorequest_url(request);
+  rc_api_url_build_dorequest_url(request, host);
 
   if (api_params->game_id == 0 || api_params->category == 0)
     return RC_INVALID_STATE;
@@ -296,12 +314,18 @@ void rc_api_destroy_update_achievement_response(rc_api_update_achievement_respon
 /* --- Update Leaderboard --- */
 
 int rc_api_init_update_leaderboard_request(rc_api_request_t* request, const rc_api_update_leaderboard_request_t* api_params) {
+  return rc_api_init_update_leaderboard_request_hosted(request, api_params, &g_host);
+}
+
+int rc_api_init_update_leaderboard_request_hosted(rc_api_request_t* request,
+                                                  const rc_api_update_leaderboard_request_t* api_params,
+                                                  const rc_api_host_t* host) {
     rc_api_url_builder_t builder;
     char buffer[33];
     md5_state_t md5;
     md5_byte_t hash[16];
 
-    rc_api_url_build_dorequest_url(request);
+    rc_api_url_build_dorequest_url(request, host);
 
     if (api_params->game_id == 0)
         return RC_INVALID_STATE;
@@ -398,9 +422,15 @@ void rc_api_destroy_update_leaderboard_response(rc_api_update_leaderboard_respon
 /* --- Fetch Badge Range --- */
 
 int rc_api_init_fetch_badge_range_request(rc_api_request_t* request, const rc_api_fetch_badge_range_request_t* api_params) {
+  return rc_api_init_fetch_badge_range_request_hosted(request, api_params, &g_host);
+}
+
+int rc_api_init_fetch_badge_range_request_hosted(rc_api_request_t* request,
+                                                 const rc_api_fetch_badge_range_request_t* api_params,
+                                                 const rc_api_host_t* host) {
   rc_api_url_builder_t builder;
 
-  rc_api_url_build_dorequest_url(request);
+  rc_api_url_build_dorequest_url(request, host);
 
   rc_url_builder_init(&builder, &request->buffer, 48);
   rc_url_builder_append_str_param(&builder, "r", "badgeiter");
@@ -455,9 +485,15 @@ void rc_api_destroy_fetch_badge_range_response(rc_api_fetch_badge_range_response
 /* --- Add Game Hash --- */
 
 int rc_api_init_add_game_hash_request(rc_api_request_t* request, const rc_api_add_game_hash_request_t* api_params) {
+  return rc_api_init_add_game_hash_request_hosted(request, api_params, &g_host);
+}
+
+int rc_api_init_add_game_hash_request_hosted(rc_api_request_t* request,
+                                             const rc_api_add_game_hash_request_t* api_params,
+                                             const rc_api_host_t* host) {
   rc_api_url_builder_t builder;
 
-  rc_api_url_build_dorequest_url(request);
+  rc_api_url_build_dorequest_url(request, host);
 
   if (api_params->console_id == 0)
     return RC_INVALID_STATE;

--- a/src/rapi/rc_api_info.c
+++ b/src/rapi/rc_api_info.c
@@ -12,9 +12,15 @@
 /* --- Fetch Achievement Info --- */
 
 int rc_api_init_fetch_achievement_info_request(rc_api_request_t* request, const rc_api_fetch_achievement_info_request_t* api_params) {
+  return rc_api_init_fetch_achievement_info_request_hosted(request, api_params, &g_host);
+}
+
+int rc_api_init_fetch_achievement_info_request_hosted(rc_api_request_t* request,
+                                                      const rc_api_fetch_achievement_info_request_t* api_params,
+                                                      const rc_api_host_t* host) {
   rc_api_url_builder_t builder;
 
-  rc_api_url_build_dorequest_url(request);
+  rc_api_url_build_dorequest_url(request, host);
 
   if (api_params->achievement_id == 0)
     return RC_INVALID_STATE;
@@ -136,9 +142,15 @@ void rc_api_destroy_fetch_achievement_info_response(rc_api_fetch_achievement_inf
 /* --- Fetch Leaderboard Info --- */
 
 int rc_api_init_fetch_leaderboard_info_request(rc_api_request_t* request, const rc_api_fetch_leaderboard_info_request_t* api_params) {
+  return rc_api_init_fetch_leaderboard_info_request_hosted(request, api_params, &g_host);
+}
+
+int rc_api_init_fetch_leaderboard_info_request_hosted(rc_api_request_t* request,
+                                                      const rc_api_fetch_leaderboard_info_request_t* api_params,
+                                                      const rc_api_host_t* host) {
   rc_api_url_builder_t builder;
 
-  rc_api_url_build_dorequest_url(request);
+  rc_api_url_build_dorequest_url(request, host);
 
   if (api_params->leaderboard_id == 0)
     return RC_INVALID_STATE;
@@ -299,9 +311,15 @@ void rc_api_destroy_fetch_leaderboard_info_response(rc_api_fetch_leaderboard_inf
 /* --- Fetch Games List --- */
 
 int rc_api_init_fetch_games_list_request(rc_api_request_t* request, const rc_api_fetch_games_list_request_t* api_params) {
+  return rc_api_init_fetch_games_list_request_hosted(request, api_params, &g_host);
+}
+
+int rc_api_init_fetch_games_list_request_hosted(rc_api_request_t* request,
+                                                const rc_api_fetch_games_list_request_t* api_params,
+                                                const rc_api_host_t* host) {
   rc_api_url_builder_t builder;
 
-  rc_api_url_build_dorequest_url(request);
+  rc_api_url_build_dorequest_url(request, host);
 
   if (api_params->console_id == 0)
     return RC_INVALID_STATE;
@@ -384,11 +402,17 @@ void rc_api_destroy_fetch_games_list_response(rc_api_fetch_games_list_response_t
 /* --- Fetch Game Titles --- */
 
 int rc_api_init_fetch_game_titles_request(rc_api_request_t* request, const rc_api_fetch_game_titles_request_t* api_params) {
+  return rc_api_init_fetch_game_titles_request_hosted(request, api_params, &g_host);
+}
+
+int rc_api_init_fetch_game_titles_request_hosted(rc_api_request_t* request,
+                                                 const rc_api_fetch_game_titles_request_t* api_params,
+                                                 const rc_api_host_t* host) {
   rc_api_url_builder_t builder;
   char num[16];
   uint32_t i;
 
-  rc_api_url_build_dorequest_url(request);
+  rc_api_url_build_dorequest_url(request, host);
 
   if (api_params->num_game_ids == 0)
     return RC_INVALID_STATE;

--- a/src/rapi/rc_api_runtime.c
+++ b/src/rapi/rc_api_runtime.c
@@ -13,9 +13,15 @@
 /* --- Resolve Hash --- */
 
 int rc_api_init_resolve_hash_request(rc_api_request_t* request, const rc_api_resolve_hash_request_t* api_params) {
+  return rc_api_init_resolve_hash_request_hosted(request, api_params, &g_host);
+}
+
+int rc_api_init_resolve_hash_request_hosted(rc_api_request_t* request,
+                                            const rc_api_resolve_hash_request_t* api_params,
+                                            const rc_api_host_t* host) {
   rc_api_url_builder_t builder;
 
-  rc_api_url_build_dorequest_url(request);
+  rc_api_url_build_dorequest_url(request, host);
 
   if (!api_params->game_hash || !*api_params->game_hash)
     return RC_INVALID_STATE;
@@ -65,9 +71,15 @@ void rc_api_destroy_resolve_hash_response(rc_api_resolve_hash_response_t* respon
 /* --- Fetch Game Data --- */
 
 int rc_api_init_fetch_game_data_request(rc_api_request_t* request, const rc_api_fetch_game_data_request_t* api_params) {
+  return rc_api_init_fetch_game_data_request_hosted(request, api_params, &g_host);
+}
+
+int rc_api_init_fetch_game_data_request_hosted(rc_api_request_t* request,
+                                               const rc_api_fetch_game_data_request_t* api_params,
+                                               const rc_api_host_t* host) {
   rc_api_url_builder_t builder;
 
-  rc_api_url_build_dorequest_url(request);
+  rc_api_url_build_dorequest_url(request, host);
 
   if (api_params->game_id == 0 && (!api_params->game_hash || !api_params->game_hash[0]))
     return RC_INVALID_STATE;
@@ -465,9 +477,15 @@ void rc_api_destroy_fetch_game_data_response(rc_api_fetch_game_data_response_t* 
 /* --- Ping --- */
 
 int rc_api_init_ping_request(rc_api_request_t* request, const rc_api_ping_request_t* api_params) {
+  return rc_api_init_ping_request_hosted(request, api_params, &g_host);
+}
+
+int rc_api_init_ping_request_hosted(rc_api_request_t* request,
+                                    const rc_api_ping_request_t* api_params,
+                                    const rc_api_host_t* host) {
   rc_api_url_builder_t builder;
 
-  rc_api_url_build_dorequest_url(request);
+  rc_api_url_build_dorequest_url(request, host);
 
   if (api_params->game_id == 0)
     return RC_INVALID_STATE;
@@ -520,12 +538,18 @@ void rc_api_destroy_ping_response(rc_api_ping_response_t* response) {
 /* --- Award Achievement --- */
 
 int rc_api_init_award_achievement_request(rc_api_request_t* request, const rc_api_award_achievement_request_t* api_params) {
+  return rc_api_init_award_achievement_request_hosted(request, api_params, &g_host);
+}
+
+int rc_api_init_award_achievement_request_hosted(rc_api_request_t* request,
+                                                 const rc_api_award_achievement_request_t* api_params,
+                                                 const rc_api_host_t* host) {
   rc_api_url_builder_t builder;
   char buffer[33];
   md5_state_t md5;
   md5_byte_t digest[16];
 
-  rc_api_url_build_dorequest_url(request);
+  rc_api_url_build_dorequest_url(request, host);
 
   if (api_params->achievement_id == 0)
     return RC_INVALID_STATE;
@@ -621,12 +645,18 @@ void rc_api_destroy_award_achievement_response(rc_api_award_achievement_response
 /* --- Submit Leaderboard Entry --- */
 
 int rc_api_init_submit_lboard_entry_request(rc_api_request_t* request, const rc_api_submit_lboard_entry_request_t* api_params) {
+  return rc_api_init_submit_lboard_entry_request_hosted(request, api_params, &g_host);
+}
+
+int rc_api_init_submit_lboard_entry_request_hosted(rc_api_request_t* request,
+                                                   const rc_api_submit_lboard_entry_request_t* api_params,
+                                                   const rc_api_host_t* host) {
   rc_api_url_builder_t builder;
   char buffer[33];
   md5_state_t md5;
   md5_byte_t digest[16];
 
-  rc_api_url_build_dorequest_url(request);
+  rc_api_url_build_dorequest_url(request, host);
 
   if (api_params->leaderboard_id == 0)
     return RC_INVALID_STATE;

--- a/src/rapi/rc_api_user.c
+++ b/src/rapi/rc_api_user.c
@@ -9,9 +9,15 @@
 /* --- Login --- */
 
 int rc_api_init_login_request(rc_api_request_t* request, const rc_api_login_request_t* api_params) {
+  return rc_api_init_login_request_hosted(request, api_params, &g_host);
+}
+
+int rc_api_init_login_request_hosted(rc_api_request_t* request,
+                                     const rc_api_login_request_t* api_params,
+                                     const rc_api_host_t* host) {
   rc_api_url_builder_t builder;
 
-  rc_api_url_build_dorequest_url(request);
+  rc_api_url_build_dorequest_url(request, host);
 
   if (!api_params->username || !*api_params->username)
     return RC_INVALID_STATE;
@@ -92,9 +98,15 @@ void rc_api_destroy_login_response(rc_api_login_response_t* response) {
 /* --- Start Session --- */
 
 int rc_api_init_start_session_request(rc_api_request_t* request, const rc_api_start_session_request_t* api_params) {
+  return rc_api_init_start_session_request_hosted(request, api_params, &g_host);
+}
+
+int rc_api_init_start_session_request_hosted(rc_api_request_t* request,
+                                             const rc_api_start_session_request_t* api_params,
+                                             const rc_api_host_t* host) {
   rc_api_url_builder_t builder;
 
-  rc_api_url_build_dorequest_url(request);
+  rc_api_url_build_dorequest_url(request, host);
 
   if (api_params->game_id == 0)
     return RC_INVALID_STATE;
@@ -209,9 +221,15 @@ void rc_api_destroy_start_session_response(rc_api_start_session_response_t* resp
 /* --- Fetch User Unlocks --- */
 
 int rc_api_init_fetch_user_unlocks_request(rc_api_request_t* request, const rc_api_fetch_user_unlocks_request_t* api_params) {
+  return rc_api_init_fetch_user_unlocks_request_hosted(request, api_params, &g_host);
+}
+
+int rc_api_init_fetch_user_unlocks_request_hosted(rc_api_request_t* request,
+                                                  const rc_api_fetch_user_unlocks_request_t* api_params,
+                                                  const rc_api_host_t* host) {
   rc_api_url_builder_t builder;
 
-  rc_api_url_build_dorequest_url(request);
+  rc_api_url_build_dorequest_url(request, host);
 
   rc_url_builder_init(&builder, &request->buffer, 48);
   if (rc_api_url_build_dorequest(&builder, "unlocks", api_params->username, api_params->api_token)) {

--- a/src/rc_client_internal.h
+++ b/src/rc_client_internal.h
@@ -299,6 +299,7 @@ typedef struct rc_client_state_t {
   rc_buffer_t buffer;
 
   rc_client_scheduled_callback_data_t* scheduled_callbacks;
+  rc_api_host_t host;
 
 #ifdef RC_CLIENT_SUPPORTS_EXTERNAL
   rc_client_external_t* external_client;

--- a/src/rc_client_raintegration.c
+++ b/src/rc_client_raintegration.c
@@ -352,7 +352,7 @@ rc_client_async_handle_t* rc_client_begin_load_raintegration(rc_client_t* client
   }
 
   memset(&request, 0, sizeof(request));
-  rc_api_url_build_dorequest_url(&request);
+  rc_api_url_build_dorequest_url(&request, NULL);
   rc_url_builder_init(&builder, &request.buffer, 48);
   rc_url_builder_append_str_param(&builder, "r", "latestintegration");
   request.post_data = rc_url_builder_finalize(&builder);

--- a/src/rc_client_raintegration.c
+++ b/src/rc_client_raintegration.c
@@ -172,7 +172,7 @@ static void rc_client_init_raintegration(rc_client_t* client,
     const char* host_url = client->state.raintegration->get_host_url();
     if (host_url) {
       if (strcmp(host_url, "OFFLINE") != 0) {
-        if (strcmp(host_url, "https://retroachievements.org") != 0)
+        if (strcmp(host_url, rc_api_default_host()) != 0)
           rc_client_set_host(client, host_url);
       }
       else if (client->state.raintegration->init_client_offline) {
@@ -344,7 +344,7 @@ rc_client_async_handle_t* rc_client_begin_load_raintegration(rc_client_t* client
 
   if (client->state.raintegration->get_host_url) {
     const char* host_url = client->state.raintegration->get_host_url();
-    if (host_url && strcmp(host_url, "https://retroachievements.org") != 0 &&
+    if (host_url && strcmp(host_url, rc_api_default_host()) != 0 &&
                     strcmp(host_url, "OFFLINE") != 0) {
       /* if the DLL specifies a custom host, use it */
       rc_client_set_host(client, host_url);
@@ -352,7 +352,7 @@ rc_client_async_handle_t* rc_client_begin_load_raintegration(rc_client_t* client
   }
 
   memset(&request, 0, sizeof(request));
-  rc_api_url_build_dorequest_url(&request, NULL);
+  rc_api_url_build_dorequest_url(&request, &client->state.host);
   rc_url_builder_init(&builder, &request.buffer, 48);
   rc_url_builder_append_str_param(&builder, "r", "latestintegration");
   request.post_data = rc_url_builder_finalize(&builder);

--- a/src/rc_client_types.natvis
+++ b/src/rc_client_types.natvis
@@ -357,6 +357,7 @@
             <Item Name="log_level">*((__rc_client_log_level_enum_t*)&amp;log_level)</Item>
             <Item Name="user">*((__rc_client_user_state_enum_t*)&amp;user)</Item>
             <Item Name="scheduled_callbacks">*((__rc_client_scheduled_callback_list_t*)this)</Item>
+            <Item Name="host">host</Item>
             <Item Name="load">load</Item>
         </Expand>
     </Type>

--- a/test/rapi/test_rc_api_common.c
+++ b/test/rapi/test_rc_api_common.c
@@ -506,13 +506,13 @@ static void test_url_build_dorequest_url_default_host() {
   rc_api_request_t request;
   rc_api_fetch_image_request_t api_params;
 
-  rc_api_url_build_dorequest_url(&request);
+  rc_api_url_build_dorequest_url(&request, NULL);
   ASSERT_STR_EQUALS(request.url, "https://retroachievements.org/dorequest.php");
   rc_api_destroy_request(&request);
 
   api_params.image_type = RC_IMAGE_TYPE_ACHIEVEMENT;
   api_params.image_name = "12345";
-  rc_api_init_fetch_image_request(&request, &api_params);
+  rc_api_init_fetch_image_request_hosted(&request, &api_params, NULL);
   ASSERT_STR_EQUALS(request.url, "https://media.retroachievements.org/Badge/12345.png");
   rc_api_destroy_request(&request);
 }
@@ -520,58 +520,58 @@ static void test_url_build_dorequest_url_default_host() {
 static void test_url_build_dorequest_url_default_host_nonssl() {
   rc_api_request_t request;
   rc_api_fetch_image_request_t api_params;
+  rc_api_host_t host;
 
-  rc_api_set_host("http://retroachievements.org");
+  memset(&host, 0, sizeof(host));
+  host.host = "http://retroachievements.org";
 
-  rc_api_url_build_dorequest_url(&request);
+  rc_api_url_build_dorequest_url(&request, &host);
   ASSERT_STR_EQUALS(request.url, "http://retroachievements.org/dorequest.php");
   rc_api_destroy_request(&request);
 
   api_params.image_type = RC_IMAGE_TYPE_ACHIEVEMENT;
   api_params.image_name = "12345";
-  rc_api_init_fetch_image_request(&request, &api_params);
+  rc_api_init_fetch_image_request_hosted(&request, &api_params, &host);
   ASSERT_STR_EQUALS(request.url, "http://media.retroachievements.org/Badge/12345.png");
   rc_api_destroy_request(&request);
-
-  rc_api_set_host(NULL);
 }
 
 static void test_url_build_dorequest_url_custom_host() {
   rc_api_request_t request;
   rc_api_fetch_image_request_t api_params;
+  rc_api_host_t host;
 
-  rc_api_set_host("http://localhost");
+  memset(&host, 0, sizeof(host));
+  host.host = "http://localhost";
 
-  rc_api_url_build_dorequest_url(&request);
+  rc_api_url_build_dorequest_url(&request, &host);
   ASSERT_STR_EQUALS(request.url, "http://localhost/dorequest.php");
   rc_api_destroy_request(&request);
 
   api_params.image_type = RC_IMAGE_TYPE_ACHIEVEMENT;
   api_params.image_name = "12345";
-  rc_api_init_fetch_image_request(&request, &api_params);
+  rc_api_init_fetch_image_request_hosted(&request, &api_params, &host);
   ASSERT_STR_EQUALS(request.url, "http://localhost/Badge/12345.png");
   rc_api_destroy_request(&request);
-
-  rc_api_set_host(NULL);
 }
 
 static void test_url_build_dorequest_url_custom_host_no_protocol() {
   rc_api_request_t request;
   rc_api_fetch_image_request_t api_params;
+  rc_api_host_t host;
 
-  rc_api_set_host("my.host");
+  memset(&host, 0, sizeof(host));
+  host.host = "my.host";
 
-  rc_api_url_build_dorequest_url(&request);
+  rc_api_url_build_dorequest_url(&request, &host);
   ASSERT_STR_EQUALS(request.url, "http://my.host/dorequest.php");
   rc_api_destroy_request(&request);
 
   api_params.image_type = RC_IMAGE_TYPE_ACHIEVEMENT;
   api_params.image_name = "12345";
-  rc_api_init_fetch_image_request(&request, &api_params);
+  rc_api_init_fetch_image_request_hosted(&request, &api_params, &host);
   ASSERT_STR_EQUALS(request.url, "http://my.host/Badge/12345.png");
   rc_api_destroy_request(&request);
-
-  rc_api_set_host(NULL);
 }
 
 static void test_url_builder_append_encoded_str(const char* input, const char* expected) {
@@ -717,57 +717,60 @@ static void test_init_fetch_image_request_custom_host()
 {
   rc_api_fetch_image_request_t fetch_image_request;
   rc_api_request_t request;
+  rc_api_host_t host;
 
-  rc_api_set_host("http://localhost");
+  memset(&host, 0, sizeof(host));
+  host.host = "http://localhost";
 
   memset(&fetch_image_request, 0, sizeof(fetch_image_request));
   fetch_image_request.image_name = "0123324";
   fetch_image_request.image_type = RC_IMAGE_TYPE_GAME;
 
-  ASSERT_NUM_EQUALS(rc_api_init_fetch_image_request(&request, &fetch_image_request), RC_OK);
+  ASSERT_NUM_EQUALS(rc_api_init_fetch_image_request_hosted(&request, &fetch_image_request, &host), RC_OK);
   ASSERT_STR_EQUALS(request.url, "http://localhost/Images/0123324.png");
   ASSERT_PTR_NULL(request.post_data);
 
   rc_api_destroy_request(&request);
-  rc_api_set_host(NULL);
 }
 
 static void test_init_fetch_image_request_explicit_default_host()
 {
   rc_api_fetch_image_request_t fetch_image_request;
   rc_api_request_t request;
+  rc_api_host_t host;
 
-  rc_api_set_host("https://retroachievements.org");
+  memset(&host, 0, sizeof(host));
+  host.host = "https://retroachievements.org";
 
   memset(&fetch_image_request, 0, sizeof(fetch_image_request));
   fetch_image_request.image_name = "0123324";
   fetch_image_request.image_type = RC_IMAGE_TYPE_GAME;
 
-  ASSERT_NUM_EQUALS(rc_api_init_fetch_image_request(&request, &fetch_image_request), RC_OK);
+  ASSERT_NUM_EQUALS(rc_api_init_fetch_image_request_hosted(&request, &fetch_image_request, &host), RC_OK);
   ASSERT_STR_EQUALS(request.url, "https://media.retroachievements.org/Images/0123324.png");
   ASSERT_PTR_NULL(request.post_data);
 
   rc_api_destroy_request(&request);
-  rc_api_set_host(NULL);
 }
 
 static void test_init_fetch_image_request_explicit_nonssl_host()
 {
   rc_api_fetch_image_request_t fetch_image_request;
   rc_api_request_t request;
+  rc_api_host_t host;
 
-  rc_api_set_host("http://retroachievements.org");
+  memset(&host, 0, sizeof(host));
+  host.host = "http://retroachievements.org";
 
   memset(&fetch_image_request, 0, sizeof(fetch_image_request));
   fetch_image_request.image_name = "0123324";
   fetch_image_request.image_type = RC_IMAGE_TYPE_GAME;
 
-  ASSERT_NUM_EQUALS(rc_api_init_fetch_image_request(&request, &fetch_image_request), RC_OK);
+  ASSERT_NUM_EQUALS(rc_api_init_fetch_image_request_hosted(&request, &fetch_image_request, &host), RC_OK);
   ASSERT_STR_EQUALS(request.url, "http://media.retroachievements.org/Images/0123324.png");
   ASSERT_PTR_NULL(request.post_data);
 
   rc_api_destroy_request(&request);
-  rc_api_set_host(NULL);
 }
 
 void test_rapi_common(void) {
@@ -867,7 +870,7 @@ void test_rapi_common(void) {
   TEST_PARAMS3(test_json_get_unum_array, "[A,B,C]", 3, RC_MISSING_VALUE);
   TEST(test_json_get_unum_array_trailing_comma);
 
-  /* rc_api_url_build_dorequest_url / rc_api_set_host */
+  /* rc_api_url_build_dorequest_url / rc_api_url_build_dorequest_url_hosted */
   TEST(test_url_build_dorequest_url_default_host);
   TEST(test_url_build_dorequest_url_default_host_nonssl);
   TEST(test_url_build_dorequest_url_custom_host);

--- a/test/rapi/test_rc_api_common.c
+++ b/test/rapi/test_rc_api_common.c
@@ -740,7 +740,7 @@ static void test_init_fetch_image_request_explicit_default_host()
   rc_api_host_t host;
 
   memset(&host, 0, sizeof(host));
-  host.host = "https://retroachievements.org";
+  host.host = rc_api_default_host();
 
   memset(&fetch_image_request, 0, sizeof(fetch_image_request));
   fetch_image_request.image_name = "0123324";

--- a/test/test_rc_client.c
+++ b/test/test_rc_client.c
@@ -3296,32 +3296,6 @@ static void test_game_get_image_url(void)
   rc_client_destroy(g_client);
 }
 
-static void test_game_get_image_url_non_ssl(void)
-{
-  char buffer[256];
-  g_client = mock_client_logged_in();
-  rc_client_set_host(g_client, "http://retroachievements.org");
-  mock_client_load_game(patchdata_2ach_1lbd, no_unlocks);
-
-  ASSERT_NUM_EQUALS(rc_client_game_get_image_url(rc_client_get_game_info(g_client), buffer, sizeof(buffer)), RC_OK);
-  ASSERT_STR_EQUALS(buffer, "http://media.retroachievements.org/Images/112233.png");
-
-  rc_client_destroy(g_client);
-}
-
-static void test_game_get_image_url_custom(void)
-{
-  char buffer[256];
-  g_client = mock_client_logged_in();
-  rc_client_set_host(g_client, "localhost");
-  mock_client_load_game(patchdata_2ach_1lbd, no_unlocks);
-
-  ASSERT_NUM_EQUALS(rc_client_game_get_image_url(rc_client_get_game_info(g_client), buffer, sizeof(buffer)), RC_OK);
-  ASSERT_STR_EQUALS(buffer, "http://localhost/Images/112233.png");
-
-  rc_client_destroy(g_client);
-}
-
 /* ----- subset ----- */
 
 static void test_load_subset(void)
@@ -9379,8 +9353,6 @@ void test_client(void) {
 
   /* game */
   TEST(test_game_get_image_url);
-  TEST(test_game_get_image_url_non_ssl);
-  TEST(test_game_get_image_url_custom);
 
   /* subset */
   TEST(test_load_subset);


### PR DESCRIPTION
Deprecates `rc_api_set_host` and `rc_api_set_image_host`. Custom hosts are now passed to `_hosted` alternatives for each API `_init` function.

Passing `NULL` to the `_hosted` functions will use the default hosts. The non-`_hosted` versions pass the custom hosts assigned by calling `rc_api_set_host` and `rc_api_set_image_host`. Once those functions are fully removed, the non-`_hosted` versions will just pass `NULL` and the default hosts will be used.

The existing `rc_client_set_host` function can be used to specify a custom host for use by a single `rc_client` instance (it was previously a wrapper for calling the above deprecated functions). It shouldn't be necessary to specify an image host, as #393 and #395 expose full URLs to images that should be used instead of trying to build a URL.