### PR TITLE
support passing new avatar fields across external interface

### DIFF
--- a/include/rc_client.h
+++ b/include/rc_client.h
@@ -188,7 +188,7 @@ typedef struct rc_client_user_t {
   uint32_t score;
   uint32_t score_softcore;
   uint32_t num_unread_messages;
-  /* minimum version: 11.7 */
+  /* minimum version: 12.0 */
   const char* avatar_url;
 } rc_client_user_t;
 
@@ -269,7 +269,7 @@ typedef struct rc_client_game_t {
   const char* title;
   const char* hash;
   const char* badge_name;
-  /* minimum version: 11.7 */
+  /* minimum version: 12.0 */
   const char* badge_url;
 } rc_client_game_t;
 
@@ -311,7 +311,7 @@ typedef struct rc_client_subset_t {
   uint32_t num_achievements;
   uint32_t num_leaderboards;
 
-  /* minimum version: 11.7 */
+  /* minimum version: 12.0 */
   const char* badge_url;
 } rc_client_subset_t;
 
@@ -380,7 +380,7 @@ typedef struct rc_client_achievement_t {
   float rarity;
   float rarity_hardcore;
   uint8_t type;
-  /* minimum version: 11.7 */
+  /* minimum version: 12.0 */
   const char* badge_url;
   const char* badge_locked_url;
 } rc_client_achievement_t;
@@ -397,7 +397,7 @@ RC_EXPORT const rc_client_achievement_t* RC_CCONV rc_client_get_achievement_info
 RC_EXPORT int RC_CCONV rc_client_achievement_get_image_url(const rc_client_achievement_t* achievement, int state, char buffer[], size_t buffer_size);
 
 typedef struct rc_client_achievement_bucket_t {
-  rc_client_achievement_t** achievements;
+  const rc_client_achievement_t** achievements;
   uint32_t num_achievements;
 
   const char* label;
@@ -406,7 +406,7 @@ typedef struct rc_client_achievement_bucket_t {
 } rc_client_achievement_bucket_t;
 
 typedef struct rc_client_achievement_list_t {
-  rc_client_achievement_bucket_t* buckets;
+  const rc_client_achievement_bucket_t* buckets;
   uint32_t num_buckets;
 } rc_client_achievement_list_t;
 
@@ -473,7 +473,7 @@ typedef struct rc_client_leaderboard_tracker_t {
 } rc_client_leaderboard_tracker_t;
 
 typedef struct rc_client_leaderboard_bucket_t {
-  rc_client_leaderboard_t** leaderboards;
+  const rc_client_leaderboard_t** leaderboards;
   uint32_t num_leaderboards;
 
   const char* label;
@@ -482,7 +482,7 @@ typedef struct rc_client_leaderboard_bucket_t {
 } rc_client_leaderboard_bucket_t;
 
 typedef struct rc_client_leaderboard_list_t {
-  rc_client_leaderboard_bucket_t* buckets;
+  const rc_client_leaderboard_bucket_t* buckets;
   uint32_t num_buckets;
 } rc_client_leaderboard_list_t;
 

--- a/src/rc_client_external.c
+++ b/src/rc_client_external.c
@@ -1,0 +1,178 @@
+#include "rc_client_external.h"
+
+#include "rc_client_external_versions.h"
+#include "rc_client_internal.h"
+
+#define RC_CONVERSION_FILL(obj, obj_type, src_type) memset((uint8_t*)obj + sizeof(src_type), 0, sizeof(obj_type) - sizeof(src_type))
+
+typedef struct rc_client_external_conversions_t {
+  rc_client_user_t user;
+  rc_client_game_t game;
+  rc_client_subset_t subsets[4];
+  rc_client_achievement_t achievements[16];
+  uint32_t next_subset_index;
+  uint32_t next_achievement_index;
+} rc_client_external_conversions_t;
+
+static void rc_client_external_conversions_init(const rc_client_t* client)
+{
+  if (!client->state.external_client_conversions) {
+    rc_client_t* mutable_client = (rc_client_t*)client;
+    rc_client_external_conversions_t* conversions = (rc_client_external_conversions_t*)
+      rc_buffer_alloc(&mutable_client->state.buffer, sizeof(rc_client_external_conversions_t));
+
+    memset(conversions, 0, sizeof(*conversions));
+
+    mutable_client->state.external_client_conversions = conversions;
+  }
+}
+
+const rc_client_user_t* rc_client_external_convert_v1_user(const rc_client_t* client, const rc_client_user_t* v1_user)
+{
+  rc_client_user_t* converted;
+  rc_client_external_conversions_init(client);
+
+  converted = &client->state.external_client_conversions->user;
+  memcpy(converted, v1_user, sizeof(v1_rc_client_user_t));
+  RC_CONVERSION_FILL(converted, rc_client_user_t, v1_rc_client_user_t);
+  return converted;
+}
+
+const rc_client_game_t* rc_client_external_convert_v1_game(const rc_client_t* client, const rc_client_game_t* v1_game)
+{
+  rc_client_game_t* converted;
+  rc_client_external_conversions_init(client);
+
+  converted = &client->state.external_client_conversions->game;
+  memcpy(converted, v1_game, sizeof(v1_rc_client_game_t));
+  RC_CONVERSION_FILL(converted, rc_client_game_t, v1_rc_client_game_t);
+  return converted;
+}
+
+const rc_client_subset_t* rc_client_external_convert_v1_subset(const rc_client_t* client, const rc_client_subset_t* v1_subset)
+{
+  rc_client_subset_t* converted = NULL;
+  const uint32_t num_subsets = sizeof(client->state.external_client_conversions->subsets) / sizeof(client->state.external_client_conversions->subsets[0]);
+  uint32_t index;
+
+  rc_client_external_conversions_init(client);
+
+  for (index = 0; index < num_subsets; ++index) {
+    if (client->state.external_client_conversions->subsets[index].id == v1_subset->id) {
+      converted = &client->state.external_client_conversions->subsets[index];
+      break;
+    }
+  }
+
+  if (!converted) {
+    converted = &client->state.external_client_conversions->subsets[client->state.external_client_conversions->next_subset_index];
+    client->state.external_client_conversions->next_subset_index = (client->state.external_client_conversions->next_subset_index + 1) % num_subsets;
+  }
+
+  memcpy(converted, v1_subset, sizeof(v1_rc_client_subset_t));
+  RC_CONVERSION_FILL(converted, rc_client_subset_t, v1_rc_client_subset_t);
+  return converted;
+}
+
+const rc_client_achievement_t* rc_client_external_convert_v1_achievement(const rc_client_t* client, const rc_client_achievement_t* v1_achievement)
+{
+  rc_client_achievement_t* converted = NULL;
+  const uint32_t num_achievements = sizeof(client->state.external_client_conversions->achievements) / sizeof(client->state.external_client_conversions->achievements[0]);
+  uint32_t index;
+
+  rc_client_external_conversions_init(client);
+
+  for (index = 0; index < num_achievements; ++index) {
+    if (client->state.external_client_conversions->achievements[index].id == v1_achievement->id) {
+      converted = &client->state.external_client_conversions->achievements[index];
+      break;
+    }
+  }
+
+  if (!converted) {
+    converted = &client->state.external_client_conversions->achievements[client->state.external_client_conversions->next_achievement_index];
+    client->state.external_client_conversions->next_achievement_index = (client->state.external_client_conversions->next_achievement_index + 1) % num_achievements;
+  }
+
+  memcpy(converted, v1_achievement, sizeof(v1_rc_client_achievement_t));
+  RC_CONVERSION_FILL(converted, rc_client_achievement_t, v1_rc_client_achievement_t);
+  return converted;
+}
+
+typedef struct rc_client_achievement_list_wrapper_t {
+  rc_client_achievement_list_info_t info;
+  rc_client_achievement_list_t* source_list;
+  rc_client_achievement_t* achievements;
+  rc_client_achievement_t** achievements_pointers;
+} rc_client_achievement_list_wrapper_t;
+
+static void rc_client_destroy_achievement_list_wrapper(rc_client_achievement_list_info_t* info)
+{
+  rc_client_achievement_list_wrapper_t* wrapper = (rc_client_achievement_list_wrapper_t*)info;
+
+  if (wrapper->achievements)
+    free(wrapper->achievements);
+  if (wrapper->achievements_pointers)
+    free(wrapper->achievements_pointers);
+  if (wrapper->info.public_.buckets)
+    free((void*)wrapper->info.public_.buckets);
+
+  rc_client_destroy_achievement_list(wrapper->source_list);
+}
+
+rc_client_achievement_list_t* rc_client_external_convert_v1_achievement_list(const rc_client_t* client, rc_client_achievement_list_t* v1_achievement_list)
+{
+  rc_client_achievement_list_wrapper_t* new_list;
+
+  new_list = (rc_client_achievement_list_wrapper_t*)calloc(1, sizeof(*new_list));
+  if (!new_list)
+    return NULL;
+
+  new_list->source_list = v1_achievement_list;
+  new_list->info.destroy_func = rc_client_destroy_achievement_list_wrapper;
+
+  if (v1_achievement_list->num_buckets) {
+    const v1_rc_client_achievement_bucket_t* src_bucket = (const v1_rc_client_achievement_bucket_t*)&v1_achievement_list->buckets[0];
+    const v1_rc_client_achievement_bucket_t* stop_bucket = src_bucket + v1_achievement_list->num_buckets;
+    rc_client_achievement_bucket_t* bucket;
+    uint32_t num_achievements = 0;
+
+    new_list->info.public_.buckets = bucket = (rc_client_achievement_bucket_t*)calloc(v1_achievement_list->num_buckets, sizeof(*new_list->info.public_.buckets));
+    if (!new_list->info.public_.buckets)
+      return (rc_client_achievement_list_t*)new_list;
+
+    for (; src_bucket < stop_bucket; src_bucket++)
+      num_achievements += src_bucket->num_achievements;
+
+    if (num_achievements) {
+      new_list->achievements = (rc_client_achievement_t*)calloc(num_achievements, sizeof(*new_list->achievements));
+      new_list->achievements_pointers = (rc_client_achievement_t**)malloc(num_achievements * sizeof(rc_client_achievement_t*));
+      if (!new_list->achievements || !new_list->achievements_pointers)
+        return (rc_client_achievement_list_t*)new_list;
+    }
+
+    num_achievements = 0;
+    src_bucket = (const v1_rc_client_achievement_bucket_t*)&v1_achievement_list->buckets[0];
+    for (; src_bucket < stop_bucket; src_bucket++, bucket++) {
+      memcpy(bucket, src_bucket, sizeof(*src_bucket));
+
+      if (src_bucket->num_achievements) {
+        const v1_rc_client_achievement_t** src_achievement = src_bucket->achievements;
+        const v1_rc_client_achievement_t** stop_achievement = src_achievement + src_bucket->num_achievements;
+        rc_client_achievement_t** achievement;
+
+        bucket->achievements = &new_list->achievements_pointers[num_achievements];
+
+        achievement = bucket->achievements;
+        for (; src_achievement < stop_achievement; ++src_achievement, ++achievement) {
+          *achievement = &new_list->achievements[num_achievements++];
+          memcpy(*achievement, *src_achievement, sizeof(**src_achievement));
+        }
+      }
+    }
+
+    new_list->info.public_.num_buckets = v1_achievement_list->num_buckets;
+  }
+
+  return (rc_client_achievement_list_t*)new_list;
+}

--- a/src/rc_client_external.c
+++ b/src/rc_client_external.c
@@ -123,6 +123,7 @@ static void rc_client_destroy_achievement_list_wrapper(rc_client_achievement_lis
 rc_client_achievement_list_t* rc_client_external_convert_v1_achievement_list(const rc_client_t* client, rc_client_achievement_list_t* v1_achievement_list)
 {
   rc_client_achievement_list_wrapper_t* new_list;
+  (void)client;
 
   new_list = (rc_client_achievement_list_wrapper_t*)calloc(1, sizeof(*new_list));
   if (!new_list)
@@ -157,13 +158,12 @@ rc_client_achievement_list_t* rc_client_external_convert_v1_achievement_list(con
       memcpy(bucket, src_bucket, sizeof(*src_bucket));
 
       if (src_bucket->num_achievements) {
-        const v1_rc_client_achievement_t** src_achievement = src_bucket->achievements;
+        const v1_rc_client_achievement_t** src_achievement = (const v1_rc_client_achievement_t**)src_bucket->achievements;
         const v1_rc_client_achievement_t** stop_achievement = src_achievement + src_bucket->num_achievements;
-        rc_client_achievement_t** achievement;
+        rc_client_achievement_t** achievement = &new_list->achievements_pointers[num_achievements];
 
-        bucket->achievements = &new_list->achievements_pointers[num_achievements];
+        bucket->achievements = (const rc_client_achievement_t**)achievement;
 
-        achievement = bucket->achievements;
         for (; src_achievement < stop_achievement; ++src_achievement, ++achievement) {
           *achievement = &new_list->achievements[num_achievements++];
           memcpy(*achievement, *src_achievement, sizeof(**src_achievement));

--- a/src/rc_client_external.c
+++ b/src/rc_client_external.c
@@ -118,6 +118,8 @@ static void rc_client_destroy_achievement_list_wrapper(rc_client_achievement_lis
     free((void*)wrapper->info.public_.buckets);
 
   rc_client_destroy_achievement_list(wrapper->source_list);
+
+  free(wrapper);
 }
 
 rc_client_achievement_list_t* rc_client_external_convert_v1_achievement_list(const rc_client_t* client, rc_client_achievement_list_t* v1_achievement_list)

--- a/src/rc_client_external.h
+++ b/src/rc_client_external.h
@@ -145,7 +145,7 @@ void rc_client_load_unknown_game(rc_client_t* client, const char* hash);
 
 /* conversion support */
 
-typedef struct rc_client_external_conversions_t rc_client_external_conversions_t;
+struct rc_client_external_conversions_t;
 const rc_client_user_t* rc_client_external_convert_v1_user(const rc_client_t* client, const rc_client_user_t* v1_user);
 const rc_client_game_t* rc_client_external_convert_v1_game(const rc_client_t* client, const rc_client_game_t* v1_game);
 const rc_client_subset_t* rc_client_external_convert_v1_subset(const rc_client_t* client, const rc_client_subset_t* v1_subset);

--- a/src/rc_client_external.h
+++ b/src/rc_client_external.h
@@ -129,12 +129,28 @@ typedef struct rc_client_external_t
   rc_client_external_add_game_hash_func_t add_game_hash;
   rc_client_external_set_string_func_t load_unknown_game;
 
+  /* VERSION 3 */
+  rc_client_external_get_user_info_func_t get_user_info_v3;
+  rc_client_external_get_game_info_func_t get_game_info_v3;
+  rc_client_external_get_subset_info_func_t get_subset_info_v3;
+  rc_client_external_get_achievement_info_func_t get_achievement_info_v3;
+  rc_client_external_create_achievement_list_func_t create_achievement_list_v3;
+
 } rc_client_external_t;
 
-#define RC_CLIENT_EXTERNAL_VERSION 2
+#define RC_CLIENT_EXTERNAL_VERSION 3
 
 void rc_client_add_game_hash(rc_client_t* client, const char* hash, uint32_t game_id);
 void rc_client_load_unknown_game(rc_client_t* client, const char* hash);
+
+/* conversion support */
+
+typedef struct rc_client_external_conversions_t rc_client_external_conversions_t;
+const rc_client_user_t* rc_client_external_convert_v1_user(const rc_client_t* client, const rc_client_user_t* v1_user);
+const rc_client_game_t* rc_client_external_convert_v1_game(const rc_client_t* client, const rc_client_game_t* v1_game);
+const rc_client_subset_t* rc_client_external_convert_v1_subset(const rc_client_t* client, const rc_client_subset_t* v1_subset);
+const rc_client_achievement_t* rc_client_external_convert_v1_achievement(const rc_client_t* client, const rc_client_achievement_t* v1_achievement);
+rc_client_achievement_list_t* rc_client_external_convert_v1_achievement_list(const rc_client_t* client, rc_client_achievement_list_t* v1_achievement_list);
 
 RC_END_C_DECLS
 

--- a/src/rc_client_external_versions.h
+++ b/src/rc_client_external_versions.h
@@ -1,0 +1,149 @@
+#ifndef RC_CLIENT_EXTERNAL_CONVERSIONS_H
+#define RC_CLIENT_EXTERNAL_CONVERSIONS_H
+
+#include "rc_client_internal.h"
+
+RC_BEGIN_C_DECLS
+
+/* user */
+
+typedef struct v1_rc_client_user_t {
+  const char* display_name;
+  const char* username;
+  const char* token;
+  uint32_t score;
+  uint32_t score_softcore;
+  uint32_t num_unread_messages;
+} v1_rc_client_user_t;
+
+typedef struct v3_rc_client_user_t {
+  const char* display_name;
+  const char* username;
+  const char* token;
+  uint32_t score;
+  uint32_t score_softcore;
+  uint32_t num_unread_messages;
+  const char* avatar_url;
+} v3_rc_client_user_t;
+
+/* game */
+
+typedef struct v1_rc_client_game_t {
+  uint32_t id;
+  uint32_t console_id;
+  const char* title;
+  const char* hash;
+  const char* badge_name;
+} v1_rc_client_game_t;
+
+typedef struct v3_rc_client_game_t {
+  uint32_t id;
+  uint32_t console_id;
+  const char* title;
+  const char* hash;
+  const char* badge_name;
+  const char* badge_url;
+} v3_rc_client_game_t;
+
+/* subset */
+
+typedef struct v1_rc_client_subset_t {
+  uint32_t id;
+  const char* title;
+  char badge_name[16];
+  uint32_t num_achievements;
+  uint32_t num_leaderboards;
+} v1_rc_client_subset_t;
+
+typedef struct v3_rc_client_subset_t {
+  uint32_t id;
+  const char* title;
+  char badge_name[16];
+  uint32_t num_achievements;
+  uint32_t num_leaderboards;
+  const char* badge_url;
+} v3_rc_client_subset_t;
+
+/* achievement */
+
+typedef struct v1_rc_client_achievement_t {
+  const char* title;
+  const char* description;
+  char badge_name[8];
+  char measured_progress[24];
+  float measured_percent;
+  uint32_t id;
+  uint32_t points;
+  time_t unlock_time;
+  uint8_t state;
+  uint8_t category;
+  uint8_t bucket;
+  uint8_t unlocked;
+  float rarity;
+  float rarity_hardcore;
+  uint8_t type;
+} v1_rc_client_achievement_t;
+
+typedef struct v3_rc_client_achievement_t {
+  const char* title;
+  const char* description;
+  char badge_name[8];
+  char measured_progress[24];
+  float measured_percent;
+  uint32_t id;
+  uint32_t points;
+  time_t unlock_time;
+  uint8_t state;
+  uint8_t category;
+  uint8_t bucket;
+  uint8_t unlocked;
+  float rarity;
+  float rarity_hardcore;
+  uint8_t type;
+  const char* badge_url;
+  const char* badge_locked_url;
+} v3_rc_client_achievement_t;
+
+/* achievement list */
+
+typedef struct v1_rc_client_achievement_bucket_t {
+  v1_rc_client_achievement_t** achievements;
+  uint32_t num_achievements;
+
+  const char* label;
+  uint32_t subset_id;
+  uint8_t bucket_type;
+} v1_rc_client_achievement_bucket_t;
+
+typedef struct v1_rc_client_achievement_list_t {
+  v1_rc_client_achievement_bucket_t* buckets;
+  uint32_t num_buckets;
+} v1_rc_client_achievement_list_t;
+
+typedef struct v1_rc_client_achievement_list_info_t {
+  v1_rc_client_achievement_list_t public_;
+  rc_client_destroy_achievement_list_func_t destroy_func;
+} v1_rc_client_achievement_list_info_t;
+
+typedef struct v3_rc_client_achievement_bucket_t {
+  const v3_rc_client_achievement_t** achievements;
+  uint32_t num_achievements;
+
+  const char* label;
+  uint32_t subset_id;
+  uint8_t bucket_type;
+} v3_rc_client_achievement_bucket_t;
+
+typedef struct v3_rc_client_achievement_list_t {
+  const v3_rc_client_achievement_bucket_t* buckets;
+  uint32_t num_buckets;
+} v3_rc_client_achievement_list_t;
+
+typedef struct v3_rc_client_achievement_list_info_t {
+  v3_rc_client_achievement_list_t public_;
+  rc_client_destroy_achievement_list_func_t destroy_func;
+} v3_rc_client_achievement_list_info_t;
+
+RC_END_C_DECLS
+
+#endif /* RC_CLIENT_EXTERNAL_CONVERSIONS_H */

--- a/src/rc_client_internal.h
+++ b/src/rc_client_internal.h
@@ -302,7 +302,7 @@ typedef struct rc_client_state_t {
 
 #ifdef RC_CLIENT_SUPPORTS_EXTERNAL
   rc_client_external_t* external_client;
-  rc_client_external_conversions_t* external_client_conversions;
+  struct rc_client_external_conversions_t* external_client_conversions;
 #endif
 #ifdef RC_CLIENT_SUPPORTS_RAINTEGRATION
   rc_client_raintegration_t* raintegration;

--- a/src/rc_client_internal.h
+++ b/src/rc_client_internal.h
@@ -302,6 +302,7 @@ typedef struct rc_client_state_t {
 
 #ifdef RC_CLIENT_SUPPORTS_EXTERNAL
   rc_client_external_t* external_client;
+  rc_client_external_conversions_t* external_client_conversions;
 #endif
 #ifdef RC_CLIENT_SUPPORTS_RAINTEGRATION
   rc_client_raintegration_t* raintegration;

--- a/test/Makefile
+++ b/test/Makefile
@@ -125,7 +125,7 @@ else ifeq ($(BUILD), retroarch)
     # Also include the RC_CLIENT_SUPPORTS_EXTERNAL flag to ensure we do the full level of validation on the
     # most code. The c89 build will ensure things still build without the RC_CLIENT_SUPPORTS_EXTERNAL flag.
     CFLAGS += -DRC_CLIENT_SUPPORTS_EXTERNAL
-    OBJ += test_rc_client_external.o
+    OBJ += $(RC_SRC)/rc_client_external.o test_rc_client_external.o
 else
     $(error unknown BUILD "$(BUILD)")
 endif

--- a/test/rcheevos-test.vcxproj
+++ b/test/rcheevos-test.vcxproj
@@ -150,6 +150,7 @@
     <ClCompile Include="..\src\rcheevos\trigger.c" />
     <ClCompile Include="..\src\rcheevos\value.c" />
     <ClCompile Include="..\src\rc_client.c" />
+    <ClCompile Include="..\src\rc_client_external.c" />
     <ClCompile Include="..\src\rc_client_raintegration.c" />
     <ClCompile Include="..\src\rc_compat.c" />
     <ClCompile Include="..\src\rc_libretro.c" />
@@ -241,6 +242,7 @@
     <ClInclude Include="..\src\rapi\rc_api_common.h" />
     <ClInclude Include="..\src\rcheevos\rc_validate.h" />
     <ClInclude Include="..\src\rc_client_external.h" />
+    <ClInclude Include="..\src\rc_client_external_versions.h" />
     <ClInclude Include="..\src\rc_client_internal.h" />
     <ClInclude Include="..\src\rc_compat.h" />
     <ClInclude Include="..\src\rc_libretro.h" />

--- a/test/rcheevos-test.vcxproj.filters
+++ b/test/rcheevos-test.vcxproj.filters
@@ -308,6 +308,9 @@
     </ClCompile>
     <ClCompile Include="..\src\rc_version.c" />
     <ClCompile Include="..\src\rhash\aes.c" />
+    <ClCompile Include="..\src\rc_client_external.c">
+      <Filter>src</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\include\rcheevos.h">
@@ -398,6 +401,9 @@
       <Filter>src</Filter>
     </ClInclude>
     <ClInclude Include="..\src\rhash\aes.h" />
+    <ClInclude Include="..\src\rc_client_external_versions.h">
+      <Filter>src</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Natvis Include="..\src\rcheevos\rc_runtime_types.natvis">

--- a/test/test_rc_client.c
+++ b/test/test_rc_client.c
@@ -3432,8 +3432,8 @@ static void test_load_subset(void)
 static void test_achievement_list_simple(void)
 {
   rc_client_achievement_list_t* list;
-  rc_client_achievement_t** iter;
-  rc_client_achievement_t* achievement;
+  const rc_client_achievement_t** iter;
+  const rc_client_achievement_t* achievement;
 
   g_client = mock_client_game_loaded(patchdata_2ach_1lbd, no_unlocks);
 
@@ -3468,8 +3468,8 @@ static void test_achievement_list_simple(void)
 static void test_achievement_list_simple_with_unlocks(void)
 {
   rc_client_achievement_list_t* list;
-  rc_client_achievement_t** iter;
-  rc_client_achievement_t* achievement;
+  const rc_client_achievement_t** iter;
+  const rc_client_achievement_t* achievement;
 
   g_client = mock_client_game_loaded(patchdata_2ach_1lbd, unlock_5501h_and_5502);
 
@@ -3528,8 +3528,8 @@ static void test_achievement_list_simple_with_unlocks(void)
 static void test_achievement_list_simple_with_unlocks_encore_mode(void)
 {
   rc_client_achievement_list_t* list;
-  rc_client_achievement_t** iter;
-  rc_client_achievement_t* achievement;
+  const rc_client_achievement_t** iter;
+  const rc_client_achievement_t* achievement;
 
   uint8_t memory[64];
   memset(memory, 0, sizeof(memory));
@@ -3771,8 +3771,8 @@ static void test_achievement_list_simple_with_unofficial_off(void)
 static void test_achievement_list_buckets(void)
 {
   rc_client_achievement_list_t* list;
-  rc_client_achievement_t** iter;
-  rc_client_achievement_t* achievement;
+  const rc_client_achievement_t** iter;
+  const rc_client_achievement_t* achievement;
 
   uint8_t memory[64];
   memset(memory, 0, sizeof(memory));
@@ -3957,8 +3957,8 @@ static void test_achievement_list_buckets(void)
 static void test_achievement_list_buckets_progress_sort(void)
 {
   rc_client_achievement_list_t* list;
-  rc_client_achievement_t** iter;
-  rc_client_achievement_t* achievement;
+  const rc_client_achievement_t** iter;
+  const rc_client_achievement_t* achievement;
 
   uint8_t memory[64];
   memset(memory, 0, sizeof(memory));
@@ -4028,8 +4028,8 @@ static void test_achievement_list_buckets_progress_sort(void)
 static void test_achievement_list_buckets_progress_sort_big_ids(void)
 {
   rc_client_achievement_list_t* list;
-  rc_client_achievement_t** iter;
-  rc_client_achievement_t* achievement;
+  const rc_client_achievement_t** iter;
+  const rc_client_achievement_t* achievement;
 
   uint8_t memory[64];
   memset(memory, 0, sizeof(memory));
@@ -4329,8 +4329,8 @@ static void test_achievement_list_subset_with_unofficial_and_unsupported(void)
 static void test_achievement_list_subset_buckets(void)
 {
   rc_client_achievement_list_t* list;
-  rc_client_achievement_t** iter;
-  rc_client_achievement_t* achievement;
+  const rc_client_achievement_t** iter;
+  const rc_client_achievement_t* achievement;
 
   uint8_t memory[64];
   memset(memory, 0, sizeof(memory));
@@ -4561,8 +4561,8 @@ static void test_achievement_get_image_url(void)
 static void test_leaderboard_list_simple(void)
 {
   rc_client_leaderboard_list_t* list;
-  rc_client_leaderboard_t** iter;
-  rc_client_leaderboard_t* leaderboard;
+  const rc_client_leaderboard_t** iter;
+  const rc_client_leaderboard_t* leaderboard;
   uint8_t memory[16] = { 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0 };
 
   g_client = mock_client_logged_in();
@@ -4634,8 +4634,8 @@ static void test_leaderboard_list_simple(void)
 static void test_leaderboard_list_simple_with_unsupported(void)
 {
   rc_client_leaderboard_list_t* list;
-  rc_client_leaderboard_t** iter;
-  rc_client_leaderboard_t* leaderboard;
+  const rc_client_leaderboard_t** iter;
+  const rc_client_leaderboard_t* leaderboard;
   uint8_t memory[16] = { 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0 };
 
   g_client = mock_client_logged_in();
@@ -4683,8 +4683,8 @@ static void test_leaderboard_list_simple_with_unsupported(void)
 static void test_leaderboard_list_buckets(void)
 {
   rc_client_leaderboard_list_t* list;
-  rc_client_leaderboard_t** iter;
-  rc_client_leaderboard_t* leaderboard;
+  const rc_client_leaderboard_t** iter;
+  const rc_client_leaderboard_t* leaderboard;
   uint8_t memory[16] = { 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0 };
 
   g_client = mock_client_logged_in();
@@ -4765,8 +4765,8 @@ static void test_leaderboard_list_buckets(void)
 static void test_leaderboard_list_buckets_with_unsupported(void)
 {
   rc_client_leaderboard_list_t* list;
-  rc_client_leaderboard_t** iter;
-  rc_client_leaderboard_t* leaderboard;
+  const rc_client_leaderboard_t** iter;
+  const rc_client_leaderboard_t* leaderboard;
   uint8_t memory[16] = { 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0 };
 
   g_client = mock_client_logged_in();
@@ -4861,8 +4861,8 @@ static void test_leaderboard_list_buckets_with_unsupported(void)
 static void test_leaderboard_list_subset(void)
 {
   rc_client_leaderboard_list_t* list;
-  rc_client_leaderboard_t** iter;
-  rc_client_leaderboard_t* leaderboard;
+  const rc_client_leaderboard_t** iter;
+  const rc_client_leaderboard_t* leaderboard;
   uint8_t memory[16] = { 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0 };
 
   g_client = mock_client_logged_in();
@@ -4966,8 +4966,8 @@ static void test_leaderboard_list_subset(void)
 static void test_leaderboard_list_hidden(void)
 {
   rc_client_leaderboard_list_t* list;
-  rc_client_leaderboard_t** iter;
-  rc_client_leaderboard_t* leaderboard;
+  const rc_client_leaderboard_t** iter;
+  const rc_client_leaderboard_t* leaderboard;
   uint8_t memory[16] = { 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0 };
 
   g_client = mock_client_logged_in();

--- a/test/test_rc_client_external.c
+++ b/test/test_rc_client_external.c
@@ -1,5 +1,6 @@
 #include "rc_client.h"
 
+#include "../src/rc_client_external_versions.h"
 #include "../src/rc_client_internal.h"
 #include "../src/rc_version.h"
 #include "rc_consoles.h"
@@ -22,6 +23,17 @@ extern void mock_api_response(const char* request_params, const char* response_b
 extern void mock_api_error(const char* request_params, const char* response_body, int http_status_code);
 
 /* end from test_rc_client.c */
+
+#define RC_OFFSETOF(s,f) ((uint32_t)((uint8_t*)&(((s*)(0))->f) - ((uint8_t*)0)))
+
+#define ASSERT_FIELD_OFFSET(struct1, struct2, field) { \
+  const uint32_t __o1 = RC_OFFSETOF(struct1, field); \
+  const uint32_t __o2 = RC_OFFSETOF(struct2, field); \
+  if (__o1 != __o2) { \
+    ASSERT_FAIL("Expected: " #struct1 "." #field " at offset %u (%s:%d)\n  Found: " #struct2 "." #field " at offset %u", \
+                __o1, test_framework_basename(__FILE__), __LINE__, __o2); \
+  } \
+}
 
 static uint32_t rc_client_read_memory(uint32_t address, uint8_t* buffer, uint32_t num_bytes, rc_client_t* client)
 {
@@ -323,14 +335,26 @@ static void test_add_game_hash(void)
 
 /* ----- login ----- */
 
-typedef struct v1_rc_client_user_t {
-  const char* display_name;
-  const char* username;
-  const char* token;
-  uint32_t score;
-  uint32_t score_softcore;
-  uint32_t num_unread_messages;
-} v1_rc_client_user_t;
+static void test_v1_user_field_offsets(void)
+{
+  ASSERT_FIELD_OFFSET(rc_client_user_t, v1_rc_client_user_t, display_name);
+  ASSERT_FIELD_OFFSET(rc_client_user_t, v1_rc_client_user_t, username);
+  ASSERT_FIELD_OFFSET(rc_client_user_t, v1_rc_client_user_t, token);
+  ASSERT_FIELD_OFFSET(rc_client_user_t, v1_rc_client_user_t, score);
+  ASSERT_FIELD_OFFSET(rc_client_user_t, v1_rc_client_user_t, score_softcore);
+  ASSERT_FIELD_OFFSET(rc_client_user_t, v1_rc_client_user_t, num_unread_messages);
+}
+
+static void test_v3_user_field_offsets(void)
+{
+  ASSERT_FIELD_OFFSET(rc_client_user_t, v3_rc_client_user_t, display_name);
+  ASSERT_FIELD_OFFSET(rc_client_user_t, v3_rc_client_user_t, username);
+  ASSERT_FIELD_OFFSET(rc_client_user_t, v3_rc_client_user_t, token);
+  ASSERT_FIELD_OFFSET(rc_client_user_t, v3_rc_client_user_t, score);
+  ASSERT_FIELD_OFFSET(rc_client_user_t, v3_rc_client_user_t, score_softcore);
+  ASSERT_FIELD_OFFSET(rc_client_user_t, v3_rc_client_user_t, num_unread_messages);
+  ASSERT_FIELD_OFFSET(rc_client_user_t, v3_rc_client_user_t, avatar_url);
+}
 
 static void assert_login_with_password(rc_client_t* client, const char* username, const char* password)
 {
@@ -351,7 +375,7 @@ static rc_client_async_handle_t* rc_client_external_login_with_password(rc_clien
   return NULL;
 }
 
-static const rc_client_user_t* rc_client_external_get_user_info(void)
+static const rc_client_user_t* rc_client_external_get_user_info_v1(void)
 {
   v1_rc_client_user_t* user = (v1_rc_client_user_t*)
       rc_buffer_alloc(&g_client->state.buffer, sizeof(v1_rc_client_user_t));
@@ -367,13 +391,31 @@ static const rc_client_user_t* rc_client_external_get_user_info(void)
   return (rc_client_user_t*)user;
 }
 
+static const rc_client_user_t* rc_client_external_get_user_info_v3(void)
+{
+  v3_rc_client_user_t* user = (v3_rc_client_user_t*)
+    rc_buffer_alloc(&g_client->state.buffer, sizeof(v3_rc_client_user_t));
+
+  memset(user, 0, sizeof(*user));
+  user->display_name = "User";
+  user->username = "User";
+  user->token = "ApiToken";
+  user->score = 12345;
+  user->score_softcore = 123;
+  user->num_unread_messages = 2;
+  user->avatar_url = "/UserPic/User.png";
+
+  return (rc_client_user_t*)user;
+}
+
 static void test_login_with_password(void)
 {
   const rc_client_user_t* user;
 
   g_client = mock_client_with_external();
   g_client->state.external_client->begin_login_with_password = rc_client_external_login_with_password;
-  g_client->state.external_client->get_user_info = rc_client_external_get_user_info;
+  g_client->state.external_client->get_user_info = rc_client_external_get_user_info_v1;
+  g_client->state.external_client->get_user_info_v3 = rc_client_external_get_user_info_v3;
 
   rc_client_begin_login_with_password(g_client, "User", "Pa$$word", rc_client_callback_expect_success, g_callback_userdata);
 
@@ -388,6 +430,7 @@ static void test_login_with_password(void)
   ASSERT_NUM_EQUALS(user->score, 12345);
   ASSERT_NUM_EQUALS(user->score_softcore, 123);
   ASSERT_NUM_EQUALS(user->num_unread_messages, 2);
+  ASSERT_STR_EQUALS(user->avatar_url, "/UserPic/User.png");
 
   /* ensure non-external client user was not initialized */
   ASSERT_PTR_NULL(g_client->user.username);
@@ -414,13 +457,13 @@ static rc_client_async_handle_t* rc_client_external_login_with_token(rc_client_t
   return NULL;
 }
 
-static void test_login_with_token(void)
+static void test_login_with_token_v1(void)
 {
   const rc_client_user_t* user;
 
   g_client = mock_client_with_external();
   g_client->state.external_client->begin_login_with_token = rc_client_external_login_with_token;
-  g_client->state.external_client->get_user_info = rc_client_external_get_user_info;
+  g_client->state.external_client->get_user_info = rc_client_external_get_user_info_v1;
 
   rc_client_begin_login_with_token(g_client, "User", "ApiToken", rc_client_callback_expect_success, g_callback_userdata);
 
@@ -435,6 +478,36 @@ static void test_login_with_token(void)
   ASSERT_NUM_EQUALS(user->score, 12345);
   ASSERT_NUM_EQUALS(user->score_softcore, 123);
   ASSERT_NUM_EQUALS(user->num_unread_messages, 2);
+  ASSERT_PTR_NULL(user->avatar_url);
+
+  /* ensure non-external client user was not initialized */
+  ASSERT_PTR_NULL(g_client->user.username);
+
+  rc_client_destroy(g_client);
+}
+
+static void test_login_with_token(void)
+{
+  const rc_client_user_t* user;
+
+  g_client = mock_client_with_external();
+  g_client->state.external_client->begin_login_with_token = rc_client_external_login_with_token;
+  g_client->state.external_client->get_user_info_v3 = rc_client_external_get_user_info_v3;
+
+  rc_client_begin_login_with_token(g_client, "User", "ApiToken", rc_client_callback_expect_success, g_callback_userdata);
+
+  ASSERT_STR_EQUALS(g_external_event, "login");
+
+  /* user data should come from external client. validate structure */
+  user = rc_client_get_user_info(g_client);
+  ASSERT_PTR_NOT_NULL(user);
+  ASSERT_STR_EQUALS(user->username, "User");
+  ASSERT_STR_EQUALS(user->display_name, "User");
+  ASSERT_STR_EQUALS(user->token, "ApiToken");
+  ASSERT_NUM_EQUALS(user->score, 12345);
+  ASSERT_NUM_EQUALS(user->score_softcore, 123);
+  ASSERT_NUM_EQUALS(user->num_unread_messages, 2);
+  ASSERT_STR_EQUALS(user->avatar_url, "/UserPic/User.png");
 
   /* ensure non-external client user was not initialized */
   ASSERT_PTR_NULL(g_client->user.username);
@@ -466,15 +539,26 @@ static void test_logout(void)
 
 /* ----- load game ----- */
 
-typedef struct v1_rc_client_game_t {
-  uint32_t id;
-  uint32_t console_id;
-  const char* title;
-  const char* hash;
-  const char* badge_name;
-} v1_rc_client_game_t;
+static void test_v1_game_field_offsets(void)
+{
+  ASSERT_FIELD_OFFSET(rc_client_game_t, v1_rc_client_game_t, id);
+  ASSERT_FIELD_OFFSET(rc_client_game_t, v1_rc_client_game_t, console_id);
+  ASSERT_FIELD_OFFSET(rc_client_game_t, v1_rc_client_game_t, title);
+  ASSERT_FIELD_OFFSET(rc_client_game_t, v1_rc_client_game_t, hash);
+  ASSERT_FIELD_OFFSET(rc_client_game_t, v1_rc_client_game_t, badge_name);
+}
 
-static const rc_client_game_t* rc_client_external_get_game_info(void)
+static void test_v3_game_field_offsets(void)
+{
+  ASSERT_FIELD_OFFSET(rc_client_game_t, v3_rc_client_game_t, id);
+  ASSERT_FIELD_OFFSET(rc_client_game_t, v3_rc_client_game_t, console_id);
+  ASSERT_FIELD_OFFSET(rc_client_game_t, v3_rc_client_game_t, title);
+  ASSERT_FIELD_OFFSET(rc_client_game_t, v3_rc_client_game_t, hash);
+  ASSERT_FIELD_OFFSET(rc_client_game_t, v3_rc_client_game_t, badge_name);
+  ASSERT_FIELD_OFFSET(rc_client_game_t, v3_rc_client_game_t, badge_url);
+}
+
+static const rc_client_game_t* rc_client_external_get_game_info_v1(void)
 {
   v1_rc_client_game_t* game = (v1_rc_client_game_t*)
     rc_buffer_alloc(&g_client->state.buffer, sizeof(v1_rc_client_game_t));
@@ -485,6 +569,22 @@ static const rc_client_game_t* rc_client_external_get_game_info(void)
   game->title = "Game Title";
   game->hash = "GAME_HASH";
   game->badge_name = "BDG001";
+
+  return (const rc_client_game_t*)game;
+}
+
+static const rc_client_game_t* rc_client_external_get_game_info_v3(void)
+{
+  v3_rc_client_game_t* game = (v3_rc_client_game_t*)
+    rc_buffer_alloc(&g_client->state.buffer, sizeof(v3_rc_client_game_t));
+
+  memset(game, 0, sizeof(*game));
+  game->id = 1234;
+  game->console_id = RC_CONSOLE_PLAYSTATION;
+  game->title = "Game Title";
+  game->hash = "GAME_HASH";
+  game->badge_name = "BDG001";
+  game->badge_url = "/Badge/BDG001.png";
 
   return (const rc_client_game_t*)game;
 }
@@ -514,7 +614,7 @@ static rc_client_async_handle_t* rc_client_external_identify_and_load_game(rc_cl
   return NULL;
 }
 
-static void test_identify_and_load_game(void)
+static void test_identify_and_load_game_v1(void)
 {
   size_t image_size;
   uint8_t* image = generate_nes_file(32, 1, &image_size);
@@ -522,7 +622,7 @@ static void test_identify_and_load_game(void)
 
   g_client = mock_client_with_external();
   g_client->state.external_client->begin_identify_and_load_game = rc_client_external_identify_and_load_game;
-  g_client->state.external_client->get_game_info = rc_client_external_get_game_info;
+  g_client->state.external_client->get_game_info = rc_client_external_get_game_info_v1;
 
   rc_client_begin_identify_and_load_game(g_client, RC_CONSOLE_NINTENDO, "foo.zip#foo.nes",
     image, image_size, rc_client_callback_expect_success, g_callback_userdata);
@@ -537,6 +637,39 @@ static void test_identify_and_load_game(void)
   ASSERT_STR_EQUALS(game->title, "Game Title");
   ASSERT_STR_EQUALS(game->hash, "GAME_HASH");
   ASSERT_STR_EQUALS(game->badge_name, "BDG001");
+  ASSERT_PTR_NULL(game->badge_url);
+  /* ensure non-external client game was not initialized */
+  ASSERT_PTR_NULL(g_client->game);
+
+  rc_client_destroy(g_client);
+  free(image);
+}
+
+static void test_identify_and_load_game(void)
+{
+  size_t image_size;
+  uint8_t* image = generate_nes_file(32, 1, &image_size);
+  const rc_client_game_t* game;
+
+  g_client = mock_client_with_external();
+  g_client->state.external_client->begin_identify_and_load_game = rc_client_external_identify_and_load_game;
+  g_client->state.external_client->get_game_info = rc_client_external_get_game_info_v1;
+  g_client->state.external_client->get_game_info_v3 = rc_client_external_get_game_info_v3;
+
+  rc_client_begin_identify_and_load_game(g_client, RC_CONSOLE_NINTENDO, "foo.zip#foo.nes",
+    image, image_size, rc_client_callback_expect_success, g_callback_userdata);
+
+  ASSERT_STR_EQUALS(g_external_event, "load_game");
+
+  /* user data should come from external client. validate structure */
+  game = rc_client_get_game_info(g_client);
+  ASSERT_PTR_NOT_NULL(game);
+  ASSERT_NUM_EQUALS(game->id, 1234);
+  ASSERT_NUM_EQUALS(game->console_id, RC_CONSOLE_PLAYSTATION);
+  ASSERT_STR_EQUALS(game->title, "Game Title");
+  ASSERT_STR_EQUALS(game->hash, "GAME_HASH");
+  ASSERT_STR_EQUALS(game->badge_name, "BDG001");
+  ASSERT_STR_EQUALS(game->badge_url, "/Badge/BDG001.png");
   /* ensure non-external client game was not initialized */
   ASSERT_PTR_NULL(g_client->game);
 
@@ -564,19 +697,19 @@ static rc_client_async_handle_t* rc_client_external_load_game(rc_client_t* clien
   return NULL;
 }
 
-static void test_load_game(void)
+static void test_load_game_v1(void)
 {
   const rc_client_game_t* game;
 
   g_client = mock_client_with_external();
   g_client->state.external_client->begin_load_game = rc_client_external_load_game;
-  g_client->state.external_client->get_game_info = rc_client_external_get_game_info;
+  g_client->state.external_client->get_game_info = rc_client_external_get_game_info_v1;
 
   rc_client_begin_load_game(g_client, "6a2305a2b6675a97ff792709be1ca857", rc_client_callback_expect_success, g_callback_userdata);
 
   ASSERT_STR_EQUALS(g_external_event, "load_game");
 
-  /* user data should come from external client. validate structure */
+  /* game data should come from external client. validate structure */
   game = rc_client_get_game_info(g_client);
   ASSERT_PTR_NOT_NULL(game);
   ASSERT_NUM_EQUALS(game->id, 1234);
@@ -584,6 +717,35 @@ static void test_load_game(void)
   ASSERT_STR_EQUALS(game->title, "Game Title");
   ASSERT_STR_EQUALS(game->hash, "GAME_HASH");
   ASSERT_STR_EQUALS(game->badge_name, "BDG001");
+  ASSERT_PTR_NULL(game->badge_url);
+  /* ensure non-external client user was not initialized */
+  ASSERT_PTR_NULL(g_client->game);
+
+  rc_client_destroy(g_client);
+}
+
+static void test_load_game(void)
+{
+  const rc_client_game_t* game;
+
+  g_client = mock_client_with_external();
+  g_client->state.external_client->begin_load_game = rc_client_external_load_game;
+  g_client->state.external_client->get_game_info = rc_client_external_get_game_info_v1;
+  g_client->state.external_client->get_game_info_v3 = rc_client_external_get_game_info_v3;
+
+  rc_client_begin_load_game(g_client, "6a2305a2b6675a97ff792709be1ca857", rc_client_callback_expect_success, g_callback_userdata);
+
+  ASSERT_STR_EQUALS(g_external_event, "load_game");
+
+  /* game data should come from external client. validate structure */
+  game = rc_client_get_game_info(g_client);
+  ASSERT_PTR_NOT_NULL(game);
+  ASSERT_NUM_EQUALS(game->id, 1234);
+  ASSERT_NUM_EQUALS(game->console_id, RC_CONSOLE_PLAYSTATION);
+  ASSERT_STR_EQUALS(game->title, "Game Title");
+  ASSERT_STR_EQUALS(game->hash, "GAME_HASH");
+  ASSERT_STR_EQUALS(game->badge_name, "BDG001");
+  ASSERT_STR_EQUALS(game->badge_url, "/Badge/BDG001.png");
   /* ensure non-external client user was not initialized */
   ASSERT_PTR_NULL(g_client->game);
 
@@ -630,7 +792,7 @@ static void test_identify_and_load_game_external_hash(void)
   g_client = mock_client_with_external();
   g_client->state.external_client->add_game_hash = rc_client_external_add_game_hash;
   g_client->state.external_client->begin_load_game = rc_client_external_load_game;
-  g_client->state.external_client->get_game_info = rc_client_external_get_game_info;
+  g_client->state.external_client->get_game_info_v3 = rc_client_external_get_game_info_v3;
 
   mock_api_response("r=gameid&m=6a2305a2b6675a97ff792709be1ca857", "{\"Success\":true,\"GameID\":1234}");
   g_external_int = 0;
@@ -650,6 +812,7 @@ static void test_identify_and_load_game_external_hash(void)
   ASSERT_STR_EQUALS(game->title, "Game Title");
   ASSERT_STR_EQUALS(game->hash, "GAME_HASH");
   ASSERT_STR_EQUALS(game->badge_name, "BDG001");
+  ASSERT_STR_EQUALS(game->badge_url, "/Badge/BDG001.png");
   /* ensure internal client game was initialized to hold media hashes */
   ASSERT_PTR_NOT_NULL(g_client->game);
 
@@ -723,14 +886,95 @@ static void test_change_media_from_hash(void)
   rc_client_destroy(g_client);
 }
 
-typedef struct v1_rc_client_subset_t {
-  uint32_t id;
-  const char* title;
-  char badge_name[16];
+static const rc_client_subset_t* rc_client_external_get_subset_info_v1(uint32_t subset_id)
+{
+  v1_rc_client_subset_t* subset = (v1_rc_client_subset_t*)
+    rc_buffer_alloc(&g_client->state.buffer, sizeof(v1_rc_client_subset_t));
 
-  uint32_t num_achievements;
-  uint32_t num_leaderboards;
-} v1_rc_client_subset_t;
+  memset(subset, 0, sizeof(*subset));
+  subset->id = subset_id;
+  subset->title = "Subset Title";
+  snprintf(subset->badge_name, sizeof(subset->badge_name), "%s", "BDG001");
+  subset->num_achievements = 2;
+  subset->num_leaderboards = 1;
+
+  return (const rc_client_subset_t*)subset;
+}
+
+static const rc_client_subset_t* rc_client_external_get_subset_info_v3(uint32_t subset_id)
+{
+  v3_rc_client_subset_t* subset = (v3_rc_client_subset_t*)
+    rc_buffer_alloc(&g_client->state.buffer, sizeof(v3_rc_client_subset_t));
+
+  memset(subset, 0, sizeof(*subset));
+  subset->id = subset_id;
+  subset->title = "Subset Title";
+  snprintf(subset->badge_name, sizeof(subset->badge_name), "%s", "BDG001");
+  subset->num_achievements = 2;
+  subset->num_leaderboards = 1;
+  subset->badge_url = "/Badge/BDG001.png";
+
+  return (const rc_client_subset_t*)subset;
+}
+
+static void test_v1_subset_field_offsets(void)
+{
+  ASSERT_FIELD_OFFSET(rc_client_subset_t, v1_rc_client_subset_t, id);
+  ASSERT_FIELD_OFFSET(rc_client_subset_t, v1_rc_client_subset_t, title);
+  ASSERT_FIELD_OFFSET(rc_client_subset_t, v1_rc_client_subset_t, badge_name);
+  ASSERT_FIELD_OFFSET(rc_client_subset_t, v1_rc_client_subset_t, num_achievements);
+  ASSERT_FIELD_OFFSET(rc_client_subset_t, v1_rc_client_subset_t, num_leaderboards);
+}
+
+static void test_v3_subset_field_offsets(void)
+{
+  ASSERT_FIELD_OFFSET(rc_client_subset_t, v3_rc_client_subset_t, id);
+  ASSERT_FIELD_OFFSET(rc_client_subset_t, v3_rc_client_subset_t, title);
+  ASSERT_FIELD_OFFSET(rc_client_subset_t, v3_rc_client_subset_t, badge_name);
+  ASSERT_FIELD_OFFSET(rc_client_subset_t, v3_rc_client_subset_t, num_achievements);
+  ASSERT_FIELD_OFFSET(rc_client_subset_t, v3_rc_client_subset_t, num_leaderboards);
+  ASSERT_FIELD_OFFSET(rc_client_subset_t, v3_rc_client_subset_t, badge_url);
+}
+
+static void test_get_subset_info_v1(void)
+{
+  const rc_client_subset_t* subset;
+
+  g_client = mock_client_with_external();
+  g_client->state.external_client->get_subset_info = rc_client_external_get_subset_info_v1;
+
+  /* subset data should come from external client. validate structure */
+  subset = rc_client_get_subset_info(g_client, 1234);
+  ASSERT_PTR_NOT_NULL(subset);
+  ASSERT_NUM_EQUALS(subset->id, 1234);
+  ASSERT_STR_EQUALS(subset->title, "Subset Title");
+  ASSERT_STR_EQUALS(subset->badge_name, "BDG001");
+  ASSERT_NUM_EQUALS(subset->num_achievements, 2);
+  ASSERT_NUM_EQUALS(subset->num_leaderboards, 1);
+  ASSERT_PTR_NULL(subset->badge_url);
+
+  rc_client_destroy(g_client);
+}
+
+static void test_get_subset_info(void)
+{
+  const rc_client_subset_t* subset;
+
+  g_client = mock_client_with_external();
+  g_client->state.external_client->get_subset_info_v3 = rc_client_external_get_subset_info_v3;
+
+  /* subset data should come from external client. validate structure */
+  subset = rc_client_get_subset_info(g_client, 1234);
+  ASSERT_PTR_NOT_NULL(subset);
+  ASSERT_NUM_EQUALS(subset->id, 1234);
+  ASSERT_STR_EQUALS(subset->title, "Subset Title");
+  ASSERT_STR_EQUALS(subset->badge_name, "BDG001");
+  ASSERT_NUM_EQUALS(subset->num_achievements, 2);
+  ASSERT_NUM_EQUALS(subset->num_leaderboards, 1);
+  ASSERT_STR_EQUALS(subset->badge_url, "/Badge/BDG001.png");
+
+  rc_client_destroy(g_client);
+}
 
 static void rc_client_external_unload_game(void)
 {
@@ -751,28 +995,53 @@ static void test_unload_game(void)
 
 /* ----- achievements ----- */
 
-typedef struct v1_rc_client_achievement_t {
-  const char* title;
-  const char* description;
-  char badge_name[8];
-  char measured_progress[24];
-  float measured_percent;
-  uint32_t id;
-  uint32_t points;
-  time_t unlock_time;
-  uint8_t state;
-  uint8_t category;
-  uint8_t bucket;
-  uint8_t unlocked;
-} v1_rc_client_achievement_t;
+static void test_v1_achievement_field_offsets(void)
+{
+  ASSERT_FIELD_OFFSET(rc_client_achievement_t, v1_rc_client_achievement_t, id);
+  ASSERT_FIELD_OFFSET(rc_client_achievement_t, v1_rc_client_achievement_t, description);
+  ASSERT_FIELD_OFFSET(rc_client_achievement_t, v1_rc_client_achievement_t, badge_name);
+  ASSERT_FIELD_OFFSET(rc_client_achievement_t, v1_rc_client_achievement_t, measured_progress);
+  ASSERT_FIELD_OFFSET(rc_client_achievement_t, v1_rc_client_achievement_t, measured_percent);
+  ASSERT_FIELD_OFFSET(rc_client_achievement_t, v1_rc_client_achievement_t, id);
+  ASSERT_FIELD_OFFSET(rc_client_achievement_t, v1_rc_client_achievement_t, points);
+  ASSERT_FIELD_OFFSET(rc_client_achievement_t, v1_rc_client_achievement_t, unlock_time);
+  ASSERT_FIELD_OFFSET(rc_client_achievement_t, v1_rc_client_achievement_t, state);
+  ASSERT_FIELD_OFFSET(rc_client_achievement_t, v1_rc_client_achievement_t, category);
+  ASSERT_FIELD_OFFSET(rc_client_achievement_t, v1_rc_client_achievement_t, bucket);
+  ASSERT_FIELD_OFFSET(rc_client_achievement_t, v1_rc_client_achievement_t, unlocked);
+  ASSERT_FIELD_OFFSET(rc_client_achievement_t, v1_rc_client_achievement_t, rarity);
+  ASSERT_FIELD_OFFSET(rc_client_achievement_t, v1_rc_client_achievement_t, rarity_hardcore);
+  ASSERT_FIELD_OFFSET(rc_client_achievement_t, v1_rc_client_achievement_t, type);
+}
 
-static const rc_client_achievement_t* rc_client_external_get_achievement_info(uint32_t id)
+static void test_v3_achievement_field_offsets(void)
+{
+  ASSERT_FIELD_OFFSET(rc_client_achievement_t, v3_rc_client_achievement_t, id);
+  ASSERT_FIELD_OFFSET(rc_client_achievement_t, v3_rc_client_achievement_t, description);
+  ASSERT_FIELD_OFFSET(rc_client_achievement_t, v3_rc_client_achievement_t, badge_name);
+  ASSERT_FIELD_OFFSET(rc_client_achievement_t, v3_rc_client_achievement_t, measured_progress);
+  ASSERT_FIELD_OFFSET(rc_client_achievement_t, v3_rc_client_achievement_t, measured_percent);
+  ASSERT_FIELD_OFFSET(rc_client_achievement_t, v3_rc_client_achievement_t, id);
+  ASSERT_FIELD_OFFSET(rc_client_achievement_t, v3_rc_client_achievement_t, points);
+  ASSERT_FIELD_OFFSET(rc_client_achievement_t, v3_rc_client_achievement_t, unlock_time);
+  ASSERT_FIELD_OFFSET(rc_client_achievement_t, v3_rc_client_achievement_t, state);
+  ASSERT_FIELD_OFFSET(rc_client_achievement_t, v3_rc_client_achievement_t, category);
+  ASSERT_FIELD_OFFSET(rc_client_achievement_t, v3_rc_client_achievement_t, bucket);
+  ASSERT_FIELD_OFFSET(rc_client_achievement_t, v3_rc_client_achievement_t, unlocked);
+  ASSERT_FIELD_OFFSET(rc_client_achievement_t, v3_rc_client_achievement_t, rarity);
+  ASSERT_FIELD_OFFSET(rc_client_achievement_t, v3_rc_client_achievement_t, rarity_hardcore);
+  ASSERT_FIELD_OFFSET(rc_client_achievement_t, v3_rc_client_achievement_t, type);
+  ASSERT_FIELD_OFFSET(rc_client_achievement_t, v3_rc_client_achievement_t, badge_url);
+  ASSERT_FIELD_OFFSET(rc_client_achievement_t, v3_rc_client_achievement_t, badge_locked_url);
+}
+
+static const rc_client_achievement_t* rc_client_external_get_achievement_info_v1(uint32_t id)
 {
   v1_rc_client_achievement_t* achievement = (v1_rc_client_achievement_t*)
     rc_buffer_alloc(&g_client->state.buffer, sizeof(v1_rc_client_achievement_t));
 
   memset(achievement, 0, sizeof(*achievement));
-  achievement->id = 1234;
+  achievement->id = id;
   achievement->title = "Achievement Title";
   achievement->description = "Do something cool";
   memcpy(achievement->badge_name, "BDG1234", 8);
@@ -782,83 +1051,35 @@ static const rc_client_achievement_t* rc_client_external_get_achievement_info(ui
   achievement->category = RC_CLIENT_ACHIEVEMENT_CATEGORY_CORE;
   achievement->bucket = RC_CLIENT_ACHIEVEMENT_BUCKET_LOCKED;
   achievement->unlocked = RC_CLIENT_ACHIEVEMENT_UNLOCKED_NONE;
+  achievement->rarity = 75.0f;
+  achievement->rarity_hardcore = 66.66f;
+  achievement->type = RC_CLIENT_ACHIEVEMENT_TYPE_MISSABLE;
 
   return (const rc_client_achievement_t*)achievement;
 }
 
-typedef struct v1_rc_client_achievement_bucket_t {
-  rc_client_achievement_t** achievements;
-  uint32_t num_achievements;
-
-  const char* label;
-  uint32_t subset_id;
-  uint8_t bucket_type;
-} v1_rc_client_achievement_bucket_t;
-
-typedef struct v1_rc_client_achievement_list_t {
-  v1_rc_client_achievement_bucket_t* buckets;
-  uint32_t num_buckets;
-} v1_rc_client_achievement_list_t;
-
-typedef struct v1_rc_client_achievement_list_info_t {
-  v1_rc_client_achievement_list_t public_;
-  rc_client_destroy_achievement_list_func_t destroy_func;
-} v1_rc_client_achievement_list_info_t;
-
-static void assert_achievement_list_category_grouping(int category, int grouping)
+static const rc_client_achievement_t* rc_client_external_get_achievement_info_v3(uint32_t id)
 {
-  ASSERT_NUM_EQUALS(category, RC_CLIENT_ACHIEVEMENT_CATEGORY_CORE);
-  ASSERT_NUM_EQUALS(grouping, RC_CLIENT_ACHIEVEMENT_LIST_GROUPING_PROGRESS);
-}
+  v3_rc_client_achievement_t* achievement = (v3_rc_client_achievement_t*)
+    rc_buffer_alloc(&g_client->state.buffer, sizeof(v3_rc_client_achievement_t));
 
-static void rc_client_external_destroy_achievement_list(rc_client_achievement_list_info_t* list)
-{
-  g_external_event = "destroyed";
-  free(list);
-}
-
-static rc_client_achievement_list_info_t* rc_client_external_create_achievement_list(int category, int grouping)
-{
-  v1_rc_client_achievement_list_info_t* list;
-
-  assert_achievement_list_category_grouping(category, grouping);
-
-  list = (v1_rc_client_achievement_list_info_t*)calloc(1, sizeof(*list) + sizeof(v1_rc_client_achievement_bucket_t));
-  if (list) {
-    list->public_.num_buckets = 1;
-    list->public_.buckets = (v1_rc_client_achievement_bucket_t*)((uint8_t*)list + sizeof(*list));
-    list->public_.buckets[0].num_achievements = 2; /* didn't actually allocate these */
-    list->public_.buckets[0].bucket_type = RC_CLIENT_ACHIEVEMENT_BUCKET_LOCKED;
-    list->public_.buckets[0].label = "Locked";
-    list->public_.buckets[0].subset_id = 1234;
-
-    list->destroy_func = rc_client_external_destroy_achievement_list;
-  }
-
-  return (rc_client_achievement_list_info_t*)list;
-}
-
-static void test_create_achievement_list(void)
-{
-  rc_client_achievement_list_t* list;
-
-  g_client = mock_client_with_external();
-  g_client->state.external_client->create_achievement_list = rc_client_external_create_achievement_list;
-
-  list = rc_client_create_achievement_list(g_client, RC_CLIENT_ACHIEVEMENT_CATEGORY_CORE, RC_CLIENT_ACHIEVEMENT_LIST_GROUPING_PROGRESS);
-  ASSERT_PTR_NOT_NULL(list);
-  ASSERT_NUM_EQUALS(list->num_buckets, 1);
-  ASSERT_PTR_NOT_NULL(list->buckets);
-  ASSERT_NUM_EQUALS(list->buckets[0].num_achievements, 2);
-  ASSERT_NUM_EQUALS(list->buckets[0].bucket_type, RC_CLIENT_ACHIEVEMENT_BUCKET_LOCKED);
-  ASSERT_NUM_EQUALS(list->buckets[0].subset_id, 1234);
-  ASSERT_STR_EQUALS(list->buckets[0].label, "Locked");
-
-  rc_client_destroy_achievement_list(list);
-
-  ASSERT_STR_EQUALS(g_external_event, "destroyed");
-
-  rc_client_destroy(g_client);
+  memset(achievement, 0, sizeof(*achievement));
+  achievement->id = id;
+  achievement->title = "Achievement Title";
+  achievement->description = "Do something cool";
+  memcpy(achievement->badge_name, "BDG1234", 8);
+  achievement->measured_percent = 33.5;
+  achievement->points = 5;
+  achievement->state = RC_CLIENT_ACHIEVEMENT_STATE_ACTIVE;
+  achievement->category = RC_CLIENT_ACHIEVEMENT_CATEGORY_CORE;
+  achievement->bucket = RC_CLIENT_ACHIEVEMENT_BUCKET_LOCKED;
+  achievement->unlocked = RC_CLIENT_ACHIEVEMENT_UNLOCKED_NONE;
+  achievement->rarity = 75.0f;
+  achievement->rarity_hardcore = 66.66f;
+  achievement->type = RC_CLIENT_ACHIEVEMENT_TYPE_MISSABLE;
+  achievement->badge_url = "/Badge/000234.png";
+  achievement->badge_locked_url = "/Badge/000234_locked.png";
+  return (const rc_client_achievement_t*)achievement;
 }
 
 static void test_has_achievements(void)
@@ -875,16 +1096,16 @@ static void test_has_achievements(void)
   rc_client_destroy(g_client);
 }
 
-static void test_get_achievement_info(void)
+static void test_get_achievement_info_v1(void)
 {
   const rc_client_achievement_t* achievement;
 
   g_client = mock_client_with_external();
-  g_client->state.external_client->get_achievement_info = rc_client_external_get_achievement_info;
+  g_client->state.external_client->get_achievement_info = rc_client_external_get_achievement_info_v1;
 
   achievement = rc_client_get_achievement_info(g_client, 4);
   ASSERT_PTR_NOT_NULL(achievement);
-  ASSERT_NUM_EQUALS(achievement->id, 1234);
+  ASSERT_NUM_EQUALS(achievement->id, 4);
   ASSERT_STR_EQUALS(achievement->title, "Achievement Title");
   ASSERT_STR_EQUALS(achievement->description, "Do something cool");
   ASSERT_STR_EQUALS(achievement->badge_name, "BDG1234");
@@ -894,6 +1115,188 @@ static void test_get_achievement_info(void)
   ASSERT_NUM_EQUALS(achievement->category, RC_CLIENT_ACHIEVEMENT_CATEGORY_CORE);
   ASSERT_NUM_EQUALS(achievement->bucket, RC_CLIENT_ACHIEVEMENT_BUCKET_LOCKED);
   ASSERT_NUM_EQUALS(achievement->unlocked, RC_CLIENT_ACHIEVEMENT_UNLOCKED_NONE);
+  ASSERT_FLOAT_EQUALS(achievement->rarity, 75.0f);
+  ASSERT_FLOAT_EQUALS(achievement->rarity_hardcore, 66.66f);
+  ASSERT_NUM_EQUALS(achievement->type, RC_CLIENT_ACHIEVEMENT_TYPE_MISSABLE);
+
+  rc_client_destroy(g_client);
+}
+
+static void test_get_achievement_info(void)
+{
+  const rc_client_achievement_t* achievement;
+
+  g_client = mock_client_with_external();
+  g_client->state.external_client->get_achievement_info = rc_client_external_get_achievement_info_v1;
+  g_client->state.external_client->get_achievement_info_v3 = rc_client_external_get_achievement_info_v3;
+
+  achievement = rc_client_get_achievement_info(g_client, 4);
+  ASSERT_PTR_NOT_NULL(achievement);
+  ASSERT_NUM_EQUALS(achievement->id, 4);
+  ASSERT_STR_EQUALS(achievement->title, "Achievement Title");
+  ASSERT_STR_EQUALS(achievement->description, "Do something cool");
+  ASSERT_STR_EQUALS(achievement->badge_name, "BDG1234");
+  ASSERT_FLOAT_EQUALS(achievement->measured_percent, 33.5);
+  ASSERT_NUM_EQUALS(achievement->points, 5);
+  ASSERT_NUM_EQUALS(achievement->state, RC_CLIENT_ACHIEVEMENT_STATE_ACTIVE);
+  ASSERT_NUM_EQUALS(achievement->category, RC_CLIENT_ACHIEVEMENT_CATEGORY_CORE);
+  ASSERT_NUM_EQUALS(achievement->bucket, RC_CLIENT_ACHIEVEMENT_BUCKET_LOCKED);
+  ASSERT_NUM_EQUALS(achievement->unlocked, RC_CLIENT_ACHIEVEMENT_UNLOCKED_NONE);
+  ASSERT_FLOAT_EQUALS(achievement->rarity, 75.0f);
+  ASSERT_FLOAT_EQUALS(achievement->rarity_hardcore, 66.66f);
+  ASSERT_NUM_EQUALS(achievement->type, RC_CLIENT_ACHIEVEMENT_TYPE_MISSABLE);
+  ASSERT_STR_EQUALS(achievement->badge_url, "/Badge/000234.png");
+  ASSERT_STR_EQUALS(achievement->badge_locked_url, "/Badge/000234_locked.png");
+
+  rc_client_destroy(g_client);
+}
+
+static void test_v1_achievement_list_field_offsets(void)
+{
+  ASSERT_FIELD_OFFSET(rc_client_achievement_list_info_t, v1_rc_client_achievement_list_info_t, public_);
+  ASSERT_FIELD_OFFSET(rc_client_achievement_list_info_t, v1_rc_client_achievement_list_info_t, destroy_func);
+
+  ASSERT_FIELD_OFFSET(rc_client_achievement_list_t, v1_rc_client_achievement_list_t, buckets);
+  ASSERT_FIELD_OFFSET(rc_client_achievement_list_t, v1_rc_client_achievement_list_t, num_buckets);
+
+  ASSERT_FIELD_OFFSET(rc_client_achievement_bucket_t, v1_rc_client_achievement_bucket_t, achievements);
+  ASSERT_FIELD_OFFSET(rc_client_achievement_bucket_t, v1_rc_client_achievement_bucket_t, num_achievements);
+  ASSERT_FIELD_OFFSET(rc_client_achievement_bucket_t, v1_rc_client_achievement_bucket_t, label);
+  ASSERT_FIELD_OFFSET(rc_client_achievement_bucket_t, v1_rc_client_achievement_bucket_t, subset_id);
+  ASSERT_FIELD_OFFSET(rc_client_achievement_bucket_t, v1_rc_client_achievement_bucket_t, bucket_type);
+}
+
+static void test_v3_achievement_list_field_offsets(void)
+{
+  ASSERT_FIELD_OFFSET(rc_client_achievement_list_info_t, v3_rc_client_achievement_list_info_t, public_);
+  ASSERT_FIELD_OFFSET(rc_client_achievement_list_info_t, v3_rc_client_achievement_list_info_t, destroy_func);
+
+  ASSERT_FIELD_OFFSET(rc_client_achievement_list_t, v3_rc_client_achievement_list_t, buckets);
+  ASSERT_FIELD_OFFSET(rc_client_achievement_list_t, v3_rc_client_achievement_list_t, num_buckets);
+
+  ASSERT_FIELD_OFFSET(rc_client_achievement_bucket_t, v3_rc_client_achievement_bucket_t, achievements);
+  ASSERT_FIELD_OFFSET(rc_client_achievement_bucket_t, v3_rc_client_achievement_bucket_t, num_achievements);
+  ASSERT_FIELD_OFFSET(rc_client_achievement_bucket_t, v3_rc_client_achievement_bucket_t, label);
+  ASSERT_FIELD_OFFSET(rc_client_achievement_bucket_t, v3_rc_client_achievement_bucket_t, subset_id);
+  ASSERT_FIELD_OFFSET(rc_client_achievement_bucket_t, v3_rc_client_achievement_bucket_t, bucket_type);
+}
+
+static void assert_achievement_list_category_grouping(int category, int grouping)
+{
+  ASSERT_NUM_EQUALS(category, RC_CLIENT_ACHIEVEMENT_CATEGORY_CORE);
+  ASSERT_NUM_EQUALS(grouping, RC_CLIENT_ACHIEVEMENT_LIST_GROUPING_PROGRESS);
+}
+
+static void rc_client_external_destroy_achievement_list(rc_client_achievement_list_info_t* list)
+{
+  g_external_event = "destroyed";
+  free(list);
+}
+
+static rc_client_achievement_list_info_t* rc_client_external_create_achievement_list_v1(int category, int grouping)
+{
+  v1_rc_client_achievement_list_info_t* list;
+
+  assert_achievement_list_category_grouping(category, grouping);
+
+  list = (v1_rc_client_achievement_list_info_t*)calloc(1, sizeof(*list) + sizeof(v1_rc_client_achievement_bucket_t) + sizeof(v1_rc_client_achievement_t*) * 2);
+  if (list) {
+    list->public_.num_buckets = 1;
+    list->public_.buckets = (v1_rc_client_achievement_bucket_t*)((uint8_t*)list + sizeof(*list));
+    list->public_.buckets[0].achievements = (v1_rc_client_achievement_t**)((uint8_t*)list->public_.buckets + sizeof(*list->public_.buckets));
+    list->public_.buckets[0].achievements[0] = (v1_rc_client_achievement_t*)rc_client_external_get_achievement_info_v1(1234);
+    list->public_.buckets[0].achievements[1] = (v1_rc_client_achievement_t*)rc_client_external_get_achievement_info_v1(1235);
+    list->public_.buckets[0].num_achievements = 2;
+    list->public_.buckets[0].bucket_type = RC_CLIENT_ACHIEVEMENT_BUCKET_LOCKED;
+    list->public_.buckets[0].label = "Locked";
+    list->public_.buckets[0].subset_id = 1234;
+
+    list->destroy_func = rc_client_external_destroy_achievement_list;
+  }
+
+  return (rc_client_achievement_list_info_t*)list;
+}
+
+static rc_client_achievement_list_info_t* rc_client_external_create_achievement_list_v3(int category, int grouping)
+{
+  v3_rc_client_achievement_list_info_t* list;
+
+  assert_achievement_list_category_grouping(category, grouping);
+
+  list = (v3_rc_client_achievement_list_info_t*)calloc(1, sizeof(*list) + sizeof(v3_rc_client_achievement_bucket_t) + sizeof(v3_rc_client_achievement_t*) * 2);
+  if (list) {
+    v3_rc_client_achievement_bucket_t* bucket;
+    list->public_.num_buckets = 1;
+    list->public_.buckets = bucket = (v3_rc_client_achievement_bucket_t*)((uint8_t*)list + sizeof(*list));
+    bucket->achievements = (const v3_rc_client_achievement_t**)((uint8_t*)list->public_.buckets + sizeof(*list->public_.buckets));
+    bucket->achievements[0] = (const v3_rc_client_achievement_t*)rc_client_external_get_achievement_info_v3(1234);
+    bucket->achievements[1] = (const v3_rc_client_achievement_t*)rc_client_external_get_achievement_info_v3(1235);
+    bucket->num_achievements = 2;
+    bucket->bucket_type = RC_CLIENT_ACHIEVEMENT_BUCKET_LOCKED;
+    bucket->label = "Locked";
+    bucket->subset_id = 1234;
+
+    list->destroy_func = rc_client_external_destroy_achievement_list;
+  }
+
+  return (rc_client_achievement_list_info_t*)list;
+}
+
+static void test_create_achievement_list_v1(void)
+{
+  rc_client_achievement_list_t* list;
+
+  g_client = mock_client_with_external();
+  g_client->state.external_client->create_achievement_list = rc_client_external_create_achievement_list_v1;
+
+  list = rc_client_create_achievement_list(g_client, RC_CLIENT_ACHIEVEMENT_CATEGORY_CORE, RC_CLIENT_ACHIEVEMENT_LIST_GROUPING_PROGRESS);
+  ASSERT_PTR_NOT_NULL(list);
+  ASSERT_NUM_EQUALS(list->num_buckets, 1);
+  ASSERT_PTR_NOT_NULL(list->buckets);
+  ASSERT_NUM_EQUALS(list->buckets[0].num_achievements, 2);
+  ASSERT_NUM_EQUALS(list->buckets[0].achievements[0]->id, 1234);
+  ASSERT_NUM_EQUALS(list->buckets[0].achievements[1]->id, 1235);
+  ASSERT_NUM_EQUALS(list->buckets[0].bucket_type, RC_CLIENT_ACHIEVEMENT_BUCKET_LOCKED);
+  ASSERT_NUM_EQUALS(list->buckets[0].subset_id, 1234);
+  ASSERT_STR_EQUALS(list->buckets[0].label, "Locked");
+
+  // only difference between v1 and v3 create_achievement_list is the badge_url/badge_unlocked_url fields on each achievement
+  ASSERT_PTR_NULL(list->buckets[0].achievements[0]->badge_url);
+  ASSERT_PTR_NULL(list->buckets[0].achievements[0]->badge_locked_url);
+
+  rc_client_destroy_achievement_list(list);
+
+  ASSERT_STR_EQUALS(g_external_event, "destroyed");
+
+  rc_client_destroy(g_client);
+}
+
+static void test_create_achievement_list(void)
+{
+  rc_client_achievement_list_t* list;
+
+  g_client = mock_client_with_external();
+  g_client->state.external_client->create_achievement_list = rc_client_external_create_achievement_list_v1;
+  g_client->state.external_client->create_achievement_list_v3 = rc_client_external_create_achievement_list_v3;
+
+  list = rc_client_create_achievement_list(g_client, RC_CLIENT_ACHIEVEMENT_CATEGORY_CORE, RC_CLIENT_ACHIEVEMENT_LIST_GROUPING_PROGRESS);
+  ASSERT_PTR_NOT_NULL(list);
+  ASSERT_NUM_EQUALS(list->num_buckets, 1);
+  ASSERT_PTR_NOT_NULL(list->buckets);
+  ASSERT_NUM_EQUALS(list->buckets[0].num_achievements, 2);
+  ASSERT_NUM_EQUALS(list->buckets[0].achievements[0]->id, 1234);
+  ASSERT_NUM_EQUALS(list->buckets[0].achievements[1]->id, 1235);
+  ASSERT_NUM_EQUALS(list->buckets[0].bucket_type, RC_CLIENT_ACHIEVEMENT_BUCKET_LOCKED);
+  ASSERT_NUM_EQUALS(list->buckets[0].subset_id, 1234);
+  ASSERT_STR_EQUALS(list->buckets[0].label, "Locked");
+
+  // only difference between v1 and v3 create_achievement_list is the badge_url/badge_unlocked_url fields on each achievement
+  ASSERT_STR_EQUALS(list->buckets[0].achievements[0]->badge_url, "/Badge/000234.png");
+  ASSERT_STR_EQUALS(list->buckets[0].achievements[0]->badge_locked_url, "/Badge/000234_locked.png");
+
+  rc_client_destroy_achievement_list(list);
+
+  ASSERT_STR_EQUALS(g_external_event, "destroyed");
 
   rc_client_destroy(g_client);
 }
@@ -1249,15 +1652,23 @@ void test_client_external(void) {
   TEST(test_get_user_agent_clause);
 
   /* login */
+  TEST(test_v1_user_field_offsets);
+  TEST(test_v3_user_field_offsets);
   TEST(test_login_with_password);
+  TEST(test_login_with_token_v1);
   TEST(test_login_with_token);
 
   TEST(test_logout);
 
   /* load game */
+  TEST(test_v1_game_field_offsets);
+  TEST(test_v3_game_field_offsets);
+
 #ifdef RC_CLIENT_SUPPORTS_HASH
+  TEST(test_identify_and_load_game_v1);
   TEST(test_identify_and_load_game);
 #endif
+  TEST(test_load_game_v1);
   TEST(test_load_game);
   TEST(test_get_user_game_summary);
 #ifdef RC_CLIENT_SUPPORTS_HASH
@@ -1269,10 +1680,23 @@ void test_client_external(void) {
 
   TEST(test_unload_game);
 
+  /* subsets */
+  TEST(test_v1_subset_field_offsets);
+  TEST(test_v3_subset_field_offsets);
+  TEST(test_get_subset_info_v1);
+  TEST(test_get_subset_info);
+
   /* achievements */
-  TEST(test_create_achievement_list);
+  TEST(test_v1_achievement_field_offsets);
+  TEST(test_v3_achievement_field_offsets);
   TEST(test_has_achievements);
+  TEST(test_get_achievement_info_v1);
   TEST(test_get_achievement_info);
+
+  TEST(test_v1_achievement_list_field_offsets);
+  TEST(test_v3_achievement_list_field_offsets);
+  TEST(test_create_achievement_list_v1);
+  TEST(test_create_achievement_list);
 
   /* leaderboards */
   TEST(test_create_leaderboard_list);


### PR DESCRIPTION
Adding the avatar fields to users, games, and achievements changed the contract for communicating with the DLL, even though the new fields were placed at the end of the structure. As the DLL doesn't yet know to send the new fields, the client could reference uninitialized (or even out-of-bounds) memory.

This adds new functions to the external interface API to pass the updated structures through. If not provided, the old functions will be called to get the old structures and the new fields will be NULLed out.

This also updates the lists created by `rc_client_create_achievement_list` and `rc_client_create_leaderboard_list` to return const references to the achievements and leaderboards.