### PR TITLE
continue splitting hash.c into smaller files

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -81,6 +81,12 @@ jobs:
     - name: Run tests HAVE_HASH=0
       run: ./test
       working-directory: test
+    - name: Build HAVE_HASH_ROMS=0
+      run: make ARCH=x64 BUILD=c89 clean && make ARCH=x64 BUILD=c89 HAVE_HASH_ROMS=0 test
+      working-directory: test
+    - name: Run tests HAVE_HASH_ROMS=0
+      run: ./test
+      working-directory: test
     - name: Build HAVE_HASH_ZIP=0
       run: make ARCH=x64 BUILD=c89 clean && make ARCH=x64 BUILD=c89 HAVE_HASH_ZIP=0 test
       working-directory: test

--- a/src/rhash/hash.c
+++ b/src/rhash/hash.c
@@ -1902,7 +1902,7 @@ static int rc_hash_from_buffer(char hash[33], uint32_t console_id, const rc_hash
     case RC_CONSOLE_ZX_SPECTRUM:
       return rc_hash_buffer(hash, iterator->buffer, iterator->buffer_size, iterator);
 
-#ifndef RC_HASH_NO_ROMS
+#ifndef RC_HASH_NO_ROM
     case RC_CONSOLE_ARDUBOY:
       /* https://en.wikipedia.org/wiki/Intel_HEX */
       return rc_hash_text(hash, iterator);
@@ -2218,7 +2218,7 @@ static int rc_hash_from_file(char hash[33], uint32_t console_id, const rc_hash_i
 
       return rc_hash_3do(hash, iterator);
 
-#ifndef RC_HASH_NO_ROMS
+#ifndef RC_HASH_NO_ROM
     case RC_CONSOLE_ARCADE:
       return rc_hash_arcade(hash, iterator);
 #endif
@@ -2244,7 +2244,7 @@ static int rc_hash_from_file(char hash[33], uint32_t console_id, const rc_hash_i
     case RC_CONSOLE_NEO_GEO_CD:
       return rc_hash_neogeo_cd(hash, iterator);
 
-#ifndef RC_HASH_NO_ROMS
+#ifndef RC_HASH_NO_ROM
     case RC_CONSOLE_NINTENDO_64:
       return rc_hash_n64(hash, iterator);
 #endif
@@ -2254,7 +2254,7 @@ static int rc_hash_from_file(char hash[33], uint32_t console_id, const rc_hash_i
       return rc_hash_nintendo_3ds(hash, iterator);
 #endif
 
-#ifndef RC_HASH_NO_ROMS
+#ifndef RC_HASH_NO_ROM
     case RC_CONSOLE_NINTENDO_DS:
     case RC_CONSOLE_NINTENDO_DSI:
       return rc_hash_nintendo_ds(hash, iterator);

--- a/src/rhash/hash.c
+++ b/src/rhash/hash.c
@@ -539,7 +539,7 @@ const char* rc_path_get_filename(const char* path)
   return ptr;
 }
 
-static const char* rc_path_get_extension(const char* path)
+const char* rc_path_get_extension(const char* path)
 {
   const char* ptr = path + strlen(path);
   do
@@ -578,7 +578,7 @@ int rc_path_compare_extension(const char* path, const char* ext)
 
 /* ===================================================== */
 
-static void rc_hash_byteswap16(uint8_t* buffer, const uint8_t* stop)
+void rc_hash_byteswap16(uint8_t* buffer, const uint8_t* stop)
 {
   uint32_t* ptr = (uint32_t*)buffer;
   const uint32_t* stop32 = (const uint32_t*)stop;
@@ -591,7 +591,7 @@ static void rc_hash_byteswap16(uint8_t* buffer, const uint8_t* stop)
   }
 }
 
-static void rc_hash_byteswap32(uint8_t* buffer, const uint8_t* stop)
+void rc_hash_byteswap32(uint8_t* buffer, const uint8_t* stop)
 {
   uint32_t* ptr = (uint32_t*)buffer;
   const uint32_t* stop32 = (const uint32_t*)stop;
@@ -623,7 +623,7 @@ int rc_hash_finalize(const rc_hash_iterator_t* iterator, md5_state_t* md5, char 
   return 1;
 }
 
-static int rc_hash_buffer(char hash[33], const uint8_t* buffer, size_t buffer_size, const rc_hash_iterator_t* iterator)
+int rc_hash_buffer(char hash[33], const uint8_t* buffer, size_t buffer_size, const rc_hash_iterator_t* iterator)
 {
   md5_state_t md5;
 
@@ -637,16 +637,6 @@ static int rc_hash_buffer(char hash[33], const uint8_t* buffer, size_t buffer_si
   rc_hash_iterator_verbose_formatted(iterator, "Hashing %u byte buffer", (unsigned)buffer_size);
 
   return rc_hash_finalize(iterator, &md5, hash);
-}
-
-static int rc_hash_iterator_buffer(char hash[33], const rc_hash_iterator_t* iterator)
-{
-  return rc_hash_buffer(hash, iterator->buffer, iterator->buffer_size, iterator);
-}
-
-static int rc_hash_unheadered_iterator_buffer(char hash[33], const rc_hash_iterator_t* iterator, size_t header_size)
-{
-  return rc_hash_buffer(hash, iterator->buffer + header_size, iterator->buffer_size - header_size, iterator);
 }
 
 static int rc_hash_cd_file(md5_state_t* md5, const rc_hash_iterator_t* iterator, void* track_handle, uint32_t sector, const char* name, uint32_t size, const char* description)
@@ -809,158 +799,6 @@ static int rc_hash_3do(char hash[33], const rc_hash_iterator_t* iterator)
   return rc_hash_finalize(iterator, &md5, hash);
 }
 
-static int rc_hash_7800(char hash[33], const rc_hash_iterator_t* iterator)
-{
-  /* if the file contains a header, ignore it */
-  if (memcmp(&iterator->buffer[1], "ATARI7800", 9) == 0)
-  {
-    rc_hash_iterator_verbose(iterator, "Ignoring 7800 header");
-    return rc_hash_unheadered_iterator_buffer(hash, iterator, 128);
-  }
-
-  return rc_hash_iterator_buffer(hash, iterator);
-}
-
-static int rc_hash_arcade(char hash[33], const rc_hash_iterator_t* iterator)
-{
-  /* arcade hash is just the hash of the filename (no extension) - the cores are pretty stringent about having the right ROM data */
-  const char* filename = rc_path_get_filename(iterator->path);
-  const char* ext = rc_path_get_extension(filename);
-  char buffer[128]; /* realistically, this should never need more than ~32 characters */
-  size_t filename_length = ext - filename - 1;
-
-  /* fbneo supports loading subsystems by using specific folder names.
-   * if one is found, include it in the hash.
-   * https://github.com/libretro/FBNeo/blob/master/src/burner/libretro/README.md#emulating-consoles-and-computers
-   */
-  if (filename > iterator->path + 1)
-  {
-    int include_folder = 0;
-    const char* folder = filename - 1;
-    size_t parent_folder_length = 0;
-
-    do
-    {
-      if (folder[-1] == '/' || folder[-1] == '\\')
-        break;
-
-      --folder;
-    } while (folder > iterator->path);
-
-    parent_folder_length = filename - folder - 1;
-    if (parent_folder_length < 16)
-    {
-      char* ptr = buffer;
-      while (folder < filename - 1)
-        *ptr++ = tolower(*folder++);
-      *ptr = '\0';
-
-      folder = buffer;
-    }
-
-    switch (parent_folder_length)
-    {
-      case 3:
-        if (memcmp(folder, "nes", 3) == 0 || /* NES */
-            memcmp(folder, "fds", 3) == 0 || /* FDS */
-            memcmp(folder, "sms", 3) == 0 || /* Master System */
-            memcmp(folder, "msx", 3) == 0 || /* MSX */
-            memcmp(folder, "ngp", 3) == 0 || /* NeoGeo Pocket */
-            memcmp(folder, "pce", 3) == 0 || /* PCEngine */
-            memcmp(folder, "chf", 3) == 0 || /* ChannelF */
-            memcmp(folder, "sgx", 3) == 0)   /* SuperGrafX */
-          include_folder = 1;
-        break;
-      case 4:
-        if (memcmp(folder, "tg16", 4) == 0 || /* TurboGrafx-16 */
-            memcmp(folder, "msx1", 4) == 0)   /* MSX */
-          include_folder = 1;
-        break;
-      case 5:
-        if (memcmp(folder, "neocd", 5) == 0) /* NeoGeo CD */
-          include_folder = 1;
-        break;
-      case 6:
-        if (memcmp(folder, "coleco", 6) == 0 || /* Colecovision */
-            memcmp(folder, "sg1000", 6) == 0)   /* SG-1000 */
-          include_folder = 1;
-        break;
-      case 7:
-        if (memcmp(folder, "genesis", 7) == 0) /* Megadrive (Genesis) */
-          include_folder = 1;
-        break;
-      case 8:
-        if (memcmp(folder, "gamegear", 8) == 0 || /* Game Gear */
-            memcmp(folder, "megadriv", 8) == 0 || /* Megadrive */
-            memcmp(folder, "pcengine", 8) == 0 || /* PCEngine */
-            memcmp(folder, "channelf", 8) == 0 || /* ChannelF */
-            memcmp(folder, "spectrum", 8) == 0)   /* ZX Spectrum */
-          include_folder = 1;
-        break;
-      case 9:
-        if (memcmp(folder, "megadrive", 9) == 0) /* Megadrive */
-          include_folder = 1;
-        break;
-      case 10:
-        if (memcmp(folder, "supergrafx", 10) == 0 || /* SuperGrafX */
-            memcmp(folder, "zxspectrum", 10) == 0)   /* ZX Spectrum */
-          include_folder = 1;
-        break;
-      case 12:
-        if (memcmp(folder, "mastersystem", 12) == 0 || /* Master System */
-            memcmp(folder, "colecovision", 12) == 0)   /* Colecovision */
-          include_folder = 1;
-        break;
-      default:
-        break;
-    }
-
-    if (include_folder)
-    {
-      if (parent_folder_length + filename_length + 1 < sizeof(buffer))
-      {
-        buffer[parent_folder_length] = '_';
-        memcpy(&buffer[parent_folder_length + 1], filename, filename_length);
-        return rc_hash_buffer(hash, (uint8_t*)&buffer[0], parent_folder_length + filename_length + 1, iterator);
-      }
-    }
-  }
-
-  return rc_hash_buffer(hash, (uint8_t*)filename, filename_length, iterator);
-}
-
-static int rc_hash_text(char hash[33], const rc_hash_iterator_t* iterator)
-{
-  md5_state_t md5;
-  const uint8_t* scan = iterator->buffer;
-  const uint8_t* stop = iterator->buffer + iterator->buffer_size;
-
-  md5_init(&md5);
-
-  do {
-    const uint8_t* line = scan;
-
-    /* find end of line */
-    while (scan < stop && *scan != '\r' && *scan != '\n')
-      ++scan;
-
-    md5_append(&md5, line, (int)(scan - line));
-
-    /* include a normalized line ending */
-    /* NOTE: this causes a line ending to be hashed at the end of the file, even if one was not present */
-    md5_append(&md5, (const uint8_t*)"\n", 1);
-
-    /* skip newline */
-    if (scan < stop && *scan == '\r')
-      ++scan;
-    if (scan < stop && *scan == '\n')
-      ++scan;
-
-  } while (scan < stop);
-
-  return rc_hash_finalize(iterator, &md5, hash);
-}
-
 /* helper variable only used for testing */
 const char* _rc_hash_jaguar_cd_homebrew_hash = NULL;
 
@@ -1084,18 +922,6 @@ static int rc_hash_jaguar_cd(char hash[33], const rc_hash_iterator_t* iterator)
   } while (1);
 }
 
-static int rc_hash_lynx(char hash[33], const rc_hash_iterator_t* iterator)
-{
-  /* if the file contains a header, ignore it */
-  if (memcmp(&iterator->buffer[0], "LYNX", 5) == 0)
-  {
-    rc_hash_iterator_verbose(iterator, "Ignoring LYNX header");
-    return rc_hash_unheadered_iterator_buffer(hash, iterator, 64);
-  }
-
-  return rc_hash_iterator_buffer(hash, iterator);
-}
-
 static int rc_hash_neogeo_cd(char hash[33], const rc_hash_iterator_t* iterator)
 {
   char buffer[1024], *ptr;
@@ -1155,206 +981,6 @@ static int rc_hash_neogeo_cd(char hash[33], const rc_hash_iterator_t* iterator)
   } while (*ptr != '\0' && *ptr != '\x1a');
 
   rc_cd_close_track(iterator, track_handle);
-  return rc_hash_finalize(iterator, &md5, hash);
-}
-
-static int rc_hash_nes(char hash[33], const rc_hash_iterator_t* iterator)
-{
-  /* if the file contains a header, ignore it */
-  if (memcmp(&iterator->buffer[0], "NES\x1a", 4) == 0)
-  {
-    rc_hash_iterator_verbose(iterator, "Ignoring NES header");
-    return rc_hash_unheadered_iterator_buffer(hash, iterator, 16);
-  }
-
-  if (memcmp(&iterator->buffer[0], "FDS\x1a", 4) == 0)
-  {
-    rc_hash_iterator_verbose(iterator, "Ignoring FDS header");
-    return rc_hash_unheadered_iterator_buffer(hash, iterator, 16);
-  }
-
-  return rc_hash_iterator_buffer(hash, iterator);
-}
-
-static int rc_hash_n64(char hash[33], const rc_hash_iterator_t* iterator)
-{
-  uint8_t* buffer;
-  uint8_t* stop;
-  const size_t buffer_size = 65536;
-  md5_state_t md5;
-  size_t remaining;
-  void* file_handle;
-  int is_v64 = 0;
-  int is_n64 = 0;
-
-  file_handle = rc_file_open(iterator, iterator->path);
-  if (!file_handle)
-    return rc_hash_iterator_error(iterator, "Could not open file");
-
-  buffer = (uint8_t*)malloc(buffer_size);
-  if (!buffer) {
-    rc_file_close(iterator, file_handle);
-    return rc_hash_iterator_error(iterator, "Could not allocate temporary buffer");
-  }
-  stop = buffer + buffer_size;
-
-  /* read first byte so we can detect endianness */
-  rc_file_seek(iterator, file_handle, 0, SEEK_SET);
-  rc_file_read(iterator, file_handle, buffer, 1);
-
-  if (buffer[0] == 0x80) { /* z64 format (big endian [native]) */
-  }
-  else if (buffer[0] == 0x37) { /* v64 format (byteswapped) */
-    rc_hash_iterator_verbose(iterator, "converting v64 to z64");
-    is_v64 = 1;
-  }
-  else if (buffer[0] == 0x40) { /* n64 format (little endian) */
-    rc_hash_iterator_verbose(iterator, "converting n64 to z64");
-    is_n64 = 1;
-  }
-  else if (buffer[0] == 0xE8 || buffer[0] == 0x22) { /* ndd format (don't byteswap) */
-  }
-  else {
-    free(buffer);
-    rc_file_close(iterator, file_handle);
-
-    rc_hash_iterator_verbose(iterator, "Not a Nintendo 64 ROM");
-    return 0;
-  }
-
-  /* calculate total file size */
-  rc_file_seek(iterator, file_handle, 0, SEEK_END);
-  remaining = (size_t)rc_file_tell(iterator, file_handle);
-  if (remaining > MAX_BUFFER_SIZE)
-    remaining = MAX_BUFFER_SIZE;
-
-  rc_hash_iterator_verbose_formatted(iterator, "Hashing %u bytes", (unsigned)remaining);
-
-  /* begin hashing */
-  md5_init(&md5);
-
-  rc_file_seek(iterator, file_handle, 0, SEEK_SET);
-  while (remaining >= buffer_size) {
-    rc_file_read(iterator, file_handle, buffer, (int)buffer_size);
-
-    if (is_v64)
-      rc_hash_byteswap16(buffer, stop);
-    else if (is_n64)
-      rc_hash_byteswap32(buffer, stop);
-
-    md5_append(&md5, buffer, (int)buffer_size);
-    remaining -= buffer_size;
-  }
-
-  if (remaining > 0) {
-    rc_file_read(iterator, file_handle, buffer, (int)remaining);
-
-    stop = buffer + remaining;
-    if (is_v64)
-      rc_hash_byteswap16(buffer, stop);
-    else if (is_n64)
-      rc_hash_byteswap32(buffer, stop);
-
-    md5_append(&md5, buffer, (int)remaining);
-  }
-
-  /* cleanup */
-  rc_file_close(iterator, file_handle);
-  free(buffer);
-
-  return rc_hash_finalize(iterator, &md5, hash);
-}
-
-static int rc_hash_nintendo_ds(char hash[33], const rc_hash_iterator_t* iterator)
-{
-  uint8_t header[512];
-  uint8_t* hash_buffer;
-  uint32_t hash_size, arm9_size, arm9_addr, arm7_size, arm7_addr, icon_addr;
-  size_t num_read;
-  int64_t offset = 0;
-  md5_state_t md5;
-  void* file_handle;
-
-  file_handle = rc_file_open(iterator, iterator->path);
-  if (!file_handle)
-    return rc_hash_iterator_error(iterator, "Could not open file");
-
-  rc_file_seek(iterator, file_handle, 0, SEEK_SET);
-  if (rc_file_read(iterator, file_handle, header, sizeof(header)) != 512)
-    return rc_hash_iterator_error(iterator, "Failed to read header");
-
-  if (header[0] == 0x2E && header[1] == 0x00 && header[2] == 0x00 && header[3] == 0xEA &&
-      header[0xB0] == 0x44 && header[0xB1] == 0x46 && header[0xB2] == 0x96 && header[0xB3] == 0)
-  {
-    /* SuperCard header detected, ignore it */
-    rc_hash_iterator_verbose(iterator, "Ignoring SuperCard header");
-
-    offset = 512;
-    rc_file_seek(iterator, file_handle, offset, SEEK_SET);
-    rc_file_read(iterator, file_handle, header, sizeof(header));
-  }
-
-  arm9_addr = header[0x20] | (header[0x21] << 8) | (header[0x22] << 16) | (header[0x23] << 24);
-  arm9_size = header[0x2C] | (header[0x2D] << 8) | (header[0x2E] << 16) | (header[0x2F] << 24);
-  arm7_addr = header[0x30] | (header[0x31] << 8) | (header[0x32] << 16) | (header[0x33] << 24);
-  arm7_size = header[0x3C] | (header[0x3D] << 8) | (header[0x3E] << 16) | (header[0x3F] << 24);
-  icon_addr = header[0x68] | (header[0x69] << 8) | (header[0x6A] << 16) | (header[0x6B] << 24);
-
-  if (arm9_size + arm7_size > 16 * 1024 * 1024)
-  {
-    /* sanity check - code blocks are typically less than 1MB each - assume not a DS ROM */
-    return rc_hash_iterator_error_formatted(iterator, "arm9 code size (%u) + arm7 code size (%u) exceeds 16MB", arm9_size, arm7_size);
-  }
-
-  hash_size = 0xA00;
-  if (arm9_size > hash_size)
-    hash_size = arm9_size;
-  if (arm7_size > hash_size)
-    hash_size = arm7_size;
-
-  hash_buffer = (uint8_t*)malloc(hash_size);
-  if (!hash_buffer)
-  {
-    rc_file_close(iterator, file_handle);
-    return rc_hash_iterator_error_formatted(iterator, "Failed to allocate %u bytes", hash_size);
-  }
-
-  md5_init(&md5);
-
-  rc_hash_iterator_verbose(iterator, "Hashing 352 byte header");
-  md5_append(&md5, header, 0x160);
-
-  rc_hash_iterator_verbose_formatted(iterator, "Hashing %u byte arm9 code (at %08X)", arm9_size, arm9_addr);
-
-  rc_file_seek(iterator, file_handle, arm9_addr + offset, SEEK_SET);
-  rc_file_read(iterator, file_handle, hash_buffer, arm9_size);
-  md5_append(&md5, hash_buffer, arm9_size);
-
-  rc_hash_iterator_verbose_formatted(iterator, "Hashing %u byte arm7 code (at %08X)", arm7_size, arm7_addr);
-
-  rc_file_seek(iterator, file_handle, arm7_addr + offset, SEEK_SET);
-  rc_file_read(iterator, file_handle, hash_buffer, arm7_size);
-  md5_append(&md5, hash_buffer, arm7_size);
-
-  rc_hash_iterator_verbose_formatted(iterator, "Hashing 2560 byte icon and labels data (at %08X)", icon_addr);
-
-  rc_file_seek(iterator, file_handle, icon_addr + offset, SEEK_SET);
-  num_read = rc_file_read(iterator, file_handle, hash_buffer, 0xA00);
-  if (num_read < 0xA00)
-  {
-    /* some homebrew games don't provide a full icon block, and no data after the icon block.
-     * if we didn't get a full icon block, fill the remaining portion with 0s
-     */
-    rc_hash_iterator_verbose_formatted(iterator,
-      "Warning: only got %u bytes for icon and labels data, 0-padding to 2560 bytes", (unsigned)num_read);
-
-    memset(&hash_buffer[num_read], 0, 0xA00 - num_read);
-  }
-  md5_append(&md5, hash_buffer, 0xA00);
-
-  free(hash_buffer);
-  rc_file_close(iterator, file_handle);
-
   return rc_hash_finalize(iterator, &md5, hash);
 }
 
@@ -1632,19 +1258,6 @@ static int rc_hash_nintendo_disc(char hash[33], const rc_hash_iterator_t* iterat
   rc_file_close(iterator, file_handle);
 
   return success == 0 ? 0 : rc_hash_finalize(iterator, &md5, hash);
-}
-
-static int rc_hash_pce(char hash[33], const rc_hash_iterator_t* iterator)
-{
-  /* if the file contains a header, ignore it (expect ROM data to be multiple of 128KB) */
-  uint32_t calc_size = ((uint32_t)iterator->buffer_size / 0x20000) * 0x20000;
-  if (iterator->buffer_size - calc_size == 512)
-  {
-    rc_hash_iterator_verbose(iterator, "Ignoring PCE header");
-    return rc_hash_unheadered_iterator_buffer(hash, iterator, 512);
-  }
-
-  return rc_hash_iterator_buffer(hash, iterator);
 }
 
 static int rc_hash_pce_track(char hash[33], void* track_handle, const rc_hash_iterator_t* iterator)
@@ -2161,32 +1774,6 @@ static int rc_hash_sega_cd(char hash[33], const rc_hash_iterator_t* iterator)
   return rc_hash_buffer(hash, buffer, sizeof(buffer), iterator);
 }
 
-static int rc_hash_scv(char hash[33], const rc_hash_iterator_t* iterator)
-{
-  /* if the file contains a header, ignore it */
-  /* https://gitlab.com/MaaaX-EmuSCV/libretro-emuscv/-/blob/master/readme.txt#L211 */
-  if (memcmp(iterator->buffer, "EmuSCV", 6) == 0)
-  {
-    rc_hash_iterator_verbose(iterator, "Ignoring SCV header");
-    return rc_hash_unheadered_iterator_buffer(hash, iterator, 32);
-  }
-
-  return rc_hash_iterator_buffer(hash, iterator);
-}
-
-static int rc_hash_snes(char hash[33], const rc_hash_iterator_t* iterator)
-{
-  /* if the file contains a header, ignore it */
-  uint32_t calc_size = ((uint32_t)iterator->buffer_size / 0x2000) * 0x2000;
-  if (iterator->buffer_size - calc_size == 512)
-  {
-    rc_hash_iterator_verbose(iterator, "Ignoring SNES header");
-    return rc_hash_unheadered_iterator_buffer(hash, iterator, 512);
-  }
-
-  return rc_hash_iterator_buffer(hash, iterator);
-}
-
 struct rc_buffered_file
 {
   const uint8_t* read_ptr;
@@ -2313,8 +1900,9 @@ static int rc_hash_from_buffer(char hash[33], uint32_t console_id, const rc_hash
     case RC_CONSOLE_WASM4:
     case RC_CONSOLE_WONDERSWAN:
     case RC_CONSOLE_ZX_SPECTRUM:
-      return rc_hash_iterator_buffer(hash, iterator);
+      return rc_hash_buffer(hash, iterator->buffer, iterator->buffer_size, iterator);
 
+#ifndef RC_HASH_NO_ROMS
     case RC_CONSOLE_ARDUBOY:
       /* https://en.wikipedia.org/wiki/Intel_HEX */
       return rc_hash_text(hash, iterator);
@@ -2337,6 +1925,7 @@ static int rc_hash_from_buffer(char hash[33], uint32_t console_id, const rc_hash
 
     case RC_CONSOLE_SUPER_NINTENDO:
       return rc_hash_snes(hash, iterator);
+#endif
 
     case RC_CONSOLE_NINTENDO_64:
     case RC_CONSOLE_NINTENDO_3DS:
@@ -2562,6 +2151,7 @@ static int rc_hash_from_file(char hash[33], uint32_t console_id, const rc_hash_i
     default:
       return rc_hash_iterator_error_formatted(iterator, "Unsupported console for file hash: %d", console_id);
 
+#ifndef RC_HASH_NO_ROMS
     case RC_CONSOLE_ARCADIA_2001:
     case RC_CONSOLE_ATARI_2600:
     case RC_CONSOLE_ATARI_JAGUAR:
@@ -2594,12 +2184,7 @@ static int rc_hash_from_file(char hash[33], uint32_t console_id, const rc_hash_i
       /* generic whole-file hash - don't buffer */
       return rc_hash_whole_file(hash, iterator);
 
-    case RC_CONSOLE_AMSTRAD_PC:
-    case RC_CONSOLE_APPLE_II:
-    case RC_CONSOLE_COMMODORE_64:
     case RC_CONSOLE_MEGA_DRIVE:
-    case RC_CONSOLE_MSX:
-    case RC_CONSOLE_PC8800:
       /* generic whole-file hash with m3u support - don't buffer */
       if (rc_path_compare_extension(path, "m3u"))
         return rc_hash_generate_from_playlist(hash, console_id, iterator);
@@ -2616,6 +2201,18 @@ static int rc_hash_from_file(char hash[33], uint32_t console_id, const rc_hash_i
     case RC_CONSOLE_SUPER_NINTENDO:
       /* additional logic whole-file hash - buffer then call rc_hash_generate_from_buffer */
       return rc_hash_buffered_file(hash, console_id, iterator);
+#endif
+
+    case RC_CONSOLE_AMSTRAD_PC:
+    case RC_CONSOLE_APPLE_II:
+    case RC_CONSOLE_COMMODORE_64:
+    case RC_CONSOLE_MSX:
+    case RC_CONSOLE_PC8800:
+      /* generic whole-file hash with m3u support - don't buffer */
+      if (rc_path_compare_extension(path, "m3u"))
+        return rc_hash_generate_from_playlist(hash, console_id, iterator);
+
+      return rc_hash_whole_file(hash, iterator);
 
     case RC_CONSOLE_3DO:
       if (rc_path_compare_extension(path, "m3u"))
@@ -2623,8 +2220,10 @@ static int rc_hash_from_file(char hash[33], uint32_t console_id, const rc_hash_i
 
       return rc_hash_3do(hash, iterator);
 
+#ifndef RC_HASH_NO_ROMS
     case RC_CONSOLE_ARCADE:
       return rc_hash_arcade(hash, iterator);
+#endif
 
     case RC_CONSOLE_ATARI_JAGUAR_CD:
       return rc_hash_jaguar_cd(hash, iterator);
@@ -2647,17 +2246,21 @@ static int rc_hash_from_file(char hash[33], uint32_t console_id, const rc_hash_i
     case RC_CONSOLE_NEO_GEO_CD:
       return rc_hash_neogeo_cd(hash, iterator);
 
+#ifndef RC_HASH_NO_ROMS
     case RC_CONSOLE_NINTENDO_64:
       return rc_hash_n64(hash, iterator);
+#endif
 
 #ifndef RC_HASH_NO_ENCRYPTED
     case RC_CONSOLE_NINTENDO_3DS:
       return rc_hash_nintendo_3ds(hash, iterator);
 #endif
 
+#ifndef RC_HASH_NO_ROMS
     case RC_CONSOLE_NINTENDO_DS:
     case RC_CONSOLE_NINTENDO_DSI:
       return rc_hash_nintendo_ds(hash, iterator);
+#endif
 
     case RC_CONSOLE_PC_ENGINE_CD:
       if (rc_path_compare_extension(path, "cue") || rc_path_compare_extension(path, "chd"))

--- a/src/rhash/hash.c
+++ b/src/rhash/hash.c
@@ -2151,7 +2151,6 @@ static int rc_hash_from_file(char hash[33], uint32_t console_id, const rc_hash_i
     default:
       return rc_hash_iterator_error_formatted(iterator, "Unsupported console for file hash: %d", console_id);
 
-#ifndef RC_HASH_NO_ROMS
     case RC_CONSOLE_ARCADIA_2001:
     case RC_CONSOLE_ATARI_2600:
     case RC_CONSOLE_ATARI_JAGUAR:
@@ -2201,7 +2200,6 @@ static int rc_hash_from_file(char hash[33], uint32_t console_id, const rc_hash_i
     case RC_CONSOLE_SUPER_NINTENDO:
       /* additional logic whole-file hash - buffer then call rc_hash_generate_from_buffer */
       return rc_hash_buffered_file(hash, console_id, iterator);
-#endif
 
     case RC_CONSOLE_AMSTRAD_PC:
     case RC_CONSOLE_APPLE_II:

--- a/src/rhash/hash_rom.c
+++ b/src/rhash/hash_rom.c
@@ -1,0 +1,403 @@
+#include "rc_hash_internal.h"
+
+#include "../rc_compat.h"
+
+/* ===================================================== */
+
+static int rc_hash_unheadered_iterator_buffer(char hash[33], const rc_hash_iterator_t* iterator, size_t header_size)
+{
+  return rc_hash_buffer(hash, iterator->buffer + header_size, iterator->buffer_size - header_size, iterator);
+}
+
+static int rc_hash_iterator_buffer(char hash[33], const rc_hash_iterator_t* iterator)
+{
+  return rc_hash_buffer(hash, iterator->buffer, iterator->buffer_size, iterator);
+}
+
+/* ===================================================== */
+
+int rc_hash_7800(char hash[33], const rc_hash_iterator_t* iterator)
+{
+  /* if the file contains a header, ignore it */
+  if (memcmp(&iterator->buffer[1], "ATARI7800", 9) == 0) {
+    rc_hash_iterator_verbose(iterator, "Ignoring 7800 header");
+    return rc_hash_unheadered_iterator_buffer(hash, iterator, 128);
+  }
+
+  return rc_hash_iterator_buffer(hash, iterator);
+}
+
+int rc_hash_arcade(char hash[33], const rc_hash_iterator_t* iterator)
+{
+  /* arcade hash is just the hash of the filename (no extension) - the cores are pretty stringent about having the right ROM data */
+  const char* filename = rc_path_get_filename(iterator->path);
+  const char* ext = rc_path_get_extension(filename);
+  char buffer[128]; /* realistically, this should never need more than ~32 characters */
+  size_t filename_length = ext - filename - 1;
+
+  /* fbneo supports loading subsystems by using specific folder names.
+   * if one is found, include it in the hash.
+   * https://github.com/libretro/FBNeo/blob/master/src/burner/libretro/README.md#emulating-consoles-and-computers
+   */
+  if (filename > iterator->path + 1) {
+    int include_folder = 0;
+    const char* folder = filename - 1;
+    size_t parent_folder_length = 0;
+
+    do {
+      if (folder[-1] == '/' || folder[-1] == '\\')
+        break;
+
+      --folder;
+    } while (folder > iterator->path);
+
+    parent_folder_length = filename - folder - 1;
+    if (parent_folder_length < 16) {
+      char* ptr = buffer;
+      while (folder < filename - 1)
+        *ptr++ = tolower(*folder++);
+      *ptr = '\0';
+
+      folder = buffer;
+    }
+
+    switch (parent_folder_length) {
+      case 3:
+        if (memcmp(folder, "nes", 3) == 0 || /* NES */
+            memcmp(folder, "fds", 3) == 0 || /* FDS */
+            memcmp(folder, "sms", 3) == 0 || /* Master System */
+            memcmp(folder, "msx", 3) == 0 || /* MSX */
+            memcmp(folder, "ngp", 3) == 0 || /* NeoGeo Pocket */
+            memcmp(folder, "pce", 3) == 0 || /* PCEngine */
+            memcmp(folder, "chf", 3) == 0 || /* ChannelF */
+            memcmp(folder, "sgx", 3) == 0)   /* SuperGrafX */
+          include_folder = 1;
+        break;
+      case 4:
+        if (memcmp(folder, "tg16", 4) == 0 || /* TurboGrafx-16 */
+            memcmp(folder, "msx1", 4) == 0)   /* MSX */
+          include_folder = 1;
+        break;
+      case 5:
+        if (memcmp(folder, "neocd", 5) == 0) /* NeoGeo CD */
+          include_folder = 1;
+        break;
+      case 6:
+        if (memcmp(folder, "coleco", 6) == 0 || /* Colecovision */
+            memcmp(folder, "sg1000", 6) == 0)   /* SG-1000 */
+          include_folder = 1;
+        break;
+      case 7:
+        if (memcmp(folder, "genesis", 7) == 0) /* Megadrive (Genesis) */
+          include_folder = 1;
+        break;
+      case 8:
+        if (memcmp(folder, "gamegear", 8) == 0 || /* Game Gear */
+            memcmp(folder, "megadriv", 8) == 0 || /* Megadrive */
+            memcmp(folder, "pcengine", 8) == 0 || /* PCEngine */
+            memcmp(folder, "channelf", 8) == 0 || /* ChannelF */
+            memcmp(folder, "spectrum", 8) == 0)   /* ZX Spectrum */
+          include_folder = 1;
+        break;
+      case 9:
+        if (memcmp(folder, "megadrive", 9) == 0) /* Megadrive */
+          include_folder = 1;
+        break;
+      case 10:
+        if (memcmp(folder, "supergrafx", 10) == 0 || /* SuperGrafX */
+            memcmp(folder, "zxspectrum", 10) == 0)   /* ZX Spectrum */
+          include_folder = 1;
+        break;
+      case 12:
+        if (memcmp(folder, "mastersystem", 12) == 0 || /* Master System */
+            memcmp(folder, "colecovision", 12) == 0)   /* Colecovision */
+          include_folder = 1;
+        break;
+      default:
+        break;
+    }
+
+    if (include_folder) {
+      if (parent_folder_length + filename_length + 1 < sizeof(buffer)) {
+        buffer[parent_folder_length] = '_';
+        memcpy(&buffer[parent_folder_length + 1], filename, filename_length);
+        return rc_hash_buffer(hash, (uint8_t*)&buffer[0], parent_folder_length + filename_length + 1, iterator);
+      }
+    }
+  }
+
+  return rc_hash_buffer(hash, (uint8_t*)filename, filename_length, iterator);
+}
+
+int rc_hash_text(char hash[33], const rc_hash_iterator_t* iterator)
+{
+  md5_state_t md5;
+  const uint8_t* scan = iterator->buffer;
+  const uint8_t* stop = iterator->buffer + iterator->buffer_size;
+
+  md5_init(&md5);
+
+  do {
+    const uint8_t* line = scan;
+
+    /* find end of line */
+    while (scan < stop && *scan != '\r' && *scan != '\n')
+      ++scan;
+
+    md5_append(&md5, line, (int)(scan - line));
+
+    /* include a normalized line ending */
+    /* NOTE: this causes a line ending to be hashed at the end of the file, even if one was not present */
+    md5_append(&md5, (const uint8_t*)"\n", 1);
+
+    /* skip newline */
+    if (scan < stop && *scan == '\r')
+      ++scan;
+    if (scan < stop && *scan == '\n')
+      ++scan;
+
+  } while (scan < stop);
+
+  return rc_hash_finalize(iterator, &md5, hash);
+}
+
+int rc_hash_lynx(char hash[33], const rc_hash_iterator_t* iterator)
+{
+  /* if the file contains a header, ignore it */
+  if (memcmp(&iterator->buffer[0], "LYNX", 5) == 0) {
+    rc_hash_iterator_verbose(iterator, "Ignoring LYNX header");
+    return rc_hash_unheadered_iterator_buffer(hash, iterator, 64);
+  }
+
+  return rc_hash_iterator_buffer(hash, iterator);
+}
+
+int rc_hash_nes(char hash[33], const rc_hash_iterator_t* iterator)
+{
+  /* if the file contains a header, ignore it */
+  if (memcmp(&iterator->buffer[0], "NES\x1a", 4) == 0) {
+    rc_hash_iterator_verbose(iterator, "Ignoring NES header");
+    return rc_hash_unheadered_iterator_buffer(hash, iterator, 16);
+  }
+
+  if (memcmp(&iterator->buffer[0], "FDS\x1a", 4) == 0) {
+    rc_hash_iterator_verbose(iterator, "Ignoring FDS header");
+    return rc_hash_unheadered_iterator_buffer(hash, iterator, 16);
+  }
+
+  return rc_hash_iterator_buffer(hash, iterator);
+}
+
+int rc_hash_n64(char hash[33], const rc_hash_iterator_t* iterator)
+{
+  uint8_t* buffer;
+  uint8_t* stop;
+  const size_t buffer_size = 65536;
+  md5_state_t md5;
+  size_t remaining;
+  void* file_handle;
+  int is_v64 = 0;
+  int is_n64 = 0;
+
+  file_handle = rc_file_open(iterator, iterator->path);
+  if (!file_handle)
+    return rc_hash_iterator_error(iterator, "Could not open file");
+
+  buffer = (uint8_t*)malloc(buffer_size);
+  if (!buffer) {
+    rc_file_close(iterator, file_handle);
+    return rc_hash_iterator_error(iterator, "Could not allocate temporary buffer");
+  }
+  stop = buffer + buffer_size;
+
+  /* read first byte so we can detect endianness */
+  rc_file_seek(iterator, file_handle, 0, SEEK_SET);
+  rc_file_read(iterator, file_handle, buffer, 1);
+
+  if (buffer[0] == 0x80) { /* z64 format (big endian [native]) */
+  }
+  else if (buffer[0] == 0x37) { /* v64 format (byteswapped) */
+    rc_hash_iterator_verbose(iterator, "converting v64 to z64");
+    is_v64 = 1;
+  }
+  else if (buffer[0] == 0x40) { /* n64 format (little endian) */
+    rc_hash_iterator_verbose(iterator, "converting n64 to z64");
+    is_n64 = 1;
+  }
+  else if (buffer[0] == 0xE8 || buffer[0] == 0x22) { /* ndd format (don't byteswap) */
+  }
+  else {
+    free(buffer);
+    rc_file_close(iterator, file_handle);
+
+    rc_hash_iterator_verbose(iterator, "Not a Nintendo 64 ROM");
+    return 0;
+  }
+
+  /* calculate total file size */
+  rc_file_seek(iterator, file_handle, 0, SEEK_END);
+  remaining = (size_t)rc_file_tell(iterator, file_handle);
+  if (remaining > MAX_BUFFER_SIZE)
+    remaining = MAX_BUFFER_SIZE;
+
+  rc_hash_iterator_verbose_formatted(iterator, "Hashing %u bytes", (unsigned)remaining);
+
+  /* begin hashing */
+  md5_init(&md5);
+
+  rc_file_seek(iterator, file_handle, 0, SEEK_SET);
+  while (remaining >= buffer_size) {
+    rc_file_read(iterator, file_handle, buffer, (int)buffer_size);
+
+    if (is_v64)
+      rc_hash_byteswap16(buffer, stop);
+    else if (is_n64)
+      rc_hash_byteswap32(buffer, stop);
+
+    md5_append(&md5, buffer, (int)buffer_size);
+    remaining -= buffer_size;
+  }
+
+  if (remaining > 0) {
+    rc_file_read(iterator, file_handle, buffer, (int)remaining);
+
+    stop = buffer + remaining;
+    if (is_v64)
+      rc_hash_byteswap16(buffer, stop);
+    else if (is_n64)
+      rc_hash_byteswap32(buffer, stop);
+
+    md5_append(&md5, buffer, (int)remaining);
+  }
+
+  /* cleanup */
+  rc_file_close(iterator, file_handle);
+  free(buffer);
+
+  return rc_hash_finalize(iterator, &md5, hash);
+}
+
+int rc_hash_nintendo_ds(char hash[33], const rc_hash_iterator_t* iterator)
+{
+  uint8_t header[512];
+  uint8_t* hash_buffer;
+  uint32_t hash_size, arm9_size, arm9_addr, arm7_size, arm7_addr, icon_addr;
+  size_t num_read;
+  int64_t offset = 0;
+  md5_state_t md5;
+  void* file_handle;
+
+  file_handle = rc_file_open(iterator, iterator->path);
+  if (!file_handle)
+    return rc_hash_iterator_error(iterator, "Could not open file");
+
+  rc_file_seek(iterator, file_handle, 0, SEEK_SET);
+  if (rc_file_read(iterator, file_handle, header, sizeof(header)) != 512)
+    return rc_hash_iterator_error(iterator, "Failed to read header");
+
+  if (header[0] == 0x2E && header[1] == 0x00 && header[2] == 0x00 && header[3] == 0xEA &&
+      header[0xB0] == 0x44 && header[0xB1] == 0x46 && header[0xB2] == 0x96 && header[0xB3] == 0) {
+    /* SuperCard header detected, ignore it */
+    rc_hash_iterator_verbose(iterator, "Ignoring SuperCard header");
+
+    offset = 512;
+    rc_file_seek(iterator, file_handle, offset, SEEK_SET);
+    rc_file_read(iterator, file_handle, header, sizeof(header));
+  }
+
+  arm9_addr = header[0x20] | (header[0x21] << 8) | (header[0x22] << 16) | (header[0x23] << 24);
+  arm9_size = header[0x2C] | (header[0x2D] << 8) | (header[0x2E] << 16) | (header[0x2F] << 24);
+  arm7_addr = header[0x30] | (header[0x31] << 8) | (header[0x32] << 16) | (header[0x33] << 24);
+  arm7_size = header[0x3C] | (header[0x3D] << 8) | (header[0x3E] << 16) | (header[0x3F] << 24);
+  icon_addr = header[0x68] | (header[0x69] << 8) | (header[0x6A] << 16) | (header[0x6B] << 24);
+
+  if (arm9_size + arm7_size > 16 * 1024 * 1024) {
+    /* sanity check - code blocks are typically less than 1MB each - assume not a DS ROM */
+    return rc_hash_iterator_error_formatted(iterator, "arm9 code size (%u) + arm7 code size (%u) exceeds 16MB", arm9_size, arm7_size);
+  }
+
+  hash_size = 0xA00;
+  if (arm9_size > hash_size)
+    hash_size = arm9_size;
+  if (arm7_size > hash_size)
+    hash_size = arm7_size;
+
+  hash_buffer = (uint8_t*)malloc(hash_size);
+  if (!hash_buffer) {
+    rc_file_close(iterator, file_handle);
+    return rc_hash_iterator_error_formatted(iterator, "Failed to allocate %u bytes", hash_size);
+  }
+
+  md5_init(&md5);
+
+  rc_hash_iterator_verbose(iterator, "Hashing 352 byte header");
+  md5_append(&md5, header, 0x160);
+
+  rc_hash_iterator_verbose_formatted(iterator, "Hashing %u byte arm9 code (at %08X)", arm9_size, arm9_addr);
+
+  rc_file_seek(iterator, file_handle, arm9_addr + offset, SEEK_SET);
+  rc_file_read(iterator, file_handle, hash_buffer, arm9_size);
+  md5_append(&md5, hash_buffer, arm9_size);
+
+  rc_hash_iterator_verbose_formatted(iterator, "Hashing %u byte arm7 code (at %08X)", arm7_size, arm7_addr);
+
+  rc_file_seek(iterator, file_handle, arm7_addr + offset, SEEK_SET);
+  rc_file_read(iterator, file_handle, hash_buffer, arm7_size);
+  md5_append(&md5, hash_buffer, arm7_size);
+
+  rc_hash_iterator_verbose_formatted(iterator, "Hashing 2560 byte icon and labels data (at %08X)", icon_addr);
+
+  rc_file_seek(iterator, file_handle, icon_addr + offset, SEEK_SET);
+  num_read = rc_file_read(iterator, file_handle, hash_buffer, 0xA00);
+  if (num_read < 0xA00) {
+    /* some homebrew games don't provide a full icon block, and no data after the icon block.
+     * if we didn't get a full icon block, fill the remaining portion with 0s
+     */
+    rc_hash_iterator_verbose_formatted(iterator,
+      "Warning: only got %u bytes for icon and labels data, 0-padding to 2560 bytes", (unsigned)num_read);
+
+    memset(&hash_buffer[num_read], 0, 0xA00 - num_read);
+  }
+  md5_append(&md5, hash_buffer, 0xA00);
+
+  free(hash_buffer);
+  rc_file_close(iterator, file_handle);
+
+  return rc_hash_finalize(iterator, &md5, hash);
+}
+
+int rc_hash_pce(char hash[33], const rc_hash_iterator_t* iterator)
+{
+  /* if the file contains a header, ignore it (expect ROM data to be multiple of 128KB) */
+  uint32_t calc_size = ((uint32_t)iterator->buffer_size / 0x20000) * 0x20000;
+  if (iterator->buffer_size - calc_size == 512) {
+    rc_hash_iterator_verbose(iterator, "Ignoring PCE header");
+    return rc_hash_unheadered_iterator_buffer(hash, iterator, 512);
+  }
+
+  return rc_hash_iterator_buffer(hash, iterator);
+}
+
+int rc_hash_scv(char hash[33], const rc_hash_iterator_t* iterator)
+{
+  /* if the file contains a header, ignore it */
+  /* https://gitlab.com/MaaaX-EmuSCV/libretro-emuscv/-/blob/master/readme.txt#L211 */
+  if (memcmp(iterator->buffer, "EmuSCV", 6) == 0) {
+    rc_hash_iterator_verbose(iterator, "Ignoring SCV header");
+    return rc_hash_unheadered_iterator_buffer(hash, iterator, 32);
+  }
+
+  return rc_hash_iterator_buffer(hash, iterator);
+}
+
+int rc_hash_snes(char hash[33], const rc_hash_iterator_t* iterator)
+{
+  /* if the file contains a header, ignore it */
+  uint32_t calc_size = ((uint32_t)iterator->buffer_size / 0x2000) * 0x2000;
+  if (iterator->buffer_size - calc_size == 512) {
+    rc_hash_iterator_verbose(iterator, "Ignoring SNES header");
+    return rc_hash_unheadered_iterator_buffer(hash, iterator, 512);
+  }
+
+  return rc_hash_iterator_buffer(hash, iterator);
+}

--- a/src/rhash/hash_rom.c
+++ b/src/rhash/hash_rom.c
@@ -2,6 +2,8 @@
 
 #include "../rc_compat.h"
 
+#include <ctype.h>
+
 /* ===================================================== */
 
 static int rc_hash_unheadered_iterator_buffer(char hash[33], const rc_hash_iterator_t* iterator, size_t header_size)

--- a/src/rhash/rc_hash_internal.h
+++ b/src/rhash/rc_hash_internal.h
@@ -70,7 +70,7 @@ typedef struct rc_hash_cdrom_track_t {
 
 int rc_hash_whole_file(char hash[33], const rc_hash_iterator_t* iterator);
 
-#ifndef RC_HASH_NO_ROMS
+#ifndef RC_HASH_NO_ROM
   /* hash_rom.c */
   int rc_hash_7800(char hash[33], const rc_hash_iterator_t* iterator);
   int rc_hash_arcade(char hash[33], const rc_hash_iterator_t* iterator);

--- a/src/rhash/rc_hash_internal.h
+++ b/src/rhash/rc_hash_internal.h
@@ -33,8 +33,13 @@ int rc_hash_iterator_error_formatted(const rc_hash_iterator_t* iterator, const c
 
 int rc_hash_finalize(const rc_hash_iterator_t* iterator, md5_state_t* md5, char hash[33]);
 
+int rc_hash_buffer(char hash[33], const uint8_t* buffer, size_t buffer_size, const rc_hash_iterator_t* iterator);
+void rc_hash_byteswap16(uint8_t* buffer, const uint8_t* stop);
+void rc_hash_byteswap32(uint8_t* buffer, const uint8_t* stop);
+
 
 const char* rc_path_get_filename(const char* path);
+const char* rc_path_get_extension(const char* path);
 int rc_path_compare_extension(const char* path, const char* ext);
 
 
@@ -64,6 +69,20 @@ typedef struct rc_hash_cdrom_track_t {
 
 
 int rc_hash_whole_file(char hash[33], const rc_hash_iterator_t* iterator);
+
+#ifndef RC_HASH_NO_ROMS
+  /* hash_rom.c */
+  int rc_hash_7800(char hash[33], const rc_hash_iterator_t* iterator);
+  int rc_hash_arcade(char hash[33], const rc_hash_iterator_t* iterator);
+  int rc_hash_text(char hash[33], const rc_hash_iterator_t* iterator);
+  int rc_hash_lynx(char hash[33], const rc_hash_iterator_t* iterator);
+  int rc_hash_nes(char hash[33], const rc_hash_iterator_t* iterator);
+  int rc_hash_n64(char hash[33], const rc_hash_iterator_t* iterator);
+  int rc_hash_nintendo_ds(char hash[33], const rc_hash_iterator_t* iterator);
+  int rc_hash_pce(char hash[33], const rc_hash_iterator_t* iterator);
+  int rc_hash_scv(char hash[33], const rc_hash_iterator_t* iterator);
+  int rc_hash_snes(char hash[33], const rc_hash_iterator_t* iterator);
+#endif
 
 #ifndef RC_HASH_NO_ENCRYPTED
   /* hash_encrypted.c */

--- a/test/Makefile
+++ b/test/Makefile
@@ -3,6 +3,7 @@
 #  BUILD                 use flags for specified upstream consumer - "c89" or "retroarch" [default to "c89"]
 #  DEBUG                 if set to anything, builds with DEBUG symbols
 #  HAVE_HASH             if set to 0, excludes all hash functionality
+#  HAVE_HASH_ROM         if set to 0, excludes rom hash generation
 #  HAVE_HASH_ZIP         if set to 0, excludes zip hash generation
 #  HAVE_HASH_ENCRYPTED   if set to 0, excludes encrypted hash generation
 
@@ -143,6 +144,14 @@ else
            rhash/test_cdreader.o \
            rhash/test_hash.o \
            test_rc_libretro.o
+
+    ifeq ($(HAVE_HASH_ROM), 0)
+        EXTRA += |NO_HASH_ROM
+        CFLAGS += -DRC_HASH_NO_ROMS
+    else
+        OBJ += $(RC_HASH_SRC)/hash_rom.o \
+               rhash/test_hash_rom.o
+    endif
 
     ifeq ($(HAVE_HASH_ZIP), 0)
         EXTRA += |NO_HASH_ZIP

--- a/test/Makefile
+++ b/test/Makefile
@@ -147,7 +147,7 @@ else
 
     ifeq ($(HAVE_HASH_ROM), 0)
         EXTRA += |NO_HASH_ROM
-        CFLAGS += -DRC_HASH_NO_ROMS
+        CFLAGS += -DRC_HASH_NO_ROM
     else
         OBJ += $(RC_HASH_SRC)/hash_rom.o \
                rhash/test_hash_rom.o

--- a/test/rcheevos-test.vcxproj
+++ b/test/rcheevos-test.vcxproj
@@ -160,6 +160,7 @@
     <ClCompile Include="..\src\rhash\cdreader.c" />
     <ClCompile Include="..\src\rhash\hash.c" />
     <ClCompile Include="..\src\rhash\hash_encrypted.c" />
+    <ClCompile Include="..\src\rhash\hash_rom.c" />
     <ClCompile Include="..\src\rhash\hash_zip.c" />
     <ClCompile Include="..\src\rhash\md5.c" />
     <ClCompile Include="..\src\rurl\url.c" />
@@ -186,6 +187,7 @@
     <ClCompile Include="rhash\mock_filereader.c" />
     <ClCompile Include="rhash\test_cdreader.c" />
     <ClCompile Include="rhash\test_hash.c" />
+    <ClCompile Include="rhash\test_hash_rom.c" />
     <ClCompile Include="rhash\test_hash_zip.c" />
     <ClCompile Include="rurl\test_url.c" />
     <ClCompile Include="test.c" />

--- a/test/rcheevos-test.vcxproj.filters
+++ b/test/rcheevos-test.vcxproj.filters
@@ -218,6 +218,12 @@
     <ClCompile Include="..\src\rhash\hash_encrypted.c">
       <Filter>src\rhash</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\rhash\hash_rom.c">
+      <Filter>src\rhash</Filter>
+    </ClCompile>
+    <ClCompile Include="rhash\test_hash_rom.c">
+      <Filter>tests\rhash</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\include\rcheevos.h">

--- a/test/rhash/data.c
+++ b/test/rhash/data.c
@@ -5,37 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-/* first 64 bytes of SUPER MARIO 64 ROM in each N64 format */
-uint8_t test_rom_z64[64] = {
-  0x80, 0x37, 0x12, 0x40, 0x00, 0x00, 0x00, 0x0F, 0x80, 0x24, 0x60, 0x00, 0x00, 0x00, 0x14, 0x44,
-  0x63, 0x5A, 0x2B, 0xFF, 0x8B, 0x02, 0x23, 0x26, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-  0x53, 0x55, 0x50, 0x45, 0x52, 0x20, 0x4D, 0x41, 0x52, 0x49, 0x4F, 0x20, 0x36, 0x34, 0x20, 0x20,
-  0x20, 0x20, 0x20, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x4E, 0x53, 0x4D, 0x45, 0x00
-};
-
-uint8_t test_rom_v64[64] = {
-  0x37, 0x80, 0x40, 0x12, 0x00, 0x00, 0x0F, 0x00, 0x24, 0x80, 0x00, 0x60, 0x00, 0x00, 0x44, 0x14,
-  0x5A, 0x63, 0xFF, 0x2B, 0x02, 0x8B, 0x26, 0x23, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-  0x55, 0x53, 0x45, 0x50, 0x20, 0x52, 0x41, 0x4D, 0x49, 0x52, 0x20, 0x4F, 0x34, 0x36, 0x20, 0x20,
-  0x20, 0x20, 0x20, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x4E, 0x00, 0x4D, 0x53, 0x00, 0x45
-};
-
-uint8_t test_rom_n64[64] = {
-  0x40, 0x12, 0x37, 0x80, 0x0F, 0x00, 0x00, 0x00, 0x00, 0x60, 0x24, 0x80, 0x44, 0x14, 0x00, 0x00,
-  0xFF, 0x2B, 0x5A, 0x63, 0x26, 0x23, 0x02, 0x8B, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-  0x45, 0x50, 0x55, 0x53, 0x41, 0x4D, 0x20, 0x52, 0x20, 0x4F, 0x49, 0x52, 0x20, 0x20, 0x34, 0x36,
-  0x20, 0x20, 0x20, 0x20, 0x00, 0x00, 0x00, 0x00, 0x4E, 0x00, 0x00, 0x00, 0x00, 0x45, 0x4D, 0x53
-};
-
-/* first 64 bytes of DOSHIN THE GIANT in ndd format */
-uint8_t test_rom_ndd[64] = {
-  0xE8, 0x48, 0xD3, 0x16, 0x10, 0x13, 0x00, 0x45, 0x0C, 0x18, 0x24, 0x30, 0x3C, 0x48, 0x54, 0x60,
-  0x6C, 0x78, 0x84, 0x90, 0x9C, 0xA8, 0xB4, 0xC0, 0xFF, 0xFF, 0xFF, 0xFF, 0x80, 0x02, 0x5C, 0x00,
-  0x10, 0x16, 0x1C, 0x22, 0x28, 0x2A, 0x31, 0x32, 0x3A, 0x40, 0x46, 0x4C, 0x04, 0x0C, 0x14, 0x1C,
-  0x24, 0x2C, 0x34, 0x3C, 0x44, 0x4C, 0x54, 0x5C, 0x04, 0x0C, 0x14, 0x1C, 0x24, 0x2C, 0x34, 0x3C
-};
-
-static void fill_image(uint8_t* image, size_t size)
+void fill_image(uint8_t* image, size_t size)
 {
   int seed = (int)(size ^ (size >> 8) ^ ((size - 1) * 25387));
   int count;
@@ -112,10 +82,8 @@ uint8_t* generate_nes_file(size_t kb, int with_header, size_t* image_size)
     size_needed += 16;
 
   image = (uint8_t*)calloc(size_needed, 1);
-  if (image != NULL)
-  {
-    if (with_header)
-    {
+  if (image != NULL) {
+    if (with_header) {
       image[0] = 'N';
       image[1] = 'E';
       image[2] = 'S';
@@ -124,84 +92,9 @@ uint8_t* generate_nes_file(size_t kb, int with_header, size_t* image_size)
 
       fill_image(image + 16, size_needed - 16);
     }
-    else
-    {
+    else {
       fill_image(image, size_needed);
     }
-  }
-
-  if (image_size)
-    *image_size = size_needed;
-  return image;
-}
-
-uint8_t* generate_fds_file(size_t sides, int with_header, size_t* image_size)
-{
-  uint8_t* image;
-  size_t size_needed = sides * 65500;
-  if (with_header)
-    size_needed += 16;
-
-  image = (uint8_t*)calloc(size_needed, 1);
-  if (image != NULL)
-  {
-    if (with_header)
-    {
-      image[0] = 'F';
-      image[1] = 'D';
-      image[2] = 'S';
-      image[3] = '\x1A';
-      image[4] = (uint8_t)sides;
-
-      fill_image(image + 16, size_needed - 16);
-    }
-    else
-    {
-      fill_image(image, size_needed);
-    }
-  }
-
-  if (image_size)
-    *image_size = size_needed;
-  return image;
-}
-
-uint8_t* generate_nds_file(size_t mb, uint32_t arm9_size, uint32_t arm7_size, size_t* image_size)
-{
-  uint8_t* image;
-  const size_t size_needed = mb * 1024 * 1024;
-
-  image = (uint8_t*)calloc(size_needed, 1);
-  if (image != NULL)
-  {
-    uint32_t arm9_addr = 65536;
-    uint32_t arm7_addr = arm9_addr + arm9_size;
-    uint32_t icon_addr = arm7_addr + arm7_size;
-
-    fill_image(image, size_needed);
-
-    image[0x20] = (arm9_addr & 0xFF);
-    image[0x21] = ((arm9_addr >> 8) & 0xFF);
-    image[0x22] = ((arm9_addr >> 16) & 0xFF);
-    image[0x23] = ((arm9_addr >> 24) & 0xFF);
-    image[0x2C] = (arm9_size & 0xFF);
-    image[0x2D] = ((arm9_size >> 8) & 0xFF);
-    image[0x2E] = ((arm9_size >> 16) & 0xFF);
-    image[0x2F] = ((arm9_size >> 24) & 0xFF);
-
-    image[0x30] = (arm7_addr & 0xFF);
-    image[0x31] = ((arm7_addr >> 8) & 0xFF);
-    image[0x32] = ((arm7_addr >> 16) & 0xFF);
-    image[0x33] = ((arm7_addr >> 24) & 0xFF);
-    image[0x3C] = (arm7_size & 0xFF);
-    image[0x3D] = ((arm7_size >> 8) & 0xFF);
-    image[0x3E] = ((arm7_size >> 16) & 0xFF);
-    image[0x3F] = ((arm7_size >> 24) & 0xFF);
-
-    image[0x68] = (icon_addr & 0xFF);
-    image[0x69] = ((icon_addr >> 8) & 0xFF);
-    image[0x6A] = ((icon_addr >> 16) & 0xFF);
-    image[0x6B] = ((icon_addr >> 24) & 0xFF);
   }
 
   if (image_size)
@@ -245,44 +138,6 @@ uint8_t* generate_gamecube_iso(size_t mb, size_t* image_size)
       image[dol_sizes_addr + ix] = (ix % 4 == 2) ? (0x30 + 1 + ix / 4) : 0; 
       /* 0x000000ff for every other size */
       image[dol_sizes_addr + 0x90 + ix] = (ix % 8 == 3) ? 0xff : 0; 
-    }
-  }
-
-  if (image_size)
-    *image_size = size_needed;
-  return image;
-}
-
-uint8_t* generate_atari_7800_file(size_t kb, int with_header, size_t* image_size)
-{
-  uint8_t* image;
-  size_t size_needed = kb * 1024;
-  if (with_header)
-    size_needed += 128;
-
-  image = (uint8_t*)calloc(size_needed, 1);
-  if (image != NULL)
-  {
-    if (with_header)
-    {
-      const uint8_t header[128] = {
-        3, 'A', 'T', 'A', 'R', 'I', '7', '8', '0', '0', 0, 0, 0, 0, 0, 0, /* version + magic text */
-        0, 'G', 'a', 'm', 'e', 'N', 'a', 'm', 'e', 0, 0, 0, 0, 0, 0, 0,   /* game name */
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                   /* game name (cont'd) */
-        0, 0, 2, 0, 0, 0, 3, 1, 1, 0, 0, 0, 0, 0, 0, 0,                   /* attributes */
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                   /* unused */
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                   /* unused */
-        0, 0, 0, 0, 'A', 'C', 'T', 'U', 'A', 'L', ' ', 'C', 'A', 'R', 'T',/* magic text*/
-        'D', 'A', 'T', 'A', ' ', 'S', 'T', 'A', 'R', 'T', 'S', ' ', 'H', 'E', 'R', 'E' /* magic text */
-      };
-      memcpy(image, header, sizeof(header));
-      image[50] = (uint8_t)(kb / 4); /* 4-byte value starting at address 49 is the ROM size without header */
-
-      fill_image(image + 128, size_needed - 128);
-    }
-    else
-    {
-      fill_image(image, size_needed);
     }
   }
 

--- a/test/rhash/data.c
+++ b/test/rhash/data.c
@@ -74,34 +74,6 @@ void fill_image(uint8_t* image, size_t size)
   }
 }
 
-uint8_t* generate_nes_file(size_t kb, int with_header, size_t* image_size)
-{
-  uint8_t* image;
-  size_t size_needed = kb * 1024;
-  if (with_header)
-    size_needed += 16;
-
-  image = (uint8_t*)calloc(size_needed, 1);
-  if (image != NULL) {
-    if (with_header) {
-      image[0] = 'N';
-      image[1] = 'E';
-      image[2] = 'S';
-      image[3] = '\x1A';
-      image[4] = (uint8_t)(kb / 16);
-
-      fill_image(image + 16, size_needed - 16);
-    }
-    else {
-      fill_image(image, size_needed);
-    }
-  }
-
-  if (image_size)
-    *image_size = size_needed;
-  return image;
-}
-
 uint8_t* generate_gamecube_iso(size_t mb, size_t* image_size)
 {
   uint8_t* image;

--- a/test/rhash/data.h
+++ b/test/rhash/data.h
@@ -20,8 +20,6 @@ uint8_t* generate_pcfx_bin(uint32_t binary_sectors, size_t* image_size);
 uint8_t* generate_psx_bin(const char* binary_name, uint32_t binary_size, size_t* image_size);
 uint8_t* generate_ps2_bin(const char* binary_name, uint32_t binary_size, size_t* image_size);
 
-uint8_t* generate_nes_file(size_t kb, int with_header, size_t* image_size);
-
 uint8_t* generate_gamecube_iso(size_t mb, size_t* image_size);
 
 uint8_t* generate_iso9660_bin(uint32_t binary_sectors, const char* volume_label, size_t* image_size);

--- a/test/rhash/data.h
+++ b/test/rhash/data.h
@@ -20,19 +20,14 @@ uint8_t* generate_pcfx_bin(uint32_t binary_sectors, size_t* image_size);
 uint8_t* generate_psx_bin(const char* binary_name, uint32_t binary_size, size_t* image_size);
 uint8_t* generate_ps2_bin(const char* binary_name, uint32_t binary_size, size_t* image_size);
 
-uint8_t* generate_atari_7800_file(size_t kb, int with_header, size_t* image_size);
 uint8_t* generate_nes_file(size_t kb, int with_header, size_t* image_size);
-uint8_t* generate_fds_file(size_t sides, int with_header, size_t* image_size);
-uint8_t* generate_nds_file(size_t mb, uint32_t arm9_size, uint32_t arm7_size, size_t* image_size);
+
 uint8_t* generate_gamecube_iso(size_t mb, size_t* image_size);
 
 uint8_t* generate_iso9660_bin(uint32_t binary_sectors, const char* volume_label, size_t* image_size);
 uint8_t* generate_iso9660_file(uint8_t* image, const char* filename, const uint8_t* contents, size_t contents_size);
 
-extern uint8_t test_rom_z64[64];
-extern uint8_t test_rom_n64[64];
-extern uint8_t test_rom_v64[64];
-extern uint8_t test_rom_ndd[64];
+void fill_image(uint8_t* image, size_t size);
 
 RC_END_C_DECLS
 

--- a/test/rhash/test_hash.c
+++ b/test/rhash/test_hash.c
@@ -1539,7 +1539,7 @@ static void test_hash_m3u_absolute_path(const char* absolute_path)
   assert_valid_m3u(absolute_path, "relative/test.m3u", m3u_contents);
 }
 
-#ifndef RC_HASH_NO_ROMS
+#ifndef RC_HASH_NO_ROM
 uint8_t* generate_nes_file(size_t kb, int with_header, size_t* image_size);
 
 static void test_hash_file_without_ext()
@@ -1701,7 +1701,7 @@ void test_hash(void) {
   TEST_PARAMS1(test_hash_m3u_absolute_path, "samba:/absolute/test.d88");
 
   /* other */
-#ifndef RC_HASH_NO_ROMS
+#ifndef RC_HASH_NO_ROM
   TEST(test_hash_file_without_ext);
 #endif
   TEST(test_hash_handler_table_order);

--- a/test/rhash/test_hash.c
+++ b/test/rhash/test_hash.c
@@ -1539,6 +1539,9 @@ static void test_hash_m3u_absolute_path(const char* absolute_path)
   assert_valid_m3u(absolute_path, "relative/test.m3u", m3u_contents);
 }
 
+#ifndef RC_HASH_NO_ROMS
+uint8_t* generate_nes_file(size_t kb, int with_header, size_t* image_size);
+
 static void test_hash_file_without_ext()
 {
   size_t image_size;
@@ -1572,6 +1575,7 @@ static void test_hash_file_without_ext()
   ASSERT_NUM_EQUALS(result_iterator, 1);
   ASSERT_STR_EQUALS(hash_iterator, "64b131c5c7fec32985d9c99700babb7e");
 }
+#endif
 
 static void test_hash_handler_table_order()
 {
@@ -1697,7 +1701,9 @@ void test_hash(void) {
   TEST_PARAMS1(test_hash_m3u_absolute_path, "samba:/absolute/test.d88");
 
   /* other */
+#ifndef RC_HASH_NO_ROMS
   TEST(test_hash_file_without_ext);
+#endif
   TEST(test_hash_handler_table_order);
 
   TEST_SUITE_END();

--- a/test/rhash/test_hash_rom.c
+++ b/test/rhash/test_hash_rom.c
@@ -1,0 +1,896 @@
+#include "rc_hash.h"
+
+#include "../rhash/rc_hash_internal.h"
+
+#include "../rc_compat.h"
+#include "../test_framework.h"
+#include "data.h"
+#include "mock_filereader.h"
+
+#include <stdlib.h>
+
+/* in test_hash.c */
+void test_hash_full_file(uint32_t console_id, const char* filename, size_t size, const char* expected_md5);
+void test_hash_m3u(uint32_t console_id, const char* filename, size_t size, const char* expected_md5);
+
+/* ========================================================================= */
+
+static void test_hash_arcade(const char* path, const char* expected_md5)
+{
+  char hash_file[33], hash_iterator[33];
+
+  /* test file hash */
+  int result_file = rc_hash_generate_from_file(hash_file, RC_CONSOLE_ARCADE, path);
+
+  /* test file identification from iterator */
+  int result_iterator;
+  struct rc_hash_iterator iterator;
+
+  rc_hash_initialize_iterator(&iterator, path, NULL, 0);
+  result_iterator = rc_hash_iterate(hash_iterator, &iterator);
+  rc_hash_destroy_iterator(&iterator);
+
+  /* validation */
+  ASSERT_NUM_EQUALS(result_file, 1);
+  ASSERT_STR_EQUALS(hash_file, expected_md5);
+
+  ASSERT_NUM_EQUALS(result_iterator, 1);
+  ASSERT_STR_EQUALS(hash_iterator, expected_md5);
+}
+
+/* ========================================================================= */
+
+static void test_hash_arduboy()
+{
+  char hash_file[33], hash_iterator[33];
+  const char* expected_md5 = "67b64633285a7f965064ba29dab45148";
+
+  const char* hex_input =
+    ":100000000C94690D0C94910D0C94910D0C94910D20\n"
+    ":100010000C94910D0C94910D0C94910D0C94910DE8\n"
+    ":100020000C94910D0C94910D0C94C32A0C94352BC7\n"
+    ":00000001FF\n";
+  mock_file(0, "game.hex", (const uint8_t*)hex_input, strlen(hex_input));
+
+  /* test file hash */
+  int result_file = rc_hash_generate_from_file(hash_file, RC_CONSOLE_ARDUBOY, "game.hex");
+
+  /* test file identification from iterator */
+  int result_iterator;
+  struct rc_hash_iterator iterator;
+
+  rc_hash_initialize_iterator(&iterator, "game.hex", NULL, 0);
+  result_iterator = rc_hash_iterate(hash_iterator, &iterator);
+  rc_hash_destroy_iterator(&iterator);
+
+  /* validation */
+  ASSERT_NUM_EQUALS(result_file, 1);
+  ASSERT_STR_EQUALS(hash_file, expected_md5);
+
+  ASSERT_NUM_EQUALS(result_iterator, 1);
+  ASSERT_STR_EQUALS(hash_iterator, expected_md5);
+}
+
+static void test_hash_arduboy_crlf()
+{
+  char hash_file[33], hash_iterator[33];
+  const char* expected_md5 = "67b64633285a7f965064ba29dab45148";
+
+  const char* hex_input =
+    ":100000000C94690D0C94910D0C94910D0C94910D20\r\n"
+    ":100010000C94910D0C94910D0C94910D0C94910DE8\r\n"
+    ":100020000C94910D0C94910D0C94C32A0C94352BC7\r\n"
+    ":00000001FF\r\n";
+  mock_file(0, "game.hex", (const uint8_t*)hex_input, strlen(hex_input));
+
+  /* test file hash */
+  int result_file = rc_hash_generate_from_file(hash_file, RC_CONSOLE_ARDUBOY, "game.hex");
+
+  /* test file identification from iterator */
+  int result_iterator;
+  struct rc_hash_iterator iterator;
+
+  rc_hash_initialize_iterator(&iterator, "game.hex", NULL, 0);
+  result_iterator = rc_hash_iterate(hash_iterator, &iterator);
+  rc_hash_destroy_iterator(&iterator);
+
+  /* validation */
+  ASSERT_NUM_EQUALS(result_file, 1);
+  ASSERT_STR_EQUALS(hash_file, expected_md5);
+
+  ASSERT_NUM_EQUALS(result_iterator, 1);
+  ASSERT_STR_EQUALS(hash_iterator, expected_md5);
+}
+
+static void test_hash_arduboy_no_final_lf()
+{
+  char hash_file[33], hash_iterator[33];
+  const char* expected_md5 = "67b64633285a7f965064ba29dab45148";
+
+  const char* hex_input =
+    ":100000000C94690D0C94910D0C94910D0C94910D20\n"
+    ":100010000C94910D0C94910D0C94910D0C94910DE8\n"
+    ":100020000C94910D0C94910D0C94C32A0C94352BC7\n"
+    ":00000001FF";
+  mock_file(0, "game.hex", (const uint8_t*)hex_input, strlen(hex_input));
+
+  /* test file hash */
+  int result_file = rc_hash_generate_from_file(hash_file, RC_CONSOLE_ARDUBOY, "game.hex");
+
+  /* test file identification from iterator */
+  int result_iterator;
+  struct rc_hash_iterator iterator;
+
+  rc_hash_initialize_iterator(&iterator, "game.hex", NULL, 0);
+  result_iterator = rc_hash_iterate(hash_iterator, &iterator);
+  rc_hash_destroy_iterator(&iterator);
+
+  /* validation */
+  ASSERT_NUM_EQUALS(result_file, 1);
+  ASSERT_STR_EQUALS(hash_file, expected_md5);
+
+  ASSERT_NUM_EQUALS(result_iterator, 1);
+  ASSERT_STR_EQUALS(hash_iterator, expected_md5);
+}
+
+/* ========================================================================= */
+
+static uint8_t* generate_atari_7800_file(size_t kb, int with_header, size_t* image_size)
+{
+  uint8_t* image;
+  size_t size_needed = kb * 1024;
+  if (with_header)
+    size_needed += 128;
+
+  image = (uint8_t*)calloc(size_needed, 1);
+  if (image != NULL) {
+    if (with_header) {
+      const uint8_t header[128] = {
+        3, 'A', 'T', 'A', 'R', 'I', '7', '8', '0', '0', 0, 0, 0, 0, 0, 0, /* version + magic text */
+        0, 'G', 'a', 'm', 'e', 'N', 'a', 'm', 'e', 0, 0, 0, 0, 0, 0, 0,   /* game name */
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                   /* game name (cont'd) */
+        0, 0, 2, 0, 0, 0, 3, 1, 1, 0, 0, 0, 0, 0, 0, 0,                   /* attributes */
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                   /* unused */
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                   /* unused */
+        0, 0, 0, 0, 'A', 'C', 'T', 'U', 'A', 'L', ' ', 'C', 'A', 'R', 'T',/* magic text*/
+        'D', 'A', 'T', 'A', ' ', 'S', 'T', 'A', 'R', 'T', 'S', ' ', 'H', 'E', 'R', 'E' /* magic text */
+      };
+      memcpy(image, header, sizeof(header));
+      image[50] = (uint8_t)(kb / 4); /* 4-byte value starting at address 49 is the ROM size without header */
+
+      fill_image(image + 128, size_needed - 128);
+    }
+    else {
+      fill_image(image, size_needed);
+    }
+  }
+
+  if (image_size)
+    *image_size = size_needed;
+  return image;
+}
+
+static void test_hash_atari_7800()
+{
+  size_t image_size;
+  uint8_t* image = generate_atari_7800_file(16, 0, &image_size);
+  char hash[33];
+  int result = rc_hash_generate_from_buffer(hash, RC_CONSOLE_ATARI_7800, image, image_size);
+  free(image);
+
+  ASSERT_NUM_EQUALS(result, 1);
+  ASSERT_STR_EQUALS(hash, "455f07d8500f3fabc54906737866167f");
+  ASSERT_NUM_EQUALS(image_size, 16384);
+}
+
+static void test_hash_atari_7800_with_header()
+{
+  size_t image_size;
+  uint8_t* image = generate_atari_7800_file(16, 1, &image_size);
+  char hash[33];
+  int result = rc_hash_generate_from_buffer(hash, RC_CONSOLE_ATARI_7800, image, image_size);
+  free(image);
+
+  /* NOTE: expectation is that this hash matches the hash in test_hash_atari_7800 */
+  ASSERT_NUM_EQUALS(result, 1);
+  ASSERT_STR_EQUALS(hash, "455f07d8500f3fabc54906737866167f");
+  ASSERT_NUM_EQUALS(image_size, 16384 + 128);
+}
+
+/* ========================================================================= */
+
+static uint8_t* generate_nes_file(size_t kb, int with_header, size_t* image_size)
+{
+  uint8_t* image;
+  size_t size_needed = kb * 1024;
+  if (with_header)
+    size_needed += 16;
+
+  image = (uint8_t*)calloc(size_needed, 1);
+  if (image != NULL) {
+    if (with_header) {
+      image[0] = 'N';
+      image[1] = 'E';
+      image[2] = 'S';
+      image[3] = '\x1A';
+      image[4] = (uint8_t)(kb / 16);
+
+      fill_image(image + 16, size_needed - 16);
+    }
+    else {
+      fill_image(image, size_needed);
+    }
+  }
+
+  if (image_size)
+    *image_size = size_needed;
+  return image;
+}
+
+static uint8_t* generate_fds_file(size_t sides, int with_header, size_t* image_size)
+{
+  uint8_t* image;
+  size_t size_needed = sides * 65500;
+  if (with_header)
+    size_needed += 16;
+
+  image = (uint8_t*)calloc(size_needed, 1);
+  if (image != NULL) {
+    if (with_header) {
+      image[0] = 'F';
+      image[1] = 'D';
+      image[2] = 'S';
+      image[3] = '\x1A';
+      image[4] = (uint8_t)sides;
+
+      fill_image(image + 16, size_needed - 16);
+    }
+    else {
+      fill_image(image, size_needed);
+    }
+  }
+
+  if (image_size)
+    *image_size = size_needed;
+  return image;
+}
+
+static void test_hash_nes_32k()
+{
+  size_t image_size;
+  uint8_t* image = generate_nes_file(32, 0, &image_size);
+  char hash[33];
+  int result = rc_hash_generate_from_buffer(hash, RC_CONSOLE_NINTENDO, image, image_size);
+  free(image);
+
+  ASSERT_NUM_EQUALS(result, 1);
+  ASSERT_STR_EQUALS(hash, "6a2305a2b6675a97ff792709be1ca857");
+  ASSERT_NUM_EQUALS(image_size, 32768);
+}
+
+static void test_hash_nes_32k_with_header()
+{
+  size_t image_size;
+  uint8_t* image = generate_nes_file(32, 1, &image_size);
+  char hash[33];
+  int result = rc_hash_generate_from_buffer(hash, RC_CONSOLE_NINTENDO, image, image_size);
+  free(image);
+
+  /* NOTE: expectation is that this hash matches the hash in test_hash_nes_32k */
+  ASSERT_NUM_EQUALS(result, 1);
+  ASSERT_STR_EQUALS(hash, "6a2305a2b6675a97ff792709be1ca857");
+  ASSERT_NUM_EQUALS(image_size, 32768 + 16);
+}
+
+static void test_hash_nes_256k()
+{
+  size_t image_size;
+  uint8_t* image = generate_nes_file(256, 0, &image_size);
+  char hash[33];
+  int result = rc_hash_generate_from_buffer(hash, RC_CONSOLE_NINTENDO, image, image_size);
+  free(image);
+
+  ASSERT_NUM_EQUALS(result, 1);
+  ASSERT_STR_EQUALS(hash, "545d527301b8ae148153988d6c4fcb84");
+  ASSERT_NUM_EQUALS(image_size, 262144);
+}
+
+static void test_hash_fds_two_sides()
+{
+  size_t image_size;
+  uint8_t* image = generate_fds_file(2, 0, &image_size);
+  char hash[33];
+  int result = rc_hash_generate_from_buffer(hash, RC_CONSOLE_NINTENDO, image, image_size);
+  free(image);
+
+  ASSERT_NUM_EQUALS(result, 1);
+  ASSERT_STR_EQUALS(hash, "fd770d4d34c00760fabda6ad294a8f0b");
+  ASSERT_NUM_EQUALS(image_size, 65500 * 2);
+}
+
+static void test_hash_fds_two_sides_with_header()
+{
+  size_t image_size;
+  uint8_t* image = generate_fds_file(2, 1, &image_size);
+  char hash[33];
+  int result = rc_hash_generate_from_buffer(hash, RC_CONSOLE_NINTENDO, image, image_size);
+  free(image);
+
+  /* NOTE: expectation is that this hash matches the hash in test_hash_fds_two_sides */
+  ASSERT_NUM_EQUALS(result, 1);
+  ASSERT_STR_EQUALS(hash, "fd770d4d34c00760fabda6ad294a8f0b");
+  ASSERT_NUM_EQUALS(image_size, 65500 * 2 + 16);
+}
+
+static void test_hash_nes_file_32k()
+{
+  size_t image_size;
+  uint8_t* image = generate_nes_file(32, 0, &image_size);
+  char hash[33];
+  int result;
+
+  mock_file(0, "test.nes", image, image_size);
+  result = rc_hash_generate_from_file(hash, RC_CONSOLE_NINTENDO, "test.nes");
+  free(image);
+
+  ASSERT_NUM_EQUALS(result, 1);
+  ASSERT_STR_EQUALS(hash, "6a2305a2b6675a97ff792709be1ca857");
+  ASSERT_NUM_EQUALS(image_size, 32768);
+}
+
+static void test_hash_nes_iterator_32k()
+{
+  size_t image_size;
+  uint8_t* image = generate_nes_file(32, 0, &image_size);
+  char hash1[33], hash2[33];
+  int result1, result2;
+  struct rc_hash_iterator iterator;
+
+  mock_file(0, "test.nes", image, image_size);
+  rc_hash_initialize_iterator(&iterator, "test.nes", NULL, 0);
+  result1 = rc_hash_iterate(hash1, &iterator);
+  result2 = rc_hash_iterate(hash2, &iterator);
+  rc_hash_destroy_iterator(&iterator);
+  free(image);
+
+  ASSERT_NUM_EQUALS(result1, 1);
+  ASSERT_STR_EQUALS(hash1, "6a2305a2b6675a97ff792709be1ca857");
+
+  ASSERT_NUM_EQUALS(result2, 0);
+  ASSERT_STR_EQUALS(hash2, "");
+}
+
+static void test_hash_nes_file_iterator_32k()
+{
+  size_t image_size;
+  uint8_t* image = generate_nes_file(32, 0, &image_size);
+  char hash1[33], hash2[33];
+  int result1, result2;
+  struct rc_hash_iterator iterator;
+  rc_hash_initialize_iterator(&iterator, "test.nes", image, image_size);
+  result1 = rc_hash_iterate(hash1, &iterator);
+  result2 = rc_hash_iterate(hash2, &iterator);
+  rc_hash_destroy_iterator(&iterator);
+  free(image);
+
+  ASSERT_NUM_EQUALS(result1, 1);
+  ASSERT_STR_EQUALS(hash1, "6a2305a2b6675a97ff792709be1ca857");
+
+  ASSERT_NUM_EQUALS(result2, 0);
+  ASSERT_STR_EQUALS(hash2, "");
+}
+
+/* ========================================================================= */
+
+/* first 64 bytes of SUPER MARIO 64 ROM in each N64 format */
+static uint8_t test_rom_z64[64] = {
+  0x80, 0x37, 0x12, 0x40, 0x00, 0x00, 0x00, 0x0F, 0x80, 0x24, 0x60, 0x00, 0x00, 0x00, 0x14, 0x44,
+  0x63, 0x5A, 0x2B, 0xFF, 0x8B, 0x02, 0x23, 0x26, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x53, 0x55, 0x50, 0x45, 0x52, 0x20, 0x4D, 0x41, 0x52, 0x49, 0x4F, 0x20, 0x36, 0x34, 0x20, 0x20,
+  0x20, 0x20, 0x20, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x4E, 0x53, 0x4D, 0x45, 0x00
+};
+
+static uint8_t test_rom_v64[64] = {
+  0x37, 0x80, 0x40, 0x12, 0x00, 0x00, 0x0F, 0x00, 0x24, 0x80, 0x00, 0x60, 0x00, 0x00, 0x44, 0x14,
+  0x5A, 0x63, 0xFF, 0x2B, 0x02, 0x8B, 0x26, 0x23, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x55, 0x53, 0x45, 0x50, 0x20, 0x52, 0x41, 0x4D, 0x49, 0x52, 0x20, 0x4F, 0x34, 0x36, 0x20, 0x20,
+  0x20, 0x20, 0x20, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x4E, 0x00, 0x4D, 0x53, 0x00, 0x45
+};
+
+static uint8_t test_rom_n64[64] = {
+  0x40, 0x12, 0x37, 0x80, 0x0F, 0x00, 0x00, 0x00, 0x00, 0x60, 0x24, 0x80, 0x44, 0x14, 0x00, 0x00,
+  0xFF, 0x2B, 0x5A, 0x63, 0x26, 0x23, 0x02, 0x8B, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x45, 0x50, 0x55, 0x53, 0x41, 0x4D, 0x20, 0x52, 0x20, 0x4F, 0x49, 0x52, 0x20, 0x20, 0x34, 0x36,
+  0x20, 0x20, 0x20, 0x20, 0x00, 0x00, 0x00, 0x00, 0x4E, 0x00, 0x00, 0x00, 0x00, 0x45, 0x4D, 0x53
+};
+
+/* first 64 bytes of DOSHIN THE GIANT in ndd format */
+static uint8_t test_rom_ndd[64] = {
+  0xE8, 0x48, 0xD3, 0x16, 0x10, 0x13, 0x00, 0x45, 0x0C, 0x18, 0x24, 0x30, 0x3C, 0x48, 0x54, 0x60,
+  0x6C, 0x78, 0x84, 0x90, 0x9C, 0xA8, 0xB4, 0xC0, 0xFF, 0xFF, 0xFF, 0xFF, 0x80, 0x02, 0x5C, 0x00,
+  0x10, 0x16, 0x1C, 0x22, 0x28, 0x2A, 0x31, 0x32, 0x3A, 0x40, 0x46, 0x4C, 0x04, 0x0C, 0x14, 0x1C,
+  0x24, 0x2C, 0x34, 0x3C, 0x44, 0x4C, 0x54, 0x5C, 0x04, 0x0C, 0x14, 0x1C, 0x24, 0x2C, 0x34, 0x3C
+};
+
+static void test_hash_n64(uint8_t* buffer, size_t buffer_size, const char* expected_hash)
+{
+  char hash[33];
+  int result;
+
+  rc_hash_reset_filereader(); /* explicitly unset the filereader */
+  result = rc_hash_generate_from_buffer(hash, RC_CONSOLE_NINTENDO_64, buffer, buffer_size);
+  init_mock_filereader(); /* restore the mock filereader */
+
+  ASSERT_NUM_EQUALS(result, 1);
+  ASSERT_STR_EQUALS(hash, expected_hash);
+}
+
+static void test_hash_n64_file(const char* filename, uint8_t* buffer, size_t buffer_size, const char* expected_hash)
+{
+  char hash_file[33], hash_iterator[33];
+  mock_file(0, filename, buffer, buffer_size);
+
+  /* test file hash */
+  int result_file = rc_hash_generate_from_file(hash_file, RC_CONSOLE_NINTENDO_64, filename);
+
+  /* test file identification from iterator */
+  int result_iterator;
+  struct rc_hash_iterator iterator;
+
+  rc_hash_initialize_iterator(&iterator, filename, NULL, 0);
+  result_iterator = rc_hash_iterate(hash_iterator, &iterator);
+  rc_hash_destroy_iterator(&iterator);
+
+  /* validation */
+  ASSERT_NUM_EQUALS(result_file, 1);
+  ASSERT_STR_EQUALS(hash_file, expected_hash);
+
+  ASSERT_NUM_EQUALS(result_iterator, 1);
+  ASSERT_STR_EQUALS(hash_iterator, expected_hash);
+}
+
+/* ========================================================================= */
+
+static uint8_t* generate_nds_file(size_t mb, uint32_t arm9_size, uint32_t arm7_size, size_t* image_size)
+{
+  uint8_t* image;
+  const size_t size_needed = mb * 1024 * 1024;
+
+  image = (uint8_t*)calloc(size_needed, 1);
+  if (image != NULL) {
+    uint32_t arm9_addr = 65536;
+    uint32_t arm7_addr = arm9_addr + arm9_size;
+    uint32_t icon_addr = arm7_addr + arm7_size;
+
+    fill_image(image, size_needed);
+
+    image[0x20] = (arm9_addr & 0xFF);
+    image[0x21] = ((arm9_addr >> 8) & 0xFF);
+    image[0x22] = ((arm9_addr >> 16) & 0xFF);
+    image[0x23] = ((arm9_addr >> 24) & 0xFF);
+    image[0x2C] = (arm9_size & 0xFF);
+    image[0x2D] = ((arm9_size >> 8) & 0xFF);
+    image[0x2E] = ((arm9_size >> 16) & 0xFF);
+    image[0x2F] = ((arm9_size >> 24) & 0xFF);
+
+    image[0x30] = (arm7_addr & 0xFF);
+    image[0x31] = ((arm7_addr >> 8) & 0xFF);
+    image[0x32] = ((arm7_addr >> 16) & 0xFF);
+    image[0x33] = ((arm7_addr >> 24) & 0xFF);
+    image[0x3C] = (arm7_size & 0xFF);
+    image[0x3D] = ((arm7_size >> 8) & 0xFF);
+    image[0x3E] = ((arm7_size >> 16) & 0xFF);
+    image[0x3F] = ((arm7_size >> 24) & 0xFF);
+
+    image[0x68] = (icon_addr & 0xFF);
+    image[0x69] = ((icon_addr >> 8) & 0xFF);
+    image[0x6A] = ((icon_addr >> 16) & 0xFF);
+    image[0x6B] = ((icon_addr >> 24) & 0xFF);
+  }
+
+  if (image_size)
+    *image_size = size_needed;
+  return image;
+}
+
+static void test_hash_nds()
+{
+  size_t image_size;
+  uint8_t* image = generate_nds_file(2, 1234567, 654321, &image_size);
+  char hash_file[33], hash_iterator[33];
+  const char* expected_hash = "56b30c276cba4affa886bd38e8e34d7e";
+
+  mock_file(0, "game.nds", image, image_size);
+
+  /* test file hash */
+  int result_file = rc_hash_generate_from_file(hash_file, RC_CONSOLE_NINTENDO_DS, "game.nds");
+
+  /* test file identification from iterator */
+  int result_iterator;
+  struct rc_hash_iterator iterator;
+
+  rc_hash_initialize_iterator(&iterator, "game.nds", NULL, 0);
+  result_iterator = rc_hash_iterate(hash_iterator, &iterator);
+  rc_hash_destroy_iterator(&iterator);
+
+  /* cleanup */
+  free(image);
+
+  /* validation */
+  ASSERT_NUM_EQUALS(result_file, 1);
+  ASSERT_STR_EQUALS(hash_file, expected_hash);
+
+  ASSERT_NUM_EQUALS(result_iterator, 1);
+  ASSERT_STR_EQUALS(hash_iterator, expected_hash);
+}
+
+static void test_hash_nds_supercard()
+{
+  size_t image_size, image2_size;
+  uint8_t* image = generate_nds_file(2, 1234567, 654321, &image_size);
+  char hash_file[33], hash_iterator[33];
+  const char* expected_hash = "56b30c276cba4affa886bd38e8e34d7e";
+  ASSERT_PTR_NOT_NULL(image);
+  ASSERT_NUM_GREATER(image_size, 0);
+
+  /* inject the SuperCard header (512 bytes) */
+  image2_size = image_size + 512;
+  uint8_t* image2 = malloc(image2_size);
+  ASSERT_PTR_NOT_NULL(image2);
+  memcpy(&image2[512], &image[0], image_size);
+  memset(&image2[0], 0, 512);
+  image2[0] = 0x2E;
+  image2[1] = 0x00;
+  image2[2] = 0x00;
+  image2[3] = 0xEA;
+  image2[0xB0] = 0x44;
+  image2[0xB1] = 0x46;
+  image2[0xB2] = 0x96;
+  image2[0xB3] = 0x00;
+
+  mock_file(0, "game.nds", image2, image2_size);
+
+  /* test file hash */
+  int result_file = rc_hash_generate_from_file(hash_file, RC_CONSOLE_NINTENDO_DS, "game.nds");
+
+  /* test file identification from iterator */
+  int result_iterator;
+  struct rc_hash_iterator iterator;
+
+  rc_hash_initialize_iterator(&iterator, "game.nds", NULL, 0);
+  result_iterator = rc_hash_iterate(hash_iterator, &iterator);
+  rc_hash_destroy_iterator(&iterator);
+
+  /* cleanup */
+  free(image);
+  free(image2);
+
+  /* validation */
+  ASSERT_NUM_EQUALS(result_file, 1);
+  ASSERT_STR_EQUALS(hash_file, expected_hash);
+
+  ASSERT_NUM_EQUALS(result_iterator, 1);
+  ASSERT_STR_EQUALS(hash_iterator, expected_hash);
+}
+
+static void test_hash_nds_buffered()
+{
+  size_t image_size;
+  uint8_t* image = generate_nds_file(2, 1234567, 654321, &image_size);
+  char hash_buffer[33], hash_iterator[33];
+  const char* expected_hash = "56b30c276cba4affa886bd38e8e34d7e";
+
+  /* test file hash */
+  int result_buffer = rc_hash_generate_from_buffer(hash_buffer, RC_CONSOLE_NINTENDO_DS, image, image_size);
+
+  /* test file identification from iterator */
+  int result_iterator;
+  struct rc_hash_iterator iterator;
+
+  rc_hash_initialize_iterator(&iterator, "game.nds", image, image_size);
+  result_iterator = rc_hash_iterate(hash_iterator, &iterator);
+  rc_hash_destroy_iterator(&iterator);
+
+  /* cleanup */
+  free(image);
+
+  /* validation */
+  ASSERT_NUM_EQUALS(result_buffer, 1);
+  ASSERT_STR_EQUALS(hash_buffer, expected_hash);
+
+  ASSERT_NUM_EQUALS(result_iterator, 1);
+  ASSERT_STR_EQUALS(hash_iterator, expected_hash);
+}
+
+/* ========================================================================= */
+
+static void test_hash_dsi()
+{
+  size_t image_size;
+  uint8_t* image = generate_nds_file(2, 1234567, 654321, &image_size);
+  char hash_file[33], hash_iterator[33];
+  const char* expected_hash = "56b30c276cba4affa886bd38e8e34d7e";
+
+  mock_file(0, "game.nds", image, image_size);
+
+  /* test file hash */
+  int result_file = rc_hash_generate_from_file(hash_file, RC_CONSOLE_NINTENDO_DSI, "game.nds");
+
+  /* test file identification from iterator */
+  int result_iterator;
+  struct rc_hash_iterator iterator;
+
+  rc_hash_initialize_iterator(&iterator, "game.nds", NULL, 0);
+  result_iterator = rc_hash_iterate(hash_iterator, &iterator);
+  rc_hash_destroy_iterator(&iterator);
+
+  /* cleanup */
+  free(image);
+
+  /* validation */
+  ASSERT_NUM_EQUALS(result_file, 1);
+  ASSERT_STR_EQUALS(hash_file, expected_hash);
+
+  ASSERT_NUM_EQUALS(result_iterator, 1);
+  ASSERT_STR_EQUALS(hash_iterator, expected_hash);
+}
+
+static void test_hash_dsi_buffered()
+{
+  size_t image_size;
+  uint8_t* image = generate_nds_file(2, 1234567, 654321, &image_size);
+  char hash_buffer[33], hash_iterator[33];
+  const char* expected_hash = "56b30c276cba4affa886bd38e8e34d7e";
+
+  /* test file hash */
+  int result_buffer = rc_hash_generate_from_buffer(hash_buffer, RC_CONSOLE_NINTENDO_DSI, image, image_size);
+
+  /* test file identification from iterator */
+  int result_iterator;
+  struct rc_hash_iterator iterator;
+
+  rc_hash_initialize_iterator(&iterator, "game.nds", image, image_size);
+  result_iterator = rc_hash_iterate(hash_iterator, &iterator);
+  rc_hash_destroy_iterator(&iterator);
+
+  /* cleanup */
+  free(image);
+
+  /* validation */
+  ASSERT_NUM_EQUALS(result_buffer, 1);
+  ASSERT_STR_EQUALS(hash_buffer, expected_hash);
+
+  ASSERT_NUM_EQUALS(result_iterator, 1);
+  ASSERT_STR_EQUALS(hash_iterator, expected_hash);
+}
+
+/* ========================================================================= */
+
+static void test_hash_scv_cart()
+{
+  size_t image_size = 32768 + 32;
+  uint8_t* image = generate_generic_file(image_size);
+  char hash_file[33], hash_iterator[33];
+  const char* expected_md5 = "4309c9844b44f9ff8256dfc04687b8fd";
+
+  memcpy(image, "EmuSCV....CART..................", 32);
+
+  mock_file(0, "game.cart", image, image_size);
+  /* test file hash */
+  int result_file = rc_hash_generate_from_file(hash_file, RC_CONSOLE_SUPER_CASSETTEVISION, "game.cart");
+
+  /* test file identification from iterator */
+  int result_iterator;
+  struct rc_hash_iterator iterator;
+
+  rc_hash_initialize_iterator(&iterator, "game.cart", NULL, 0);
+  result_iterator = rc_hash_iterate(hash_iterator, &iterator);
+  rc_hash_destroy_iterator(&iterator);
+
+  /* cleanup */
+  free(image);
+
+  /* validation */
+  ASSERT_NUM_EQUALS(result_file, 1);
+  ASSERT_STR_EQUALS(hash_file, expected_md5);
+
+  ASSERT_NUM_EQUALS(result_iterator, 1);
+  ASSERT_STR_EQUALS(hash_iterator, expected_md5);
+}
+
+/* ========================================================================= */
+
+void test_hash_rom(void) {
+  TEST_SUITE_BEGIN();
+
+  init_mock_filereader();
+
+  /* Arcade */
+  TEST_PARAMS2(test_hash_arcade, "game.zip", "c8d46d341bea4fd5bff866a65ff8aea9");
+  TEST_PARAMS2(test_hash_arcade, "game.7z", "c8d46d341bea4fd5bff866a65ff8aea9");
+  TEST_PARAMS2(test_hash_arcade, "/game.zip", "c8d46d341bea4fd5bff866a65ff8aea9");
+  TEST_PARAMS2(test_hash_arcade, "\\game.zip", "c8d46d341bea4fd5bff866a65ff8aea9");
+  TEST_PARAMS2(test_hash_arcade, "roms\\game.zip", "c8d46d341bea4fd5bff866a65ff8aea9");
+  TEST_PARAMS2(test_hash_arcade, "C:\\roms\\game.zip", "c8d46d341bea4fd5bff866a65ff8aea9");
+  TEST_PARAMS2(test_hash_arcade, "/home/user/roms/game.zip", "c8d46d341bea4fd5bff866a65ff8aea9");
+  TEST_PARAMS2(test_hash_arcade, "/home/user/games/game.zip", "c8d46d341bea4fd5bff866a65ff8aea9");
+  TEST_PARAMS2(test_hash_arcade, "/home/user/roms/game.7z", "c8d46d341bea4fd5bff866a65ff8aea9");
+
+  TEST_PARAMS2(test_hash_arcade, "/home/user/nes_game.zip", "9b7aad36b365712fc93728088de4c209");
+  TEST_PARAMS2(test_hash_arcade, "/home/user/nes/game.zip", "9b7aad36b365712fc93728088de4c209");
+  TEST_PARAMS2(test_hash_arcade, "C:\\roms\\nes\\game.zip", "9b7aad36b365712fc93728088de4c209");
+  TEST_PARAMS2(test_hash_arcade, "C:\\roms\\NES\\game.zip", "9b7aad36b365712fc93728088de4c209");
+  TEST_PARAMS2(test_hash_arcade, "nes\\game.zip", "9b7aad36b365712fc93728088de4c209");
+  TEST_PARAMS2(test_hash_arcade, "/home/user/snes/game.zip", "c8d46d341bea4fd5bff866a65ff8aea9");
+  TEST_PARAMS2(test_hash_arcade, "/home/user/nes2/game.zip", "c8d46d341bea4fd5bff866a65ff8aea9");
+
+  /* we don't care that multiple aliases for the same system generate different hashes - the point is
+   * that they don't generate the same hash as an actual arcade ROM with the same filename. */
+  TEST_PARAMS2(test_hash_arcade, "/home/user/chf/game.zip", "6ef57f16562ea0c7f49d93853b313e32");
+  TEST_PARAMS2(test_hash_arcade, "/home/user/channelf/game.zip", "7b6506637a0cc79bd1d24a43a34fa3b9");
+  TEST_PARAMS2(test_hash_arcade, "/home/user/coleco/game.zip", "c546f63ae7de98add4b9f221a4749260");
+  TEST_PARAMS2(test_hash_arcade, "/home/user/colecovision/game.zip", "47279207b94dbf2a45cb13efa56d685e");
+  TEST_PARAMS2(test_hash_arcade, "/home/user/msx/game.zip", "59ab85f6b56324fd81b4e324b804c29f");
+  TEST_PARAMS2(test_hash_arcade, "/home/user/msx1/game.zip", "33328d832dcb0854383cdd4a4565c459");
+  TEST_PARAMS2(test_hash_arcade, "/home/user/pce/game.zip", "c414a783f3983bbe2e9e01d9d5320c7e");
+  TEST_PARAMS2(test_hash_arcade, "/home/user/pcengine/game.zip", "49370c3cbe98bdcdce545c68379487db");
+  TEST_PARAMS2(test_hash_arcade, "/home/user/sgx/game.zip", "db545ab29694bfda1010317d4bac83b8");
+  TEST_PARAMS2(test_hash_arcade, "/home/user/supergrafx/game.zip", "5665c9ef4c2f6609d8e420c4d86ba692");
+  TEST_PARAMS2(test_hash_arcade, "/home/user/tg16/game.zip", "8b6c5c2e54915be2cdba63973862e143");
+  TEST_PARAMS2(test_hash_arcade, "/home/user/fds/game.zip", "c0c135a97e8c577cfdf9204823ff211f");
+  TEST_PARAMS2(test_hash_arcade, "/home/user/gamegear/game.zip", "f6f471e952b8103032b723f57bdbe767");
+  TEST_PARAMS2(test_hash_arcade, "/home/user/mastersystem/game.zip", "f4805afe0ff5647140a26bd0a1057373");
+  TEST_PARAMS2(test_hash_arcade, "/home/user/sms/game.zip", "43f35f575dead94dd2f42f9caf69fe5a");
+  TEST_PARAMS2(test_hash_arcade, "/home/user/megadriv/game.zip", "f99d0aaf12ba3eb6ced9878c76692c63");
+  TEST_PARAMS2(test_hash_arcade, "/home/user/megadrive/game.zip", "73eb5d7034b382093b1d36414d9e84e4");
+  TEST_PARAMS2(test_hash_arcade, "/home/user/genesis/game.zip", "b62f810c63e1cba7f5b7569643bec236");
+  TEST_PARAMS2(test_hash_arcade, "/home/user/sg1000/game.zip", "e8f6c711c4371f09537b4f2a7a304d6c");
+  TEST_PARAMS2(test_hash_arcade, "/home/user/spectrum/game.zip", "a5f62157b2617bd728c4b1bc885c29e9");
+  TEST_PARAMS2(test_hash_arcade, "/home/user/ngp/game.zip", "d4133b74c4e57274ca514e27a370dcb6");
+
+  /* Arduboy */
+  TEST(test_hash_arduboy);
+  TEST(test_hash_arduboy_crlf);
+  TEST(test_hash_arduboy_no_final_lf);
+
+  /* Arcadia 2001 */
+  TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_ARCADIA_2001, "test.bin", 4096, "572686c3a073162e4ec6eff86e6f6e3a");
+
+  /* Atari 2600 */
+  TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_ATARI_2600, "test.bin", 2048, "02c3f2fa186388ba8eede9147fb431c4");
+
+  /* Atari 7800 */
+  TEST(test_hash_atari_7800);
+  TEST(test_hash_atari_7800_with_header);
+
+  /* Atari Jaguar */
+  TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_ATARI_JAGUAR, "test.jag", 0x400000, "a247ec8a8c42e18fcb80702dfadac14b");
+
+  /* Colecovision */
+  TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_COLECOVISION, "test.col", 16384, "455f07d8500f3fabc54906737866167f");
+
+  /* Elektor TV Games Computer */
+  TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_ELEKTOR_TV_GAMES_COMPUTER, "test.pgm", 4096, "572686c3a073162e4ec6eff86e6f6e3a");
+  TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_ELEKTOR_TV_GAMES_COMPUTER, "test.tvc", 1861, "37097124a29aff663432d049654a17dc");
+
+  /* Fairchild Channel F */
+  TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_FAIRCHILD_CHANNEL_F, "test.bin", 2048, "02c3f2fa186388ba8eede9147fb431c4");
+  TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_FAIRCHILD_CHANNEL_F, "test.chf", 2048, "02c3f2fa186388ba8eede9147fb431c4");
+
+  /* Gameboy */
+  TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_GAMEBOY, "test.gb", 131072, "a0f425b23200568132ba76b2405e3933");
+
+  /* Gameboy Color */
+  TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_GAMEBOY_COLOR, "test.gbc", 2097152, "cf86acf519625a25a17b1246975e90ae");
+
+  /* Gameboy Advance */
+  TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_GAMEBOY_COLOR, "test.gba", 4194304, "a247ec8a8c42e18fcb80702dfadac14b");
+
+  /* Game Gear */
+  TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_GAME_GEAR, "test.gg", 524288, "68f0f13b598e0b66461bc578375c3888");
+
+  /* Intellivision */
+  TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_INTELLIVISION, "test.bin", 8192, "ce1127f881b40ce6a67ecefba50e2835");
+
+  /* Interton VC 4000 */
+  TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_INTERTON_VC_4000, "test.bin", 2048, "02c3f2fa186388ba8eede9147fb431c4");
+
+  /* Magnavox Odyssey 2 */
+  TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_MAGNAVOX_ODYSSEY2, "test.bin", 4096, "572686c3a073162e4ec6eff86e6f6e3a");
+
+  /* Master System */
+  TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_MASTER_SYSTEM, "test.sms", 131072, "a0f425b23200568132ba76b2405e3933");
+
+  /* Mega Drive */
+  TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_MEGA_DRIVE, "test.md", 1048576, "da9461b3b0f74becc3ccf6c2a094c516");
+  TEST_PARAMS4(test_hash_m3u, RC_CONSOLE_MEGA_DRIVE, "test.md", 1048576, "da9461b3b0f74becc3ccf6c2a094c516");
+
+  /* Mega Duck */
+  TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_MEGADUCK, "test.bin", 65536, "8e6576cd5c21e44e0bbfc4480577b040");
+
+  /* Neo Geo Pocket */
+  TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_NEOGEO_POCKET, "test.ngc", 2097152, "cf86acf519625a25a17b1246975e90ae");
+
+  /* NES */
+  TEST(test_hash_nes_32k);
+  TEST(test_hash_nes_32k_with_header);
+  TEST(test_hash_nes_256k);
+  TEST(test_hash_fds_two_sides);
+  TEST(test_hash_fds_two_sides_with_header);
+
+  TEST(test_hash_nes_file_32k);
+  TEST(test_hash_nes_file_iterator_32k);
+  TEST(test_hash_nes_iterator_32k);
+
+  /* Nintendo 64 */
+  TEST_PARAMS3(test_hash_n64, test_rom_z64, sizeof(test_rom_z64), "06096d7ce21cb6bcde38391534c4eb91");
+  TEST_PARAMS3(test_hash_n64, test_rom_v64, sizeof(test_rom_v64), "06096d7ce21cb6bcde38391534c4eb91");
+  TEST_PARAMS3(test_hash_n64, test_rom_n64, sizeof(test_rom_n64), "06096d7ce21cb6bcde38391534c4eb91");
+  TEST_PARAMS4(test_hash_n64_file, "game.z64", test_rom_z64, sizeof(test_rom_z64), "06096d7ce21cb6bcde38391534c4eb91");
+  TEST_PARAMS4(test_hash_n64_file, "game.v64", test_rom_v64, sizeof(test_rom_v64), "06096d7ce21cb6bcde38391534c4eb91");
+  TEST_PARAMS4(test_hash_n64_file, "game.n64", test_rom_n64, sizeof(test_rom_n64), "06096d7ce21cb6bcde38391534c4eb91");
+  TEST_PARAMS4(test_hash_n64_file, "game.n64", test_rom_z64, sizeof(test_rom_z64), "06096d7ce21cb6bcde38391534c4eb91"); /* misnamed */
+  TEST_PARAMS4(test_hash_n64_file, "game.z64", test_rom_n64, sizeof(test_rom_n64), "06096d7ce21cb6bcde38391534c4eb91"); /* misnamed */
+  TEST_PARAMS3(test_hash_n64, test_rom_ndd, sizeof(test_rom_ndd), "a698b32a52970d8a52a5a52c83acc2a9");
+
+  /* Nintendo DS */
+  TEST(test_hash_nds);
+  TEST(test_hash_nds_supercard);
+  TEST(test_hash_nds_buffered);
+
+  /* Nintendo DSi */
+  TEST(test_hash_dsi);
+  TEST(test_hash_dsi_buffered);
+
+  /* Oric (no fixed file size) */
+  TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_ORIC, "test.tap", 18119, "953a2baa3232c63286aeae36b2172cef");
+
+  /* PC Engine */
+  TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_PC_ENGINE, "test.pce", 524288, "68f0f13b598e0b66461bc578375c3888");
+  TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_PC_ENGINE, "test.pce", 524288 + 512, "258c93ebaca1c3f488ab48218e5e8d38");
+
+  /* Pokemon Mini */
+  TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_POKEMON_MINI, "test.min", 524288, "68f0f13b598e0b66461bc578375c3888");
+
+  /* Sega 32X */
+  TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_SEGA_32X, "test.bin", 3145728, "07d733f252896ec41b4fd521fe610e2c");
+
+  /* SG-1000 */
+  TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_SG1000, "test.sg", 32768, "6a2305a2b6675a97ff792709be1ca857");
+
+  /* SNES */
+  TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_SUPER_NINTENDO, "test.smc", 524288, "68f0f13b598e0b66461bc578375c3888");
+  TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_SUPER_NINTENDO, "test.smc", 524288 + 512, "258c93ebaca1c3f488ab48218e5e8d38");
+
+  /* Super Cassette Vision */
+  TEST(test_hash_scv_cart);
+  TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_SUPER_CASSETTEVISION, "test.bin", 32768, "6a2305a2b6675a97ff792709be1ca857");
+
+  /* TI-83 */
+  TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_TI83, "test.83g", 1695, "bfb6048395a425c69743900785987c42");
+  TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_TI83, "test.83p", 2500, "6e81d530ee9a79d4f4f505729ad74bb5");
+
+  /* TIC-80 */
+  TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_TIC80, "test.tic", 67682, "79b96f4ffcedb3ce8210a83b22cd2c69");
+
+  /* Uzebox */
+  TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_UZEBOX, "test.uze", 53654, "a9aab505e92edc034d3c732869159789");
+
+  /* Vectrex */
+  TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_SG1000, "test.vec", 4096, "572686c3a073162e4ec6eff86e6f6e3a");
+
+  /* VirtualBoy */
+  TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_SG1000, "test.vb", 524288, "68f0f13b598e0b66461bc578375c3888");
+
+  /* Watara Supervision */
+  TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_SUPERVISION, "test.sv", 32768, "6a2305a2b6675a97ff792709be1ca857");
+
+  /* WASM-4 */
+  TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_WASM4, "test.wasm", 33454, "bce38bb5f05622fc7e0e56757059d180");
+
+  /* WonderSwan */
+  TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_WONDERSWAN, "test.ws", 524288, "68f0f13b598e0b66461bc578375c3888");
+  TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_WONDERSWAN, "test.wsc", 4194304, "a247ec8a8c42e18fcb80702dfadac14b");
+
+  TEST_SUITE_END();
+}

--- a/test/rhash/test_hash_rom.c
+++ b/test/rhash/test_hash_rom.c
@@ -199,7 +199,7 @@ static void test_hash_atari_7800_with_header()
 
 /* ========================================================================= */
 
-static uint8_t* generate_nes_file(size_t kb, int with_header, size_t* image_size)
+uint8_t* generate_nes_file(size_t kb, int with_header, size_t* image_size)
 {
   uint8_t* image;
   size_t size_needed = kb * 1024;

--- a/test/test.c
+++ b/test/test.c
@@ -40,7 +40,12 @@ extern void test_url();
 
 extern void test_cdreader();
 extern void test_hash();
+#ifndef RC_HASH_NO_ROMS
+extern void test_hash_rom();
+#endif
+#ifndef RC_HASH_NO_ZIP
 extern void test_hash_zip();
+#endif
 
 extern void test_rapi_common();
 extern void test_rapi_user();
@@ -91,6 +96,9 @@ int main(void) {
   test_rc_libretro(); /* libretro extensions require hash support */
   test_cdreader();
   test_hash();
+ #ifndef RC_HASH_NO_ROMS
+  test_hash_rom();
+ #endif
  #ifndef RC_HASH_NO_ZIP
   test_hash_zip();
  #endif

--- a/test/test.c
+++ b/test/test.c
@@ -40,7 +40,7 @@ extern void test_url();
 
 extern void test_cdreader();
 extern void test_hash();
-#ifndef RC_HASH_NO_ROMS
+#ifndef RC_HASH_NO_ROM
 extern void test_hash_rom();
 #endif
 #ifndef RC_HASH_NO_ZIP
@@ -96,7 +96,7 @@ int main(void) {
   test_rc_libretro(); /* libretro extensions require hash support */
   test_cdreader();
   test_hash();
- #ifndef RC_HASH_NO_ROMS
+ #ifndef RC_HASH_NO_ROM
   test_hash_rom();
  #endif
  #ifndef RC_HASH_NO_ZIP

--- a/test/test_rc_client.c
+++ b/test/test_rc_client.c
@@ -2180,7 +2180,7 @@ static void test_identify_and_load_game_console_not_specified(void)
   free(image);
 }
 
-#ifndef RC_HASH_NO_ROMS
+#ifndef RC_HASH_NO_ROM
 uint8_t* generate_nes_file(size_t kb, int with_header, size_t* image_size);
 
 static void test_identify_and_load_game_multiconsole_first(void)
@@ -2274,7 +2274,7 @@ static void test_identify_and_load_game_multiconsole_second(void)
   free(image);
 }
 
-#endif /* RC_HASH_NO_ROMS */
+#endif /* RC_HASH_NO_ROM */
 
 static void test_identify_and_load_game_unknown_hash(void)
 {
@@ -2355,7 +2355,7 @@ static void test_identify_and_load_game_unknown_hash_repeated(void)
   free(image);
 }
 
-#ifndef RC_HASH_NO_ROMS
+#ifndef RC_HASH_NO_ROM
 
 static void test_identify_and_load_game_unknown_hash_multiconsole(void)
 {
@@ -9324,13 +9324,13 @@ void test_client(void) {
   TEST(test_identify_and_load_game_required_fields);
   TEST(test_identify_and_load_game_console_specified);
   TEST(test_identify_and_load_game_console_not_specified);
- #ifndef RC_HASH_NO_ROMS
+ #ifndef RC_HASH_NO_ROM
   TEST(test_identify_and_load_game_multiconsole_first);
   TEST(test_identify_and_load_game_multiconsole_second);
  #endif
   TEST(test_identify_and_load_game_unknown_hash);
   TEST(test_identify_and_load_game_unknown_hash_repeated);
- #ifndef RC_HASH_NO_ROMS
+ #ifndef RC_HASH_NO_ROM
   TEST(test_identify_and_load_game_unknown_hash_multiconsole);
  #endif
   TEST(test_identify_and_load_game_unknown_hash_console_specified);

--- a/test/test_rc_client_external.c
+++ b/test/test_rc_client_external.c
@@ -601,10 +601,10 @@ static void assert_identify_and_load_game(rc_client_t* client,
 {
   ASSERT_PTR_EQUALS(client, g_client);
 
-  ASSERT_NUM_EQUALS(console_id, RC_CONSOLE_NINTENDO);
-  ASSERT_STR_EQUALS(file_path, "foo.zip#foo.nes");
+  ASSERT_NUM_EQUALS(console_id, RC_CONSOLE_GAMEBOY);
+  ASSERT_STR_EQUALS(file_path, "foo.zip#foo.gb");
   ASSERT_PTR_NOT_NULL(data);
-  ASSERT_NUM_EQUALS(32784, data_size);
+  ASSERT_NUM_EQUALS(32768, data_size);
 }
 
 static rc_client_async_handle_t* rc_client_external_identify_and_load_game(rc_client_t* client,
@@ -621,15 +621,15 @@ static rc_client_async_handle_t* rc_client_external_identify_and_load_game(rc_cl
 
 static void test_identify_and_load_game_v1(void)
 {
-  size_t image_size;
-  uint8_t* image = generate_nes_file(32, 1, &image_size);
+  const size_t image_size = 32768;
+  uint8_t* image = generate_generic_file(image_size);
   const rc_client_game_t* game;
 
   g_client = mock_client_with_external();
   g_client->state.external_client->begin_identify_and_load_game = rc_client_external_identify_and_load_game;
   g_client->state.external_client->get_game_info = rc_client_external_get_game_info_v1;
 
-  rc_client_begin_identify_and_load_game(g_client, RC_CONSOLE_NINTENDO, "foo.zip#foo.nes",
+  rc_client_begin_identify_and_load_game(g_client, RC_CONSOLE_GAMEBOY, "foo.zip#foo.gb",
     image, image_size, rc_client_callback_expect_success, g_callback_userdata);
 
   ASSERT_STR_EQUALS(g_external_event, "load_game");
@@ -652,8 +652,8 @@ static void test_identify_and_load_game_v1(void)
 
 static void test_identify_and_load_game(void)
 {
-  size_t image_size;
-  uint8_t* image = generate_nes_file(32, 1, &image_size);
+  const size_t image_size = 32768;
+  uint8_t* image = generate_generic_file(image_size);
   const rc_client_game_t* game;
 
   g_client = mock_client_with_external();
@@ -661,7 +661,7 @@ static void test_identify_and_load_game(void)
   g_client->state.external_client->get_game_info = rc_client_external_get_game_info_v1;
   g_client->state.external_client->get_game_info_v3 = rc_client_external_get_game_info_v3;
 
-  rc_client_begin_identify_and_load_game(g_client, RC_CONSOLE_NINTENDO, "foo.zip#foo.nes",
+  rc_client_begin_identify_and_load_game(g_client, RC_CONSOLE_GAMEBOY, "foo.zip#foo.gb",
     image, image_size, rc_client_callback_expect_success, g_callback_userdata);
 
   ASSERT_STR_EQUALS(g_external_event, "load_game");
@@ -804,8 +804,8 @@ static void test_get_user_game_summary(void)
 
 static void test_identify_and_load_game_external_hash(void)
 {
-  size_t image_size;
-  uint8_t* image = generate_nes_file(32, 1, &image_size);
+  const size_t image_size = 32768;
+  uint8_t* image = generate_generic_file(image_size);
   const rc_client_game_t* game;
 
   g_client = mock_client_with_external();
@@ -816,7 +816,7 @@ static void test_identify_and_load_game_external_hash(void)
   mock_api_response("r=gameid&m=6a2305a2b6675a97ff792709be1ca857", "{\"Success\":true,\"GameID\":1234}");
   g_external_int = 0;
 
-  rc_client_begin_identify_and_load_game(g_client, RC_CONSOLE_NINTENDO, "foo.zip#foo.nes",
+  rc_client_begin_identify_and_load_game(g_client, RC_CONSOLE_GAMEBOY, "foo.zip#foo.gb",
     image, image_size, rc_client_callback_expect_success, g_callback_userdata);
 
   ASSERT_STR_EQUALS(g_external_event, "load_game"); /* begin_load_game called */
@@ -842,9 +842,9 @@ static void test_identify_and_load_game_external_hash(void)
 static void assert_change_media(rc_client_t* client, const char* file_path, const uint8_t* data, size_t data_size)
 {
   ASSERT_PTR_EQUALS(client, g_client);
-  ASSERT_STR_EQUALS(file_path, "foo.zip#foo.nes");
+  ASSERT_STR_EQUALS(file_path, "foo.zip#foo.gb");
   ASSERT_PTR_NOT_NULL(data);
-  ASSERT_NUM_EQUALS(data_size, 32784);
+  ASSERT_NUM_EQUALS(data_size, 32768);
 }
 
 static rc_client_async_handle_t* rc_client_external_begin_change_media(rc_client_t* client, const char* file_path,
@@ -860,13 +860,13 @@ static rc_client_async_handle_t* rc_client_external_begin_change_media(rc_client
 
 static void test_change_media(void)
 {
-  size_t image_size;
-  uint8_t* image = generate_nes_file(32, 1, &image_size);
+  const size_t image_size = 32768;
+  uint8_t* image = generate_generic_file(image_size);
 
   g_client = mock_client_with_external();
   g_client->state.external_client->begin_change_media = rc_client_external_begin_change_media;
 
-  rc_client_begin_change_media(g_client, "foo.zip#foo.nes", image, image_size, rc_client_callback_expect_success, g_callback_userdata);
+  rc_client_begin_change_media(g_client, "foo.zip#foo.gb", image, image_size, rc_client_callback_expect_success, g_callback_userdata);
 
   ASSERT_STR_EQUALS(g_external_event, "change_media");
 


### PR DESCRIPTION
Moves the header skipping and byte-reordering code needed for ROM files into a separate file.

Allows compiling without that through compiler flags: RC_HASH_NO_ROMS