### PR TITLE
Add allprogress/hashlibrary endpoint wrappers

### DIFF
--- a/include/rc_api_info.h
+++ b/include/rc_api_info.h
@@ -233,6 +233,46 @@ RC_EXPORT int RC_CCONV rc_api_init_fetch_game_titles_request_hosted(rc_api_reque
 RC_EXPORT int RC_CCONV rc_api_process_fetch_game_titles_server_response(rc_api_fetch_game_titles_response_t* response, const rc_api_server_response_t* server_response);
 RC_EXPORT void RC_CCONV rc_api_destroy_fetch_game_titles_response(rc_api_fetch_game_titles_response_t* response);
 
+/* --- Fetch Game Hashes --- */
+
+/**
+ * API parameters for a fetch games list request.
+ */
+typedef struct rc_api_fetch_hash_library_request_t {
+  /**
+   * The unique identifier of the console to query.
+   * Passing RC_CONSOLE_UNKNOWN will return hashes for all consoles.
+   */
+  uint32_t console_id;
+} rc_api_fetch_hash_library_request_t;
+
+/* A hash library entry */
+typedef struct rc_api_hash_library_entry_t {
+  /* The hash for the game */
+  const char* hash;
+  /* The unique identifier of the game */
+  uint32_t game_id;
+} rc_api_hash_library_entry_t;
+
+/**
+ * Response data for a fetch hash library request.
+ */
+typedef struct rc_api_fetch_hash_library_response_t {
+  /* An array of entries, one per game */
+  rc_api_hash_library_entry_t* entries;
+  /* The number of items in the entries array */
+  uint32_t num_entries;
+
+  /* Common server-provided response information */
+  rc_api_response_t response;
+}
+rc_api_fetch_hash_library_response_t;
+
+RC_EXPORT int RC_CCONV rc_api_init_fetch_hash_library_request(rc_api_request_t* request, const rc_api_fetch_hash_library_request_t* api_params);
+RC_EXPORT int RC_CCONV rc_api_init_fetch_hash_library_request_hosted(rc_api_request_t* request, const rc_api_fetch_hash_library_request_t* api_params, const rc_api_host_t* host);
+RC_EXPORT int RC_CCONV rc_api_process_fetch_hash_library_server_response(rc_api_fetch_hash_library_response_t* response, const rc_api_server_response_t* server_response);
+RC_EXPORT void RC_CCONV rc_api_destroy_fetch_hash_library_response(rc_api_fetch_hash_library_response_t* response);
+
 RC_END_C_DECLS
 
 #endif /* RC_API_INFO_H */

--- a/include/rc_api_user.h
+++ b/include/rc_api_user.h
@@ -213,6 +213,50 @@ RC_EXPORT int RC_CCONV rc_api_init_fetch_followed_users_request_hosted(rc_api_re
 RC_EXPORT int RC_CCONV rc_api_process_fetch_followed_users_server_response(rc_api_fetch_followed_users_response_t* response, const rc_api_server_response_t* server_response);
 RC_EXPORT void RC_CCONV rc_api_destroy_fetch_followed_users_response(rc_api_fetch_followed_users_response_t* response);
 
+/* --- Fetch All Progress --- */
+
+/**
+ * API parameters for a fetch all user progress request.
+ */
+typedef struct rc_api_fetch_all_user_progress_request_t {
+  /* The username of the player */
+  const char* username;
+  /* The API token from the login request */
+  const char* api_token;
+  /* The unique identifier of the console to query */
+  uint32_t console_id;
+} rc_api_fetch_all_user_progress_request_t;
+
+/* An all-user-progress entry */
+typedef struct rc_api_all_user_progress_entry_t {
+  /* The unique identifier of the game */
+  uint32_t game_id;
+  /* The total number of achievements for this game */
+  uint32_t num_achievements;
+  /* The total number of unlocked achievements for this game in softcore mode */
+  uint32_t num_unlocked_achievements;
+  /* The total number of unlocked achievements for this game in hardcore mode */
+  uint32_t num_unlocked_achievements_hardcore;
+} rc_api_all_user_progress_entry_t;
+
+/**
+ * Response data for a fetch all user progress request.
+ */
+typedef struct rc_api_fetch_all_user_progress_response_t {
+  /* An array of entries, one per game */
+  rc_api_all_user_progress_entry_t* entries;
+  /* The number of items in the entries array */
+  uint32_t num_entries;
+
+  /* Common server-provided response information */
+  rc_api_response_t response;
+} rc_api_fetch_all_user_progress_response_t;
+
+RC_EXPORT int RC_CCONV rc_api_init_fetch_all_user_progress_request(rc_api_request_t* request, const rc_api_fetch_all_user_progress_request_t* api_params);
+RC_EXPORT int RC_CCONV rc_api_init_fetch_all_user_progress_request_hosted(rc_api_request_t* request, const rc_api_fetch_all_user_progress_request_t* api_params, const rc_api_host_t* host);
+RC_EXPORT int RC_CCONV rc_api_process_fetch_all_user_progress_server_response(rc_api_fetch_all_user_progress_response_t* response, const rc_api_server_response_t* server_response);
+RC_EXPORT void RC_CCONV rc_api_destroy_fetch_all_user_progress_response(rc_api_fetch_all_user_progress_response_t* response);
+
 RC_END_C_DECLS
 
 #endif /* RC_API_H */

--- a/include/rc_client.h
+++ b/include/rc_client.h
@@ -219,6 +219,39 @@ typedef struct rc_client_user_game_summary_t {
  */
 RC_EXPORT void RC_CCONV rc_client_get_user_game_summary(const rc_client_t* client, rc_client_user_game_summary_t* summary);
 
+typedef struct rc_client_all_user_progress_entry_t {
+  uint32_t game_id;
+  uint32_t num_achievements;
+  uint32_t num_unlocked_achievements;
+  uint32_t num_unlocked_achievements_hardcore;
+} rc_client_all_user_progress_entry_t;
+
+typedef struct rc_client_all_user_progress_t {
+  rc_client_all_user_progress_entry_t* entries;
+  uint32_t num_entries;
+} rc_client_all_user_progress_t;
+
+/**
+ * Callback that is fired when an all progress query completes. list may be null if the query failed.
+ */
+typedef void(RC_CCONV* rc_client_fetch_all_user_progress_callback_t)(int result, const char* error_message,
+                                                                     rc_client_all_user_progress_t* list,
+                                                                     rc_client_t* client, void* callback_userdata);
+
+/**
+ * Starts an asynchronous request for all progress for the given console.
+ * This query returns the total number of achievements for all games tracked by this console, as well as
+ * the user's achievement unlock count for both softcore and hardcore modes.
+ */
+RC_EXPORT rc_client_async_handle_t* RC_CCONV
+rc_client_begin_fetch_all_user_progress(rc_client_t* client, uint32_t console_id,
+                                        rc_client_fetch_all_user_progress_callback_t callback, void* callback_userdata);
+
+/**
+ * Destroys a previously-allocated result from the rc_client_begin_fetch_all_progress_list() callback.
+ */
+RC_EXPORT void RC_CCONV rc_client_destroy_all_user_progress(rc_client_all_user_progress_t* list);
+
 /*****************************************************************************\
 | Game                                                                        |
 \*****************************************************************************/
@@ -316,6 +349,40 @@ typedef struct rc_client_subset_t {
 } rc_client_subset_t;
 
 RC_EXPORT const rc_client_subset_t* RC_CCONV rc_client_get_subset_info(rc_client_t* client, uint32_t subset_id);
+
+/*****************************************************************************\
+| Fetch Game Hashes                                                           |
+\*****************************************************************************/
+
+typedef struct rc_client_hash_library_entry_t {
+  char hash[33];
+  uint32_t game_id;
+} rc_client_hash_library_entry_t;
+
+typedef struct rc_client_hash_library_t {
+  rc_client_hash_library_entry_t* entries;
+  uint32_t num_entries;
+} rc_client_hash_library_t;
+
+/**
+ * Callback that is fired when a hash library request completes. list may be null if the query failed.
+ */
+typedef void(RC_CCONV* rc_client_fetch_hash_library_callback_t)(int result, const char* error_message,
+                                                                rc_client_hash_library_t* list, rc_client_t* client,
+                                                                void* callback_userdata);
+
+/**
+ * Starts an asynchronous request for all hashes for the given console.
+ * This request returns a mapping from hashes to the game's unique identifier. A single game may have multiple
+ * hashes in the case of multi-disc games, or variants that are still compatible with the same achievement set.
+ */
+RC_EXPORT rc_client_async_handle_t* RC_CCONV rc_client_begin_fetch_hash_library(
+  rc_client_t* client, uint32_t console_id, rc_client_fetch_hash_library_callback_t callback, void* callback_userdata);
+
+/**
+ * Destroys a previously-allocated result from the rc_client_destroy_hash_library() callback.
+ */
+RC_EXPORT void RC_CCONV rc_client_destroy_hash_library(rc_client_hash_library_t* list);
 
 /*****************************************************************************\
 | Achievements                                                                |

--- a/src/rapi/rc_api_info.c
+++ b/src/rapi/rc_api_info.c
@@ -492,3 +492,91 @@ int rc_api_process_fetch_game_titles_server_response(rc_api_fetch_game_titles_re
 void rc_api_destroy_fetch_game_titles_response(rc_api_fetch_game_titles_response_t* response) {
   rc_buffer_destroy(&response->response.buffer);
 }
+
+/* --- Fetch Game Hashes --- */
+
+int rc_api_init_fetch_hash_library_request(rc_api_request_t* request,
+                                           const rc_api_fetch_hash_library_request_t* api_params)
+{
+  return rc_api_init_fetch_hash_library_request_hosted(request, api_params, &g_host);
+}
+
+int rc_api_init_fetch_hash_library_request_hosted(rc_api_request_t* request,
+                                                  const rc_api_fetch_hash_library_request_t* api_params,
+                                                  const rc_api_host_t* host)
+{
+  rc_api_url_builder_t builder;
+  rc_api_url_build_dorequest_url(request, host);
+
+  /* note: unauthenticated request */
+  rc_url_builder_init(&builder, &request->buffer, 48);
+  rc_url_builder_append_str_param(&builder, "r", "hashlibrary");
+  if (api_params->console_id != 0)
+    rc_url_builder_append_unum_param(&builder, "c", api_params->console_id);
+
+  request->post_data = rc_url_builder_finalize(&builder);
+  request->content_type = RC_CONTENT_TYPE_URLENCODED;
+
+  return builder.result;
+}
+
+int rc_api_process_fetch_hash_library_server_response(rc_api_fetch_hash_library_response_t* response,
+                                                      const rc_api_server_response_t* server_response)
+{
+  rc_api_hash_library_entry_t* entry;
+  rc_json_iterator_t iterator;
+  rc_json_field_t field;
+  int result;
+
+  rc_json_field_t fields[] = {
+    RC_JSON_NEW_FIELD("Success"),
+    RC_JSON_NEW_FIELD("Error"),
+    RC_JSON_NEW_FIELD("MD5List"),
+  };
+
+  memset(response, 0, sizeof(*response));
+  rc_buffer_init(&response->response.buffer);
+
+  result =
+    rc_json_parse_server_response(&response->response, server_response, fields, sizeof(fields) / sizeof(fields[0]));
+  if (result != RC_OK)
+    return result;
+
+  if (!fields[2].value_start) {
+    /* call rc_json_get_required_object to generate the error message */
+    rc_json_get_required_object(NULL, 0, &response->response, &fields[2], "MD5List");
+    return RC_MISSING_VALUE;
+  }
+
+  response->num_entries = fields[2].array_size;
+  if (response->num_entries > 0) {
+    rc_buffer_reserve(&response->response.buffer, response->num_entries * (33 + sizeof(rc_api_hash_library_entry_t)));
+
+    response->entries = (rc_api_hash_library_entry_t*)rc_buffer_alloc(
+      &response->response.buffer, response->num_entries * sizeof(rc_api_hash_library_entry_t));
+    if (!response->entries)
+      return RC_OUT_OF_MEMORY;
+
+    memset(&iterator, 0, sizeof(iterator));
+    iterator.json = fields[2].value_start;
+    iterator.end = fields[2].value_end;
+
+    entry = response->entries;
+    while (rc_json_get_next_object_field(&iterator, &field)) {
+      entry->hash = rc_buffer_strncpy(&response->response.buffer, field.name, field.name_len);
+
+      field.name = "";
+      if (!rc_json_get_unum(&entry->game_id, &field, ""))
+        return RC_MISSING_VALUE;
+
+      ++entry;
+    }
+  }
+
+  return RC_OK;
+}
+
+void rc_api_destroy_fetch_hash_library_response(rc_api_fetch_hash_library_response_t* response)
+{
+  rc_buffer_destroy(&response->response.buffer);
+}

--- a/src/rc_client.c
+++ b/src/rc_client.c
@@ -972,6 +972,126 @@ void rc_client_get_user_game_summary(const rc_client_t* client, rc_client_user_g
   rc_mutex_unlock((rc_mutex_t*)&client->state.mutex); /* remove const cast for mutex access */
 }
 
+typedef struct rc_client_fetch_all_user_progress_callback_data_t {
+  rc_client_t* client;
+  rc_client_fetch_all_user_progress_callback_t callback;
+  void* callback_userdata;
+  uint32_t console_id;
+  rc_client_async_handle_t async_handle;
+} rc_client_fetch_all_user_progress_callback_data_t;
+
+static void rc_client_fetch_all_user_progress_callback(const rc_api_server_response_t* server_response,
+                                                       void* callback_data)
+{
+  rc_client_fetch_all_user_progress_callback_data_t* ap_callback_data =
+    (rc_client_fetch_all_user_progress_callback_data_t*)callback_data;
+  rc_client_t* client = ap_callback_data->client;
+  rc_api_fetch_all_user_progress_response_t ap_response;
+  const char* error_message;
+  int result;
+
+  result = rc_client_end_async(client, &ap_callback_data->async_handle);
+  if (result) {
+    if (result != RC_CLIENT_ASYNC_DESTROYED)
+      RC_CLIENT_LOG_VERBOSE(client, "Fetch all progress aborted");
+
+    free(ap_callback_data);
+    return;
+  }
+
+  result = rc_api_process_fetch_all_user_progress_server_response(&ap_response, server_response);
+  error_message = rc_client_server_error_message(&result, server_response->http_status_code, &ap_response.response);
+  if (error_message) {
+    RC_CLIENT_LOG_ERR_FORMATTED(client, "Fetch all progress for console %u failed: %s", ap_callback_data->console_id,
+                                error_message);
+    ap_callback_data->callback(result, error_message, NULL, client, ap_callback_data->callback_userdata);
+  } else {
+    rc_client_all_user_progress_t* list;
+    const size_t list_size = sizeof(*list) + sizeof(rc_client_all_user_progress_entry_t) * ap_response.num_entries;
+
+    list = (rc_client_all_user_progress_t*)malloc(list_size);
+    if (!list) {
+      ap_callback_data->callback(RC_OUT_OF_MEMORY, rc_error_str(RC_OUT_OF_MEMORY), NULL, client,
+                                 ap_callback_data->callback_userdata);
+    } else {
+      rc_client_all_user_progress_entry_t* entry = list->entries =
+        (rc_client_all_user_progress_entry_t*)((uint8_t*)list + sizeof(*list));
+      const rc_api_all_user_progress_entry_t* hlentry = ap_response.entries;
+      const rc_api_all_user_progress_entry_t* stop = hlentry + ap_response.num_entries;
+
+      for (; hlentry < stop; ++hlentry, ++entry)
+      {
+        entry->game_id = hlentry->game_id;
+        entry->num_achievements = hlentry->num_achievements;
+        entry->num_unlocked_achievements = hlentry->num_unlocked_achievements;
+        entry->num_unlocked_achievements_hardcore = hlentry->num_unlocked_achievements_hardcore;
+      }
+
+      list->num_entries = ap_response.num_entries;
+
+      ap_callback_data->callback(RC_OK, NULL, list, client, ap_callback_data->callback_userdata);
+    }
+  }
+
+  rc_api_destroy_fetch_all_user_progress_response(&ap_response);
+  free(ap_callback_data);
+}
+
+rc_client_async_handle_t* rc_client_begin_fetch_all_user_progress(rc_client_t* client, uint32_t console_id,
+                                                                  rc_client_fetch_all_user_progress_callback_t callback,
+                                                                  void* callback_userdata)
+{
+  rc_api_fetch_all_user_progress_request_t api_params;
+  rc_client_fetch_all_user_progress_callback_data_t* callback_data;
+  rc_client_async_handle_t* async_handle;
+  rc_api_request_t request;
+  int result;
+  const char* error_message;
+
+  if (!client) {
+    callback(RC_INVALID_STATE, "client is required", NULL, client, callback_userdata);
+    return NULL;
+  } else if (client->state.user != RC_CLIENT_USER_STATE_LOGGED_IN) {
+    callback(RC_INVALID_STATE, "client must be logged in", NULL, client, callback_userdata);
+    return NULL;
+  }
+
+  api_params.username = client->user.username;
+  api_params.api_token = client->user.token;
+  api_params.console_id = console_id;
+
+  result = rc_api_init_fetch_all_user_progress_request_hosted(&request, &api_params, &client->state.host);
+
+  if (result != RC_OK) {
+    error_message = rc_error_str(result);
+    callback(result, error_message, NULL, client, callback_userdata);
+    return NULL;
+  }
+
+  callback_data = (rc_client_fetch_all_user_progress_callback_data_t*)calloc(1, sizeof(*callback_data));
+  if (!callback_data) {
+    callback(RC_OUT_OF_MEMORY, rc_error_str(RC_OUT_OF_MEMORY), NULL, client, callback_userdata);
+    return NULL;
+  }
+
+  callback_data->client = client;
+  callback_data->callback = callback;
+  callback_data->callback_userdata = callback_userdata;
+  callback_data->console_id = console_id;
+
+  async_handle = &callback_data->async_handle;
+  rc_client_begin_async(client, async_handle);
+  client->callbacks.server_call(&request, rc_client_fetch_all_user_progress_callback, callback_data, client);
+  rc_api_destroy_request(&request);
+
+  return rc_client_async_handle_valid(client, async_handle) ? async_handle : NULL;
+}
+
+void rc_client_destroy_all_user_progress(rc_client_all_user_progress_t* list)
+{
+  free(list);
+}
+
 /* ===== Game ===== */
 
 static void rc_client_free_game(rc_client_game_info_t* game)
@@ -3245,6 +3365,118 @@ const rc_client_subset_t* rc_client_get_subset_info(rc_client_t* client, uint32_
   }
 
   return NULL;
+}
+
+/* ===== Fetch Game Hashes ===== */
+
+typedef struct rc_client_fetch_hash_library_callback_data_t {
+  rc_client_t* client;
+  rc_client_fetch_hash_library_callback_t callback;
+  void* callback_userdata;
+  uint32_t console_id;
+  rc_client_async_handle_t async_handle;
+} rc_client_fetch_hash_library_callback_data_t;
+
+static void rc_client_fetch_hash_library_callback(const rc_api_server_response_t* server_response, void* callback_data)
+{
+  rc_client_fetch_hash_library_callback_data_t* hashlib_callback_data =
+    (rc_client_fetch_hash_library_callback_data_t*)callback_data;
+  rc_client_t* client = hashlib_callback_data->client;
+  rc_api_fetch_hash_library_response_t hashlib_response;
+  const char* error_message;
+  int result;
+
+  result = rc_client_end_async(client, &hashlib_callback_data->async_handle);
+  if (result) {
+    if (result != RC_CLIENT_ASYNC_DESTROYED)
+      RC_CLIENT_LOG_VERBOSE(client, "Fetch hash library aborted");
+
+    free(hashlib_callback_data);
+    return;
+  }
+
+  result = rc_api_process_fetch_hash_library_server_response(&hashlib_response, server_response);
+  error_message =
+    rc_client_server_error_message(&result, server_response->http_status_code, &hashlib_response.response);
+  if (error_message) {
+    RC_CLIENT_LOG_ERR_FORMATTED(client, "Fetch hash library for console %u failed: %s",
+                                hashlib_callback_data->console_id, error_message);
+    hashlib_callback_data->callback(result, error_message, NULL, client, hashlib_callback_data->callback_userdata);
+  } else {
+    rc_client_hash_library_t* list;
+    const size_t list_size = sizeof(*list) + sizeof(rc_client_hash_library_entry_t) * hashlib_response.num_entries;
+    list = (rc_client_hash_library_t*)malloc(list_size);
+    if (!list) {
+      hashlib_callback_data->callback(RC_OUT_OF_MEMORY, rc_error_str(RC_OUT_OF_MEMORY), NULL, client,
+                                      hashlib_callback_data->callback_userdata);
+    } else {
+      rc_client_hash_library_entry_t* entry = list->entries =
+        (rc_client_hash_library_entry_t*)((uint8_t*)list + sizeof(*list));
+      const rc_api_hash_library_entry_t* hlentry = hashlib_response.entries;
+      const rc_api_hash_library_entry_t* stop = hlentry + hashlib_response.num_entries;
+
+      for (; hlentry < stop; ++hlentry, ++entry) {
+        snprintf(entry->hash, sizeof(entry->hash), "%s", hlentry->hash);
+        entry->game_id = hlentry->game_id;
+      }
+
+      list->num_entries = hashlib_response.num_entries;
+
+      hashlib_callback_data->callback(RC_OK, NULL, list, client, hashlib_callback_data->callback_userdata);
+    }
+  }
+
+  rc_api_destroy_fetch_hash_library_response(&hashlib_response);
+  free(hashlib_callback_data);
+}
+
+rc_client_async_handle_t* rc_client_begin_fetch_hash_library(rc_client_t* client, uint32_t console_id,
+                                                             rc_client_fetch_hash_library_callback_t callback,
+                                                             void* callback_userdata)
+{
+  rc_api_fetch_hash_library_request_t api_params;
+  rc_client_fetch_hash_library_callback_data_t* callback_data;
+  rc_client_async_handle_t* async_handle;
+  rc_api_request_t request;
+  int result;
+  const char* error_message;
+
+  if (!client) {
+    callback(RC_INVALID_STATE, "client is required", NULL, client, callback_userdata);
+    return NULL;
+  }
+
+  api_params.console_id = console_id;
+  result = rc_api_init_fetch_hash_library_request_hosted(&request, &api_params, &client->state.host);
+
+  if (result != RC_OK) {
+    error_message = rc_error_str(result);
+    callback(result, error_message, NULL, client, callback_userdata);
+    return NULL;
+  }
+
+  callback_data = (rc_client_fetch_hash_library_callback_data_t*)calloc(1, sizeof(*callback_data));
+  if (!callback_data) {
+    callback(RC_OUT_OF_MEMORY, rc_error_str(RC_OUT_OF_MEMORY), NULL, client, callback_userdata);
+    return NULL;
+  }
+
+  callback_data->client = client;
+  callback_data->callback = callback;
+  callback_data->callback_userdata = callback_userdata;
+  callback_data->console_id = console_id;
+
+  async_handle = &callback_data->async_handle;
+  rc_client_begin_async(client, async_handle);
+  client->callbacks.server_call(&request, rc_client_fetch_hash_library_callback, callback_data, client);
+  rc_api_destroy_request(&request);
+
+  return rc_client_async_handle_valid(client, async_handle) ? async_handle : NULL;
+}
+
+void rc_client_destroy_hash_library(rc_client_hash_library_t* list)
+{
+  free(list);
 }
 
 /* ===== Achievements ===== */


### PR DESCRIPTION
These functions when paired together allow an emulator to populate its game list with the achievement count for each game, and the number of achievements unlocked by the user.

NOTE: Consumers of these APIs should cache the responses to these calls on disk. You should *not* issue an allprogress call every time the application starts or the list refreshes.