### PR TITLE
homebrew PCE games don't have to be multiples of 128KB

### DIFF
--- a/src/rhash/hash_rom.c
+++ b/src/rhash/hash_rom.c
@@ -388,9 +388,12 @@ int rc_hash_nintendo_ds(char hash[33], const rc_hash_iterator_t* iterator)
 
 int rc_hash_pce(char hash[33], const rc_hash_iterator_t* iterator)
 {
-  /* if the file contains a header, ignore it (expect ROM data to be multiple of 128KB) */
-  uint32_t calc_size = ((uint32_t)iterator->buffer_size / 0x20000) * 0x20000;
-  if (iterator->buffer_size - calc_size == 512) {
+  /* The PCE header doesn't bear any distinguishable marks, so we have to detect
+   * it by looking at the file size. The core looks for anything that's 512 bytes
+   * more than a multiple of 8KB, so we'll do that too.
+   * https://github.com/libretro/beetle-pce-libretro/blob/af28fb0385d00e0292c4703b3aa7e72762b564d2/mednafen/pce/huc.cpp#L196-L202
+   */
+  if (iterator->buffer_size & 512) {
     rc_hash_iterator_verbose(iterator, "Ignoring PCE header");
     return rc_hash_unheadered_iterator_buffer(hash, iterator, 512);
   }

--- a/test/rhash/test_hash_rom.c
+++ b/test/rhash/test_hash_rom.c
@@ -846,8 +846,11 @@ void test_hash_rom(void) {
   TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_ORIC, "test.tap", 18119, "953a2baa3232c63286aeae36b2172cef");
 
   /* PC Engine */
+  /* NOTE: because the data after the header doesn't match, the headered and non-headered hashes won't match
+   * but the test results ensure that we're only hashing the portion after the header when detected */
   TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_PC_ENGINE, "test.pce", 524288, "68f0f13b598e0b66461bc578375c3888");
   TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_PC_ENGINE, "test.pce", 524288 + 512, "258c93ebaca1c3f488ab48218e5e8d38");
+  TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_PC_ENGINE, "test.pce", 491520 + 512, "ebb565a7f964ccdfaecdce0d6ed540af");
 
   /* Pokemon Mini */
   TEST_PARAMS4(test_hash_full_file, RC_CONSOLE_POKEMON_MINI, "test.min", 524288, "68f0f13b598e0b66461bc578375c3888");


### PR DESCRIPTION
Fixes an issue where a homebrew PCE game (120KB) was generating different hashes depending on whether or not it was headered.

Updated the logic to match the [core](https://github.com/libretro/beetle-pce-libretro/blob/af28fb0385d00e0292c4703b3aa7e72762b564d2/mednafen/pce/huc.cpp#L196-L202) (only check if the bit for an extra 512 bytes is set).