### PR TITLE
add rc_condition_get_real_operand1

### DIFF
--- a/include/rc_runtime_types.h
+++ b/include/rc_runtime_types.h
@@ -124,6 +124,9 @@ typedef struct rc_operand_t {
 
   /* specifies how to read the memref for some types (RC_OPERAND_*) */
   uint8_t memref_access_type;
+
+  /* if set, this operand is combining the current condition with the previous one */
+  uint8_t is_combining;
 }
 rc_operand_t;
 

--- a/src/rcheevos/condition.c
+++ b/src/rcheevos/condition.c
@@ -432,6 +432,7 @@ void rc_condition_update_parse_state(rc_condition_t* condition, rc_parse_state_t
       if (parse->addsource_parent.type != RC_OPERAND_NONE) {
         /* type determined by leaf */
         rc_operand_addsource(&condition->operand1, parse, condition->operand1.size);
+        condition->operand1.is_combining = 1;
       }
 
       memcpy(&parse->remember, &condition->operand1, sizeof(parse->remember));
@@ -465,6 +466,7 @@ void rc_condition_update_parse_state(rc_condition_t* condition, rc_parse_state_t
       if (parse->addsource_parent.type != RC_OPERAND_NONE) {
         /* type determined by leaf */
         rc_operand_addsource(&condition->operand1, parse, condition->operand1.size);
+        condition->operand1.is_combining = 1;
 
         if (parse->buffer)
           condition->optimized_comparator = rc_condition_determine_comparator(condition);
@@ -474,6 +476,49 @@ void rc_condition_update_parse_state(rc_condition_t* condition, rc_parse_state_t
       parse->indirect_parent.type = RC_OPERAND_NONE;
       break;
   }
+}
+
+static const rc_modified_memref_t* rc_operand_get_modified_memref(const rc_operand_t* operand) {
+  if (!rc_operand_is_memref(operand))
+    return NULL;
+
+  if (operand->value.memref->value.memref_type != RC_MEMREF_TYPE_MODIFIED_MEMREF)
+    return NULL;
+
+  return (rc_modified_memref_t*)operand->value.memref;
+}
+
+/* rc_condition_update_parse_state will mutate the operand1 to point at the modified memref
+ * containing the accumulated result up until that point. this function returns the original
+ * unmodified operand1 from parsing the definition.
+ */
+const rc_operand_t* rc_condition_get_real_operand1(const rc_condition_t* self) {
+  const rc_operand_t* operand = &self->operand1;
+  const rc_modified_memref_t* modified_memref;
+
+  if (operand->is_combining) {
+    /* operand = "previous + current" - extract current */
+    const rc_modified_memref_t* combining_modified_memref = rc_operand_get_modified_memref(operand);
+    if (combining_modified_memref)
+      operand = &combining_modified_memref->modifier;
+  }
+
+  /* modifying operators are merged into an rc_modified_memref_t
+   * if operand1 is a modified memref, assume it's been merged with the right side and
+   * extract the parent which is the actual operand1. */
+  modified_memref = rc_operand_get_modified_memref(operand);
+  if (modified_memref) {
+    if (modified_memref->modifier_type == RC_OPERATOR_INDIRECT_READ) {
+      /* if the modified memref is an indirect read, the parent is the indirect
+       * address and the modifier is the offset. the actual size and address are
+       * stored in the modified memref - use it */
+    } else if (rc_operator_is_modifying(self->oper) && self->oper != RC_OPERATOR_NONE) {
+      /* operand = "parent*modifier" - extract parent.modifier will already be in operand2 */
+      operand = &modified_memref->parent;
+    }
+  }
+
+  return operand;
 }
 
 int rc_condition_is_combining(const rc_condition_t* self) {

--- a/src/rcheevos/operand.c
+++ b/src/rcheevos/operand.c
@@ -55,6 +55,7 @@ static int rc_parse_operand_variable(rc_operand_t* self, const char** memaddr, r
     }
     else {
       memcpy(self, &parse->remember, sizeof(*self));
+      self->is_combining = 0;
       self->memref_access_type = self->type;
     }
     self->type = RC_OPERAND_RECALL;
@@ -146,6 +147,8 @@ int rc_parse_operand(rc_operand_t* self, const char** memaddr, rc_parse_state_t*
   unsigned long value;
   int negative;
   int allow_decimal = 0;
+
+  self->is_combining = 0;
 
   switch (*aux) {
     case 'h': case 'H': /* hex constant */

--- a/src/rcheevos/rc_internal.h
+++ b/src/rcheevos/rc_internal.h
@@ -335,6 +335,7 @@ int rc_test_condition(rc_condition_t* self, rc_eval_state_t* eval_state);
 void rc_evaluate_condition_value(rc_typed_value_t* value, rc_condition_t* self, rc_eval_state_t* eval_state);
 int rc_condition_is_combining(const rc_condition_t* self);
 void rc_condition_convert_to_operand(const rc_condition_t* condition, rc_operand_t* operand, rc_parse_state_t* parse);
+const rc_operand_t* rc_condition_get_real_operand1(const rc_condition_t* self);
 
 int rc_parse_operand(rc_operand_t* self, const char** memaddr, rc_parse_state_t* parse);
 void rc_evaluate_operand(rc_typed_value_t* value, const rc_operand_t* self, rc_eval_state_t* eval_state);

--- a/test/rcheevos/test_value.c
+++ b/test/rcheevos/test_value.c
@@ -696,9 +696,10 @@ void test_value(void) {
   /* delta should initially be 0, so a hit will be tallied */
   TEST_PARAMS2(test_evaluate_value, "M:0xH0002!=d0xH0002", 1);
 
-  /* division (cannot occur directly on measured condition, so use AddSource) */
+  /* division */
   TEST_PARAMS2(test_evaluate_value, "A:0xH0001/2_M:0", 9);       /* 18/2 = 9 */
   TEST_PARAMS2(test_evaluate_value, "A:0xH0001/5_M:0", 3);       /* 18/5 = 3 */
+  TEST_PARAMS2(test_evaluate_value, "M:0xH0001/5", 3);           /* 18/5 = 3 */
   TEST_PARAMS2(test_evaluate_value, "A:0xH0002/0xH0001_M:0", 2); /* 52/18 = 2 */
   TEST_PARAMS2(test_evaluate_value, "A:0xH0001/0xH0002_M:0", 0); /* 18/52 = 0 */
   TEST_PARAMS2(test_evaluate_value, "A:0xH0001/0xH0001_M:0", 1); /* 18/18 = 1 */


### PR DESCRIPTION
needed to fix an issue displaying some conditions in the achievement editor caused by the modified memref logic.

the left side of this should be a memory read:
![image](https://github.com/user-attachments/assets/4de9178d-0dbc-4ba6-aefb-48fbe2f75884)

