### PR TITLE
don't chain previous hashes on subsequent unknown hash resolution

### DIFF
--- a/src/rc_client.c
+++ b/src/rc_client.c
@@ -2496,7 +2496,9 @@ static rc_client_async_handle_t* rc_client_load_game(rc_client_load_state_t* loa
 {
   rc_client_t* client = load_state->client;
   rc_client_game_hash_t* old_hash;
+#ifdef RC_CLIENT_SUPPORTS_HASH
   size_t i;
+#endif
 
   if (!rc_client_attach_load_state(client, load_state)) {
     rc_client_free_load_state(load_state);
@@ -2506,6 +2508,7 @@ static rc_client_async_handle_t* rc_client_load_game(rc_client_load_state_t* loa
   old_hash = load_state->hash;
   load_state->hash = rc_client_find_game_hash(client, hash);
 
+#ifdef RC_CLIENT_SUPPORTS_HASH
   i = 0;
   do {
     if (!load_state->tried_hashes[i]) {
@@ -2521,6 +2524,7 @@ static rc_client_async_handle_t* rc_client_load_game(rc_client_load_state_t* loa
       break;
     }
   } while (1);
+#endif
 
   if (file_path) {
     rc_client_media_hash_t* media_hash =

--- a/src/rc_client.c
+++ b/src/rc_client.c
@@ -64,6 +64,7 @@ typedef struct rc_client_load_state_t
 
 #ifdef RC_CLIENT_SUPPORTS_HASH
   rc_hash_iterator_t hash_iterator;
+  rc_client_game_hash_t* tried_hashes[4];
 #endif
   rc_client_pending_media_t* pending_media;
 
@@ -2229,40 +2230,31 @@ static void rc_client_process_resolved_hash(rc_client_load_state_t* load_state)
       return;
     }
 
-    if (load_state->game->media_hash &&
-        load_state->game->media_hash->game_hash &&
-        load_state->game->media_hash->game_hash->next) {
+    if (load_state->tried_hashes[1]) {
       /* multiple hashes were tried, create a CSV */
-      struct rc_client_game_hash_t* game_hash = load_state->game->media_hash->game_hash;
-      int count = 1;
+      size_t i;
+      size_t count = 0;
       char* ptr;
-      size_t size;
+      size_t size = 0;
 
-      size = strlen(game_hash->hash) + 1;
-      while (game_hash->next) {
-        game_hash = game_hash->next;
-        size += strlen(game_hash->hash) + 1;
+      for (i = 0; i < sizeof(load_state->tried_hashes) / sizeof(load_state->tried_hashes[0]); ++i) {
+        if (!load_state->tried_hashes[i])
+          break;
+
+        size += strlen(load_state->tried_hashes[i]->hash) + 1;
         count++;
       }
 
       ptr = (char*)rc_buffer_alloc(&load_state->game->buffer, size);
-      ptr += size - 1;
-      *ptr = '\0';
-      game_hash = load_state->game->media_hash->game_hash;
-      do {
-        const size_t hash_len = strlen(game_hash->hash);
-        ptr -= hash_len;
-        memcpy(ptr, game_hash->hash, hash_len);
-
-        game_hash = game_hash->next;
-        if (!game_hash)
-          break;
-
-        ptr--;
-        *ptr = ',';
-      } while (1);
-
       load_state->game->public_.hash = ptr;
+      for (i = 0; i < count; i++) {
+        const size_t hash_len = strlen(load_state->tried_hashes[i]->hash);
+        memcpy(ptr, load_state->tried_hashes[i]->hash, hash_len);
+        ptr += hash_len;
+        *ptr++ = ',';
+      }
+      *(ptr - 1) = '\0';
+
       load_state->game->public_.console_id = RC_CONSOLE_UNKNOWN;
     } else {
       /* only a single hash was tried, capture it */
@@ -2504,6 +2496,7 @@ static rc_client_async_handle_t* rc_client_load_game(rc_client_load_state_t* loa
 {
   rc_client_t* client = load_state->client;
   rc_client_game_hash_t* old_hash;
+  size_t i;
 
   if (!rc_client_attach_load_state(client, load_state)) {
     rc_client_free_load_state(load_state);
@@ -2512,6 +2505,22 @@ static rc_client_async_handle_t* rc_client_load_game(rc_client_load_state_t* loa
 
   old_hash = load_state->hash;
   load_state->hash = rc_client_find_game_hash(client, hash);
+
+  i = 0;
+  do {
+    if (!load_state->tried_hashes[i]) {
+      load_state->tried_hashes[i] = load_state->hash;
+      break;
+    }
+
+    if (load_state->tried_hashes[i] == load_state->hash)
+      break;
+
+    if (++i == sizeof(load_state->tried_hashes) / sizeof(load_state->tried_hashes[0])) {
+      RC_CLIENT_LOG_VERBOSE(client, "tried_hashes buffer is full");
+      break;
+    }
+  } while (1);
 
   if (file_path) {
     rc_client_media_hash_t* media_hash =

--- a/src/rc_client_types.natvis
+++ b/src/rc_client_types.natvis
@@ -364,7 +364,7 @@
     <Type Name="rc_client_t">
         <Expand>
             <Item Name="game">game</Item>
-            <Item Name="hashes">*((__rc_client_game_hash_list_t*)&amp;hashes)</Item>
+            <Item Name="hashes">*((__rc_client_game_hash_list_t*)this)</Item>
             <Item Name="user">user</Item>
             <Item Name="callbacks">callbacks</Item>
             <Item Name="state">state</Item>

--- a/test/test_rc_client.c
+++ b/test/test_rc_client.c
@@ -1437,54 +1437,49 @@ static void test_load_game_unknown_hash_multiple(void)
 {
   rc_client_async_handle_t* handle;
 
-  const size_t disk_size = 256 * 16 * 35; /* 140KB - Apple II disk size */
-  uint8_t* disk = generate_generic_file(disk_size);
-
   g_client = mock_client_logged_in();
   g_client->callbacks.server_call = rc_client_server_call_async;
 
   reset_mock_api_handlers();
 
   /* first request */
-  handle = rc_client_begin_identify_and_load_game(g_client, RC_CONSOLE_APPLE_II,
-    "disk1.dsk", disk, disk_size, rc_client_callback_expect_unknown_game, g_callback_userdata);
+  handle = rc_client_begin_load_game(g_client, "0123456789ABCDEF",
+                                     rc_client_callback_expect_unknown_game, g_callback_userdata);
   ASSERT_PTR_NOT_NULL(handle);
   ASSERT_PTR_NOT_NULL(g_client->state.load);
 
-  async_api_response("r=patch&u=Username&t=ApiToken&m=88be638f4d78b4072109e55f13e8a0ac", patchdata_not_found);
+  async_api_response("r=patch&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_not_found);
 
   ASSERT_PTR_NULL(g_client->state.load);
   ASSERT_PTR_NOT_NULL(g_client->game);
   ASSERT_PTR_EQUALS(rc_client_get_game_info(g_client), &g_client->game->public_);
 
   ASSERT_NUM_EQUALS(g_client->game->public_.id, 0);
-  ASSERT_NUM_EQUALS(g_client->game->public_.console_id, RC_CONSOLE_APPLE_II);
+  ASSERT_NUM_EQUALS(g_client->game->public_.console_id, RC_CONSOLE_UNKNOWN);
   ASSERT_STR_EQUALS(g_client->game->public_.title, "Unknown Game");
-  ASSERT_STR_EQUALS(g_client->game->public_.hash, "88be638f4d78b4072109e55f13e8a0ac");
+  ASSERT_STR_EQUALS(g_client->game->public_.hash, "0123456789ABCDEF");
   ASSERT_STR_EQUALS(g_client->game->public_.badge_name, "");
   ASSERT_STR_EQUALS(g_client->game->public_.badge_url, default_game_badge);
 
-  /* second request - modify file so new hash is generated */
-  disk[16]++;
-  handle = rc_client_begin_identify_and_load_game(g_client, RC_CONSOLE_APPLE_II,
-    "disk1.dsk", disk, disk_size, rc_client_callback_expect_unknown_game, g_callback_userdata);
+  /* second request */
+  handle = rc_client_begin_load_game(g_client, "FEDCBA9876543210",
+                                     rc_client_callback_expect_unknown_game, g_callback_userdata);
   ASSERT_PTR_NOT_NULL(handle);
   ASSERT_PTR_NOT_NULL(g_client->state.load);
 
-  async_api_response("r=patch&u=Username&t=ApiToken&m=8e39c6077108cafd6193d1c649b5d695", patchdata_not_found);
+  async_api_response("r=patch&u=Username&t=ApiToken&m=FEDCBA9876543210", patchdata_not_found);
 
   ASSERT_PTR_NULL(g_client->state.load);
   ASSERT_PTR_NOT_NULL(g_client->game);
   ASSERT_PTR_EQUALS(rc_client_get_game_info(g_client), &g_client->game->public_);
 
   ASSERT_NUM_EQUALS(g_client->game->public_.id, 0);
-  ASSERT_NUM_EQUALS(g_client->game->public_.console_id, RC_CONSOLE_APPLE_II);
+  ASSERT_NUM_EQUALS(g_client->game->public_.console_id, RC_CONSOLE_UNKNOWN);
   ASSERT_STR_EQUALS(g_client->game->public_.title, "Unknown Game");
-  ASSERT_STR_EQUALS(g_client->game->public_.hash, "8e39c6077108cafd6193d1c649b5d695");
+  ASSERT_STR_EQUALS(g_client->game->public_.hash, "FEDCBA9876543210");
   ASSERT_STR_EQUALS(g_client->game->public_.badge_name, "");
   ASSERT_STR_EQUALS(g_client->game->public_.badge_url, default_game_badge);
 
-  free(disk);
   rc_client_destroy(g_client);
 }
 
@@ -2408,6 +2403,61 @@ static void test_identify_and_load_game_unknown_hash_repeated(void)
 
   rc_client_destroy(g_client);
   free(image);
+}
+
+static void test_identify_and_load_game_unknown_hash_multiple(void)
+{
+  rc_client_async_handle_t* handle;
+
+  const size_t disk_size = 256 * 16 * 35; /* 140KB - Apple II disk size */
+  uint8_t* disk = generate_generic_file(disk_size);
+
+  g_client = mock_client_logged_in();
+  g_client->callbacks.server_call = rc_client_server_call_async;
+
+  reset_mock_api_handlers();
+
+  /* first request */
+  handle = rc_client_begin_identify_and_load_game(g_client, RC_CONSOLE_APPLE_II,
+    "disk1.dsk", disk, disk_size, rc_client_callback_expect_unknown_game, g_callback_userdata);
+  ASSERT_PTR_NOT_NULL(handle);
+  ASSERT_PTR_NOT_NULL(g_client->state.load);
+
+  async_api_response("r=patch&u=Username&t=ApiToken&m=88be638f4d78b4072109e55f13e8a0ac", patchdata_not_found);
+
+  ASSERT_PTR_NULL(g_client->state.load);
+  ASSERT_PTR_NOT_NULL(g_client->game);
+  ASSERT_PTR_EQUALS(rc_client_get_game_info(g_client), &g_client->game->public_);
+
+  ASSERT_NUM_EQUALS(g_client->game->public_.id, 0);
+  ASSERT_NUM_EQUALS(g_client->game->public_.console_id, RC_CONSOLE_APPLE_II);
+  ASSERT_STR_EQUALS(g_client->game->public_.title, "Unknown Game");
+  ASSERT_STR_EQUALS(g_client->game->public_.hash, "88be638f4d78b4072109e55f13e8a0ac");
+  ASSERT_STR_EQUALS(g_client->game->public_.badge_name, "");
+  ASSERT_STR_EQUALS(g_client->game->public_.badge_url, default_game_badge);
+
+  /* second request - modify file so new hash is generated */
+  disk[16]++;
+  handle = rc_client_begin_identify_and_load_game(g_client, RC_CONSOLE_APPLE_II,
+    "disk1.dsk", disk, disk_size, rc_client_callback_expect_unknown_game, g_callback_userdata);
+  ASSERT_PTR_NOT_NULL(handle);
+  ASSERT_PTR_NOT_NULL(g_client->state.load);
+
+  async_api_response("r=patch&u=Username&t=ApiToken&m=8e39c6077108cafd6193d1c649b5d695", patchdata_not_found);
+
+  ASSERT_PTR_NULL(g_client->state.load);
+  ASSERT_PTR_NOT_NULL(g_client->game);
+  ASSERT_PTR_EQUALS(rc_client_get_game_info(g_client), &g_client->game->public_);
+
+  ASSERT_NUM_EQUALS(g_client->game->public_.id, 0);
+  ASSERT_NUM_EQUALS(g_client->game->public_.console_id, RC_CONSOLE_APPLE_II);
+  ASSERT_STR_EQUALS(g_client->game->public_.title, "Unknown Game");
+  ASSERT_STR_EQUALS(g_client->game->public_.hash, "8e39c6077108cafd6193d1c649b5d695");
+  ASSERT_STR_EQUALS(g_client->game->public_.badge_name, "");
+  ASSERT_STR_EQUALS(g_client->game->public_.badge_url, default_game_badge);
+
+  free(disk);
+  rc_client_destroy(g_client);
 }
 
 #ifndef RC_HASH_NO_ROM
@@ -9386,6 +9436,7 @@ void test_client(void) {
  #endif
   TEST(test_identify_and_load_game_unknown_hash);
   TEST(test_identify_and_load_game_unknown_hash_repeated);
+  TEST(test_identify_and_load_game_unknown_hash_multiple);
  #ifndef RC_HASH_NO_ROM
   TEST(test_identify_and_load_game_unknown_hash_multiconsole);
  #endif


### PR DESCRIPTION
prevents multiple hashes from appearing in the unknown game's hash field if only one hash was tried.
![image](https://github.com/user-attachments/assets/5b9ffcca-53cb-46df-bd88-2939d51a95d3)

this image shows the current game's hash, as well as the previous game's hash