### PR TITLE
add ignore_non_parse_error flag

### DIFF
--- a/src/rcheevos/alloc.c
+++ b/src/rcheevos/alloc.c
@@ -292,6 +292,7 @@ void rc_reset_parse_state(rc_parse_state_t* parse, void* buffer)
   parse->is_value = 0;
   parse->has_required_hits = 0;
   parse->measured_as_percent = 0;
+  parse->ignore_non_parse_errors = 0;
 
   parse->scratch.strings = NULL;
 }

--- a/src/rcheevos/condition.c
+++ b/src/rcheevos/condition.c
@@ -255,7 +255,7 @@ void rc_parse_condition_internal(rc_condition_t* self, const char** memaddr, rc_
     /* non-modifying statements must have a second operand */
     if (!can_modify) {
       /* measured does not require a second operand when used in a value */
-      if (self->type != RC_CONDITION_MEASURED) {
+      if (self->type != RC_CONDITION_MEASURED && !parse->ignore_non_parse_errors) {
         parse->offset = RC_INVALID_OPERATOR;
         return;
       }
@@ -274,14 +274,16 @@ void rc_parse_condition_internal(rc_condition_t* self, const char** memaddr, rc_
       case RC_CONDITION_ADD_SOURCE:
       case RC_CONDITION_SUB_SOURCE:
       case RC_CONDITION_ADD_ADDRESS:
-      case RC_CONDITION_REMEMBER:
         /* prevent parse errors on legacy achievements where a condition was present before changing the type */
         self->oper = RC_OPERATOR_NONE;
         break;
 
       default:
-        parse->offset = RC_INVALID_OPERATOR;
-        return;
+        if (!parse->ignore_non_parse_errors) {
+          parse->offset = RC_INVALID_OPERATOR;
+          return;
+        }
+        break;
     }
   }
 

--- a/src/rcheevos/condset.c
+++ b/src/rcheevos/condset.c
@@ -47,7 +47,7 @@ static int rc_classify_condition(const rc_condition_t* cond) {
   }
 }
 
-static int32_t rc_classify_conditions(rc_condset_t* self, const char* memaddr) {
+static int32_t rc_classify_conditions(rc_condset_t* self, const char* memaddr, const rc_parse_state_t* parent_parse) {
   rc_parse_state_t parse;
   rc_memrefs_t memrefs;
   rc_condition_t condition;
@@ -57,6 +57,7 @@ static int32_t rc_classify_conditions(rc_condset_t* self, const char* memaddr) {
 
   rc_init_parse_state(&parse, NULL);
   rc_init_parse_state_memrefs(&parse, &memrefs);
+  parse.ignore_non_parse_errors = parent_parse->ignore_non_parse_errors;
 
   do {
     rc_parse_condition_internal(&condition, &memaddr, &parse);
@@ -215,7 +216,7 @@ rc_condset_t* rc_parse_condset(const char** memaddr, rc_parse_state_t* parse) {
   }
 
   memset(&local_condset, 0, sizeof(local_condset));
-  result = rc_classify_conditions(&local_condset, *memaddr);
+  result = rc_classify_conditions(&local_condset, *memaddr, parse);
   if (result < 0) {
     parse->offset = result;
     return NULL;
@@ -260,7 +261,7 @@ rc_condset_t* rc_parse_condset(const char** memaddr, rc_parse_state_t* parse) {
     if (parse->offset < 0)
       return NULL;
 
-    if (condition.oper == RC_OPERATOR_NONE) {
+    if (condition.oper == RC_OPERATOR_NONE && !parse->ignore_non_parse_errors) {
       switch (condition.type) {
         case RC_CONDITION_ADD_ADDRESS:
         case RC_CONDITION_ADD_SOURCE:
@@ -285,8 +286,10 @@ rc_condset_t* rc_parse_condset(const char** memaddr, rc_parse_state_t* parse) {
       case RC_CONDITION_MEASURED:
         if (measured_target != 0) {
           /* multiple Measured flags cannot exist in the same group */
-          parse->offset = RC_MULTIPLE_MEASURED;
-          return NULL;
+          if (!parse->ignore_non_parse_errors) {
+            parse->offset = RC_MULTIPLE_MEASURED;
+            return NULL;
+          }
         }
         else if (parse->is_value) {
           measured_target = (uint32_t)-1;
@@ -304,15 +307,17 @@ rc_condset_t* rc_parse_condset(const char** memaddr, rc_parse_state_t* parse) {
         else if (condition.operand2.type == RC_OPERAND_FP) {
           measured_target = (unsigned)condition.operand2.value.dbl;
         }
-        else {
+        else if (!parse->ignore_non_parse_errors) {
           parse->offset = RC_INVALID_MEASURED_TARGET;
           return NULL;
         }
 
         if (parse->measured_target && measured_target != parse->measured_target) {
           /* multiple Measured flags in separate groups must have the same target */
-          parse->offset = RC_MULTIPLE_MEASURED;
-          return NULL;
+          if (!parse->ignore_non_parse_errors) {
+            parse->offset = RC_MULTIPLE_MEASURED;
+            return NULL;
+          }
         }
 
         parse->measured_target = measured_target;
@@ -321,7 +326,7 @@ rc_condset_t* rc_parse_condset(const char** memaddr, rc_parse_state_t* parse) {
       case RC_CONDITION_STANDARD:
       case RC_CONDITION_TRIGGER:
         /* these flags are not allowed in value expressions */
-        if (parse->is_value) {
+        if (parse->is_value && !parse->ignore_non_parse_errors) {
           parse->offset = RC_INVALID_VALUE_FLAG;
           return NULL;
         }

--- a/src/rcheevos/rc_internal.h
+++ b/src/rcheevos/rc_internal.h
@@ -256,6 +256,7 @@ typedef struct {
   uint8_t is_value;
   uint8_t has_required_hits;
   uint8_t measured_as_percent;
+  uint8_t ignore_non_parse_errors;
 }
 rc_parse_state_t;
 

--- a/test/rcheevos/test_condset.c
+++ b/test/rcheevos/test_condset.c
@@ -4607,6 +4607,7 @@ static void test_ignore_parse_errors(const char* memaddr, uint8_t is_value, int3
   memaddr_test = memaddr;
   rc_parse_condset(&memaddr_test, &preparse.parse);
   ASSERT_NUM_EQUALS(preparse.parse.offset, expected_error);
+  rc_destroy_preparse_state(&preparse);
 
   rc_init_preparse_state(&preparse);
   preparse.parse.is_value = is_value;
@@ -4615,6 +4616,7 @@ static void test_ignore_parse_errors(const char* memaddr, uint8_t is_value, int3
   memaddr_test = memaddr;
   rc_parse_condset(&memaddr_test, &preparse.parse);
   ASSERT_NUM_GREATER(preparse.parse.offset, 0);
+  rc_destroy_preparse_state(&preparse);
 }
 
 void test_condset(void) {


### PR DESCRIPTION
allows asset editor to parse pasted logic that contains errors like multiple measured targets