### PR TITLE
fix get_real_operand1 for AddAddress const chain

### DIFF
--- a/src/rcheevos/operand.c
+++ b/src/rcheevos/operand.c
@@ -118,16 +118,11 @@ static int rc_parse_operand_memory(rc_operand_t* self, const char** memaddr, rc_
   }
 
   if (parse->indirect_parent.type != RC_OPERAND_NONE) {
-    if (parse->indirect_parent.type == RC_OPERAND_CONST) {
-      self->value.memref = rc_alloc_memref(parse, address + parse->indirect_parent.value.num, size);
-    }
-    else {
-      rc_operand_t offset;
-      rc_operand_set_const(&offset, address);
+    rc_operand_t offset;
+    rc_operand_set_const(&offset, address);
 
-      self->value.memref = (rc_memref_t*)rc_alloc_modified_memref(parse,
-        size, &parse->indirect_parent, RC_OPERATOR_INDIRECT_READ, &offset);
-    }
+    self->value.memref = (rc_memref_t*)rc_alloc_modified_memref(parse,
+      size, &parse->indirect_parent, RC_OPERATOR_INDIRECT_READ, &offset);
   }
   else {
     self->value.memref = rc_alloc_memref(parse, address, size);

--- a/test/rcheevos/test_condset.c
+++ b/test/rcheevos/test_condset.c
@@ -4680,6 +4680,41 @@ static void test_get_real_operand1_recall(void)
   ASSERT_NUM_EQUALS(operand->is_combining, 0);
 }
 
+static void test_get_real_operand1_indirect_static()
+{
+  rc_condset_t* condset;
+  rc_condition_t* condition;
+  const rc_operand_t* operand;
+  rc_memrefs_t memrefs;
+  char buffer[2048];
+
+  assert_parse_condset(&condset, &memrefs, buffer, "I:8_I:0xH0010_0xH0020=2");
+
+  condition = condset->conditions;
+  ASSERT_NUM_EQUALS(condition->operand1.is_combining, 0);
+  operand = rc_condition_get_real_operand1(condition);
+  ASSERT_NUM_EQUALS(operand->type, RC_OPERAND_CONST);
+  ASSERT_NUM_EQUALS(operand->size, RC_MEMSIZE_32_BITS);
+  ASSERT_NUM_EQUALS(operand->value.num, 8);
+  ASSERT_NUM_EQUALS(operand->is_combining, 0);
+
+  condition = condition->next;
+  ASSERT_NUM_EQUALS(condition->operand1.is_combining, 0);
+  operand = rc_condition_get_real_operand1(condition);
+  ASSERT_NUM_EQUALS(operand->type, RC_OPERAND_ADDRESS);
+  ASSERT_NUM_EQUALS(operand->size, RC_MEMSIZE_8_BITS);
+  ASSERT_NUM_EQUALS(operand->value.memref->address, 0x0010);
+  ASSERT_NUM_EQUALS(operand->is_combining, 0);
+
+  condition = condition->next;
+  ASSERT_NUM_EQUALS(condition->operand1.is_combining, 0);
+  operand = rc_condition_get_real_operand1(condition);
+  ASSERT_NUM_EQUALS(operand->type, RC_OPERAND_ADDRESS);
+  ASSERT_NUM_EQUALS(operand->size, RC_MEMSIZE_8_BITS);
+  ASSERT_NUM_EQUALS(operand->value.memref->address, 0x0020);
+  ASSERT_NUM_EQUALS(operand->is_combining, 0);
+}
+
 static void test_ignore_parse_errors(const char* memaddr, uint8_t is_value, int32_t expected_error)
 {
   const char* memaddr_test;
@@ -4849,6 +4884,7 @@ void test_condset(void) {
   /* get_real_operand1 */
   TEST(test_get_real_operand1);
   TEST(test_get_real_operand1_recall);
+  TEST(test_get_real_operand1_indirect_static);
 
   /* ignore parse errors */
   TEST_PARAMS3(test_ignore_parse_errors, "M:0x1234=5_M:0x1234=6", 0, RC_MULTIPLE_MEASURED);


### PR DESCRIPTION
don't optimize away operand when using "AddAddress value" in a chain.

https://discord.com/channels/310192285306454017/1149693430306447380/1364333512060309544