### PR TITLE
fix value type of modified memref created from float_be parent

### DIFF
--- a/src/rcheevos/memref.c
+++ b/src/rcheevos/memref.c
@@ -150,7 +150,7 @@ rc_modified_memref_t* rc_alloc_modified_memref(rc_parse_state_t* parse, uint8_t 
   memset(modified_memref, 0, sizeof(*modified_memref));
   modified_memref->memref.value.memref_type = RC_MEMREF_TYPE_MODIFIED_MEMREF;
   modified_memref->memref.value.size = size;
-  modified_memref->memref.value.type = (size == RC_MEMSIZE_FLOAT) ? RC_VALUE_TYPE_FLOAT : RC_VALUE_TYPE_UNSIGNED;
+  modified_memref->memref.value.type = rc_memsize_is_float(size) ? RC_VALUE_TYPE_FLOAT : RC_VALUE_TYPE_UNSIGNED;
   memcpy(&modified_memref->parent, parent, sizeof(modified_memref->parent));
   memcpy(&modified_memref->modifier, modifier, sizeof(modified_memref->modifier));
   modified_memref->modifier_type = modifier_type;

--- a/src/rcheevos/operand.c
+++ b/src/rcheevos/operand.c
@@ -358,7 +358,7 @@ int rc_operator_is_modifying(int oper) {
   }
 }
 
-static int rc_memsize_is_float(uint8_t size) {
+int rc_memsize_is_float(uint8_t size) {
   switch (size) {
     case RC_MEMSIZE_FLOAT:
     case RC_MEMSIZE_FLOAT_BE:

--- a/src/rcheevos/rc_internal.h
+++ b/src/rcheevos/rc_internal.h
@@ -340,6 +340,7 @@ const rc_operand_t* rc_condition_get_real_operand1(const rc_condition_t* self);
 int rc_parse_operand(rc_operand_t* self, const char** memaddr, rc_parse_state_t* parse);
 void rc_evaluate_operand(rc_typed_value_t* value, const rc_operand_t* self, rc_eval_state_t* eval_state);
 int rc_operator_is_modifying(int oper);
+int rc_memsize_is_float(uint8_t size);
 int rc_operand_is_float_memref(const rc_operand_t* self);
 int rc_operand_is_float(const rc_operand_t* self);
 int rc_operand_is_recall(const rc_operand_t* self);

--- a/test/rcheevos/test_rc_validate.c
+++ b/test/rcheevos/test_rc_validate.c
@@ -333,6 +333,7 @@ void test_conflicting_conditions() {
   TEST_PARAMS2(test_validate_trigger, "O:0xH0000<5_0xH0000=5", ""); /* ignore combining conditions */
   TEST_PARAMS2(test_validate_trigger, "A:0xH0000<5_0xH0000=5", ""); /* ignore combining conditions */
   TEST_PARAMS2(test_validate_trigger, "N:0xH0000<5_R:0xH0001=8_T:0xH0000=0", ""); /* ignore combining conditions */
+  TEST_PARAMS2(test_validate_trigger, "0xH0001=58_N:0xH0001!=58_N:0xH0001!=4_R:0xH0001!=18", ""); /* ignore combining conditions */
   TEST_PARAMS2(test_validate_trigger, "0xH0000<=5_0xH0000>=5", "");
   TEST_PARAMS2(test_validate_trigger, "0xH0000>1_0xH0000<3", "");
   TEST_PARAMS2(test_validate_trigger, "1=1S0xH0000=1S0xH0000=2", "");


### PR DESCRIPTION
fixes https://discord.com/channels/310192285306454017/1149693430306447380/1368057501177876532

because FLOAT_BE was not FLOAT, it was marking the combination of the two values as an integer, so the comparison ended up being wrong.