### PR TITLE
don't limit indirect value by pointer mask

### DIFF
--- a/src/rcheevos/rc_validate.c
+++ b/src/rcheevos/rc_validate.c
@@ -199,8 +199,10 @@ static uint32_t rc_max_chain_value(const rc_operand_t* operand)
 {
   if (rc_operand_is_memref(operand) && operand->value.memref->value.memref_type == RC_MEMREF_TYPE_MODIFIED_MEMREF) {
     const rc_modified_memref_t* modified_memref = (const rc_modified_memref_t*)operand->value.memref;
-    const uint32_t op_max = rc_max_chain_value(&modified_memref->parent);
-    return rc_scale_value(op_max, modified_memref->modifier_type, &modified_memref->modifier);
+    if (modified_memref->modifier_type != RC_OPERATOR_INDIRECT_READ) {
+      const uint32_t op_max = rc_max_chain_value(&modified_memref->parent);
+      return rc_scale_value(op_max, modified_memref->modifier_type, &modified_memref->modifier);
+    }
   }
 
   return rc_max_value(operand);

--- a/test/rcheevos/test_rc_validate.c
+++ b/test/rcheevos/test_rc_validate.c
@@ -206,6 +206,8 @@ static void test_range_comparisons() {
   /* max for SubSource is always 0xFFFFFFFF */
   TEST_PARAMS2(test_validate_trigger, "B:0xH1234_0xH1235<510", "");
   TEST_PARAMS2(test_validate_trigger, "B:0xH1234_0xH1235<=510", "");
+
+  TEST_PARAMS2(test_validate_trigger, "I:0xG1234&536870911_R:0xG0000=4294967294", "");
 }
 
 void test_size_comparisons() {


### PR DESCRIPTION
fixes https://discord.com/channels/310192285306454017/1149693430306447380/1365345738682404964

The maximum value for the comparison was the mask used on the AddAddress line.