### PR TITLE
replace switch statement for matching extension with lookup table

### DIFF
--- a/src/rhash/rc_hash_internal.h
+++ b/src/rhash/rc_hash_internal.h
@@ -13,6 +13,15 @@ int rc_hash_error_formatted(const rc_hash_callbacks_t* callbacks, const char* fo
 
 int64_t rc_file_size(const char* path);
 
+typedef void (RC_CCONV* rc_hash_iterator_ext_handler_t)(rc_hash_iterator_t* iterator, const char* path, int data);
+typedef struct rc_hash_iterator_ext_handler_entry_t {
+  char ext[8];
+  rc_hash_iterator_ext_handler_t handler;
+  int data;
+} rc_hash_iterator_ext_handler_entry_t;
+
+const rc_hash_iterator_ext_handler_entry_t* rc_hash_get_iterator_ext_handlers(size_t* num_handlers);
+
 RC_END_C_DECLS
 
 #endif /* RC_HASH_INTERNAL_H */

--- a/test/rhash/test_hash.c
+++ b/test/rhash/test_hash.c
@@ -1,5 +1,7 @@
 #include "rc_hash.h"
 
+#include "../rhash/rc_hash_internal.h"
+
 #include "../rc_compat.h"
 #include "../test_framework.h"
 #include "data.h"
@@ -2208,6 +2210,19 @@ static void test_hash_file_without_ext()
   ASSERT_STR_EQUALS(hash_iterator, "64b131c5c7fec32985d9c99700babb7e");
 }
 
+static void test_hash_handler_table_order()
+{
+  size_t num_handlers;
+  const rc_hash_iterator_ext_handler_entry_t* handlers = rc_hash_get_iterator_ext_handlers(&num_handlers);
+  int index;
+
+  for (index = 1; index < num_handlers; ++index) {
+    if (strcmp(handlers[index].ext, handlers[index - 1].ext) <= 0) {
+      ASSERT_FAIL("handler[%s] after handler[%s]", handlers[index].ext, handlers[index - 1].ext);
+    }
+  }
+}
+
 /* ========================================================================= */
 
 void test_hash(void) {
@@ -2513,6 +2528,7 @@ void test_hash(void) {
 
   /* other */
   TEST(test_hash_file_without_ext);
+  TEST(test_hash_handler_table_order);
 
   TEST_SUITE_END();
 }


### PR DESCRIPTION
These changes are primarily designed to support future PRs to break the one large file into smaller files.

There could be marginal benefits from doing a bsearch match, but the switch already minimizes the number of string comparisons used. The trade-off comes from the fact that `rc_path_compare_extension` is overkill when the extension has already been extracted. If we'd just normalize the extension to lowercase, all the `rc_path_compare_extension`s could be replaced with `strcmp`. The bsearch does normalize the extension to lowercase, but changes the 1-5 string compares within each case of the switch to a single bsearch that will do 1-7 compares without doing the switch first.

In the end, this function isn't called frequently enough to worry about the performance. 