### PR TITLE
add wrapper for acheivementsets api

### DIFF
--- a/include/rc_api_runtime.h
+++ b/include/rc_api_runtime.h
@@ -135,29 +135,6 @@ typedef struct rc_api_achievement_definition_t {
 }
 rc_api_achievement_definition_t;
 
-/* A game subset definition */
-typedef struct rc_api_subset_definition_t {
-  /* The unique identifier of the subset */
-  uint32_t id;
-  /* The title of the subset */
-  const char* title;
-  /* The image name for the subset badge */
-  const char* image_name;
-  /* The URL for the subset badge */
-  const char* image_url;
-
-  /* An array of achievements for the game */
-  rc_api_achievement_definition_t* achievements;
-  /* The number of items in the achievements array */
-  uint32_t num_achievements;
-
-  /* An array of leaderboards for the game */
-  rc_api_leaderboard_definition_t* leaderboards;
-  /* The number of items in the leaderboards array */
-  uint32_t num_leaderboards;
-}
-rc_api_subset_definition_t;
-
 #define RC_ACHIEVEMENT_CATEGORY_CORE 3
 #define RC_ACHIEVEMENT_CATEGORY_UNOFFICIAL 5
 
@@ -193,11 +170,6 @@ typedef struct rc_api_fetch_game_data_response_t {
   /* The number of items in the leaderboards array */
   uint32_t num_leaderboards;
 
-  /* An array of subsets for the game */
-  rc_api_subset_definition_t* subsets;
-  /* The number of items in the subsets array */
-  uint32_t num_subsets;
-
   /* Common server-provided response information */
   rc_api_response_t response;
 }
@@ -209,6 +181,88 @@ RC_EXPORT int RC_CCONV rc_api_init_fetch_game_data_request_hosted(rc_api_request
 RC_EXPORT int RC_CCONV rc_api_process_fetch_game_data_response(rc_api_fetch_game_data_response_t* response, const char* server_response);
 RC_EXPORT int RC_CCONV rc_api_process_fetch_game_data_server_response(rc_api_fetch_game_data_response_t* response, const rc_api_server_response_t* server_response);
 RC_EXPORT void RC_CCONV rc_api_destroy_fetch_game_data_response(rc_api_fetch_game_data_response_t* response);
+
+/* --- Fetch Game Sets --- */
+
+/**
+ * API parameters for a fetch game data request.
+ */
+typedef struct rc_api_fetch_game_sets_request_t {
+  /* The username of the player */
+  const char* username;
+  /* The API token from the login request */
+  const char* api_token;
+  /* The generated hash of the game to be identified */
+  const char* game_hash;
+}
+rc_api_fetch_game_sets_request_t;
+
+#define RC_ACHIEVEMENT_SET_TYPE_CORE 0
+#define RC_ACHIEVEMENT_SET_TYPE_BONUS 1
+#define RC_ACHIEVEMENT_SET_TYPE_SPECIALTY 2
+#define RC_ACHIEVEMENT_SET_TYPE_EXCLUSIVE 3
+
+/* A game subset definition */
+typedef struct rc_api_achievement_set_definition_t {
+  /* The unique identifier of the achievement set */
+  uint32_t id;
+  /* The legacy game_id of the achievement set (used for editor API calls) */
+  uint32_t game_id;
+  /* The title of the achievement set */
+  const char* title;
+  /* The image name for the achievement set badge */
+  const char* image_name;
+  /* The URL for the achievement set badge */
+  const char* image_url;
+
+  /* An array of achievements for the achievement set */
+  rc_api_achievement_definition_t* achievements;
+  /* The number of items in the achievements array */
+  uint32_t num_achievements;
+
+  /* An array of leaderboards for the achievement set */
+  rc_api_leaderboard_definition_t* leaderboards;
+  /* The number of items in the leaderboards array */
+  uint32_t num_leaderboards;
+
+  /* The type of the achievement set */
+  uint8_t type;
+}
+rc_api_achievement_set_definition_t;
+
+/**
+ * Response data for a fetch game sets request.
+ */
+typedef struct rc_api_fetch_game_sets_response_t {
+  /* The unique identifier of the game */
+  uint32_t id;
+  /* The console associated to the game */
+  uint32_t console_id;
+  /* The title of the game */
+  const char* title;
+  /* The image name for the game badge */
+  const char* image_name;
+  /* The URL for the game badge */
+  const char* image_url;
+  /* The rich presence script for the game to be passed to rc_runtime_activate_richpresence */
+  const char* rich_presence_script;
+  /* The unique identifier of the game to use for session requests (startsession/ping/etc) */
+  uint32_t session_game_id;
+
+  /* An array of sets for the game */
+  rc_api_achievement_set_definition_t* sets;
+  /* The number of items in the sets array */
+  uint32_t num_sets;
+
+  /* Common server-provided response information */
+  rc_api_response_t response;
+}
+rc_api_fetch_game_sets_response_t;
+
+RC_EXPORT int RC_CCONV rc_api_init_fetch_game_sets_request(rc_api_request_t* request, const rc_api_fetch_game_sets_request_t* api_params);
+RC_EXPORT int RC_CCONV rc_api_init_fetch_game_sets_request_hosted(rc_api_request_t* request, const rc_api_fetch_game_sets_request_t* api_params, const rc_api_host_t* host);
+RC_EXPORT int RC_CCONV rc_api_process_fetch_game_sets_server_response(rc_api_fetch_game_sets_response_t* response, const rc_api_server_response_t* server_response);
+RC_EXPORT void RC_CCONV rc_api_destroy_fetch_game_sets_response(rc_api_fetch_game_sets_response_t* response);
 
 /* --- Ping --- */
 

--- a/include/rc_api_runtime.h
+++ b/include/rc_api_runtime.h
@@ -192,7 +192,9 @@ typedef struct rc_api_fetch_game_sets_request_t {
   const char* username;
   /* The API token from the login request */
   const char* api_token;
-  /* The generated hash of the game to be identified */
+  /* The unique identifier of the game */
+  uint32_t game_id;
+  /* The generated hash of the game to be identified (ignored if game_id is not 0) */
   const char* game_hash;
 }
 rc_api_fetch_game_sets_request_t;

--- a/src/rapi/rc_api_common.c
+++ b/src/rapi/rc_api_common.c
@@ -317,6 +317,8 @@ static int rc_json_convert_error_code(const char* server_error_code)
     case 'i':
       if (strcmp(server_error_code, "invalid_credentials") == 0)
         return RC_INVALID_CREDENTIALS;
+      if (strcmp(server_error_code, "invalid_parameter") == 0)
+        return RC_INVALID_STATE;
       break;
 
     case 'm':

--- a/src/rapi/rc_api_common.c
+++ b/src/rapi/rc_api_common.c
@@ -319,6 +319,11 @@ static int rc_json_convert_error_code(const char* server_error_code)
         return RC_INVALID_CREDENTIALS;
       break;
 
+    case 'm':
+      if (strcmp(server_error_code, "missing_parameter") == 0)
+        return RC_INVALID_STATE;
+      break;
+
     case 'n':
       if (strcmp(server_error_code, "not_found") == 0)
         return RC_NOT_FOUND;
@@ -698,6 +703,57 @@ int rc_json_get_string(const char** out, rc_buffer_t* buffer, const rc_json_fiel
   *dst++ = '\0';
   rc_buffer_consume(buffer, (uint8_t*)(*out), (uint8_t*)dst);
   return 1;
+}
+
+int rc_json_field_string_matches(const rc_json_field_t* field, const char* text) {
+  int is_quoted = 0;
+  const char* ptr = field->value_start;
+  if (!ptr)
+    return 0;
+
+  if (*ptr == '"') {
+    is_quoted = 1;
+    ++ptr;
+  }
+
+  while (ptr < field->value_end) {
+    if (*ptr != *text) {
+      if (*ptr != '\\') {
+        if (*ptr == '"' && is_quoted && (*text == '\0')) {
+          is_quoted = 0;
+          ++ptr;
+          continue;
+        }
+
+        return 0;
+      }
+
+      ++ptr;
+      switch (*ptr) {
+        case 'n':
+          if (*text != '\n')
+            return 0;
+          break;
+        case 'r':
+          if (*text != '\r')
+            return 0;
+          break;
+        case 't':
+          if (*text != '\t')
+            return 0;
+          break;
+        default:
+          if (*text != *ptr)
+            return 0;
+          break;
+      }
+    }
+
+    ++text;
+    ++ptr;
+  }
+
+  return !is_quoted && (*text == '\0');
 }
 
 void rc_json_get_optional_string(const char** out, rc_api_response_t* response, const rc_json_field_t* field, const char* field_name, const char* default_value) {

--- a/src/rapi/rc_api_common.h
+++ b/src/rapi/rc_api_common.h
@@ -68,6 +68,7 @@ int rc_json_get_required_array(uint32_t* num_entries, rc_json_field_t* array_fie
 int rc_json_get_array_entry_object(rc_json_field_t* fields, size_t field_count, rc_json_iterator_t* iterator);
 int rc_json_get_next_object_field(rc_json_iterator_t* iterator, rc_json_field_t* field);
 int rc_json_get_object_string_length(const char* json);
+int rc_json_field_string_matches(const rc_json_field_t* field, const char* text);
 
 void rc_json_extract_filename(rc_json_field_t* field);
 

--- a/src/rapi/rc_api_runtime.c
+++ b/src/rapi/rc_api_runtime.c
@@ -391,7 +391,7 @@ int rc_api_init_fetch_game_sets_request_hosted(rc_api_request_t* request,
     return RC_INVALID_STATE;
 
   rc_url_builder_init(&builder, &request->buffer, 48);
-  if (rc_api_url_build_dorequest(&builder, "hashdata", api_params->username, api_params->api_token)) {
+  if (rc_api_url_build_dorequest(&builder, "achievementsets", api_params->username, api_params->api_token)) {
     if (api_params->game_id)
       rc_url_builder_append_unum_param(&builder, "g", api_params->game_id);
     else

--- a/src/rapi/rc_api_runtime.c
+++ b/src/rapi/rc_api_runtime.c
@@ -387,12 +387,15 @@ int rc_api_init_fetch_game_sets_request_hosted(rc_api_request_t* request,
 
   rc_api_url_build_dorequest_url(request, host);
 
-  if (!api_params->game_hash || !api_params->game_hash[0])
+  if (!api_params->game_id && (!api_params->game_hash || !api_params->game_hash[0]))
     return RC_INVALID_STATE;
 
   rc_url_builder_init(&builder, &request->buffer, 48);
   if (rc_api_url_build_dorequest(&builder, "hashdata", api_params->username, api_params->api_token)) {
-    rc_url_builder_append_str_param(&builder, "m", api_params->game_hash);
+    if (api_params->game_id)
+      rc_url_builder_append_unum_param(&builder, "g", api_params->game_id);
+    else
+      rc_url_builder_append_str_param(&builder, "m", api_params->game_hash);
 
     request->post_data = rc_url_builder_finalize(&builder);
     request->content_type = RC_CONTENT_TYPE_URLENCODED;

--- a/src/rapi/rc_api_runtime.c
+++ b/src/rapi/rc_api_runtime.c
@@ -108,27 +108,13 @@ int rc_api_process_fetch_game_data_response(rc_api_fetch_game_data_response_t* r
   return rc_api_process_fetch_game_data_server_response(response, &response_obj);
 }
 
-static int rc_parse_achievement_type(const char* type) {
-  if (strcmp(type, "missable") == 0)
-    return RC_ACHIEVEMENT_TYPE_MISSABLE;
-
-  if (strcmp(type, "win_condition") == 0)
-    return RC_ACHIEVEMENT_TYPE_WIN;
-
-  if (strcmp(type, "progression") == 0)
-    return RC_ACHIEVEMENT_TYPE_PROGRESSION;
-
-  return RC_ACHIEVEMENT_TYPE_STANDARD;
-}
-
-static int rc_api_process_fetch_game_data_achievements(rc_api_fetch_game_data_response_t* response, rc_api_achievement_definition_t* achievement, rc_json_field_t* array_field) {
+static int rc_api_process_fetch_game_data_achievements(rc_api_response_t* response, rc_api_achievement_definition_t* achievement, rc_json_field_t* array_field) {
   rc_json_iterator_t iterator;
   const char* last_author = "";
   const char* last_author_field = "";
   size_t last_author_len = 0;
   uint32_t timet;
   size_t len;
-  char type[16];
 
   rc_json_field_t achievement_fields[] = {
     RC_JSON_NEW_FIELD("ID"),
@@ -153,35 +139,35 @@ static int rc_api_process_fetch_game_data_achievements(rc_api_fetch_game_data_re
   iterator.end = array_field->value_end;
 
   while (rc_json_get_array_entry_object(achievement_fields, sizeof(achievement_fields) / sizeof(achievement_fields[0]), &iterator)) {
-    if (!rc_json_get_required_unum(&achievement->id, &response->response, &achievement_fields[0], "ID"))
+    if (!rc_json_get_required_unum(&achievement->id, response, &achievement_fields[0], "ID"))
       return RC_MISSING_VALUE;
-    if (!rc_json_get_required_string(&achievement->title, &response->response, &achievement_fields[1], "Title"))
+    if (!rc_json_get_required_string(&achievement->title, response, &achievement_fields[1], "Title"))
       return RC_MISSING_VALUE;
-    if (!rc_json_get_required_string(&achievement->description, &response->response, &achievement_fields[2], "Description"))
+    if (!rc_json_get_required_string(&achievement->description, response, &achievement_fields[2], "Description"))
       return RC_MISSING_VALUE;
-    if (!rc_json_get_required_unum(&achievement->category, &response->response, &achievement_fields[3], "Flags"))
+    if (!rc_json_get_required_unum(&achievement->category, response, &achievement_fields[3], "Flags"))
       return RC_MISSING_VALUE;
-    if (!rc_json_get_required_unum(&achievement->points, &response->response, &achievement_fields[4], "Points"))
+    if (!rc_json_get_required_unum(&achievement->points, response, &achievement_fields[4], "Points"))
       return RC_MISSING_VALUE;
-    if (!rc_json_get_required_string(&achievement->definition, &response->response, &achievement_fields[5], "MemAddr"))
+    if (!rc_json_get_required_string(&achievement->definition, response, &achievement_fields[5], "MemAddr"))
       return RC_MISSING_VALUE;
-    if (!rc_json_get_required_string(&achievement->badge_name, &response->response, &achievement_fields[7], "BadgeName"))
+    if (!rc_json_get_required_string(&achievement->badge_name, response, &achievement_fields[7], "BadgeName"))
       return RC_MISSING_VALUE;
 
-    rc_json_get_optional_string(&achievement->badge_url, &response->response, &achievement_fields[13], "BadgeURL", "");
+    rc_json_get_optional_string(&achievement->badge_url, response, &achievement_fields[13], "BadgeURL", "");
     if (!achievement->badge_url[0])
-      achievement->badge_url = rc_api_build_avatar_url(&response->response.buffer, RC_IMAGE_TYPE_ACHIEVEMENT, achievement->badge_name);
+      achievement->badge_url = rc_api_build_avatar_url(&response->buffer, RC_IMAGE_TYPE_ACHIEVEMENT, achievement->badge_name);
 
-    rc_json_get_optional_string(&achievement->badge_locked_url, &response->response, &achievement_fields[14], "BadgeLockedURL", "");
+    rc_json_get_optional_string(&achievement->badge_locked_url, response, &achievement_fields[14], "BadgeLockedURL", "");
     if (!achievement->badge_locked_url[0])
-      achievement->badge_locked_url = rc_api_build_avatar_url(&response->response.buffer, RC_IMAGE_TYPE_ACHIEVEMENT_LOCKED, achievement->badge_name);
+      achievement->badge_locked_url = rc_api_build_avatar_url(&response->buffer, RC_IMAGE_TYPE_ACHIEVEMENT_LOCKED, achievement->badge_name);
 
     len = achievement_fields[6].value_end - achievement_fields[6].value_start;
     if (len == last_author_len && memcmp(achievement_fields[6].value_start, last_author_field, len) == 0) {
       achievement->author = last_author;
     }
     else {
-      if (!rc_json_get_required_string(&achievement->author, &response->response, &achievement_fields[6], "Author"))
+      if (!rc_json_get_required_string(&achievement->author, response, &achievement_fields[6], "Author"))
         return RC_MISSING_VALUE;
 
       if (achievement->author == NULL) {
@@ -195,22 +181,23 @@ static int rc_api_process_fetch_game_data_achievements(rc_api_fetch_game_data_re
       }
     }
 
-    if (!rc_json_get_required_unum(&timet, &response->response, &achievement_fields[8], "Created"))
+    if (!rc_json_get_required_unum(&timet, response, &achievement_fields[8], "Created"))
       return RC_MISSING_VALUE;
     achievement->created = (time_t)timet;
-    if (!rc_json_get_required_unum(&timet, &response->response, &achievement_fields[9], "Modified"))
+    if (!rc_json_get_required_unum(&timet, response, &achievement_fields[9], "Modified"))
       return RC_MISSING_VALUE;
     achievement->updated = (time_t)timet;
 
-    achievement->type = RC_ACHIEVEMENT_TYPE_STANDARD;
-    if (achievement_fields[10].value_end) {
-      len = achievement_fields[10].value_end - achievement_fields[10].value_start - 2;
-      if (len < sizeof(type) - 1) {
-        memcpy(type, achievement_fields[10].value_start + 1, len);
-        type[len] = '\0';
-        achievement->type = rc_parse_achievement_type(type);
-      }
-    }
+    if (rc_json_field_string_matches(&achievement_fields[10], ""))
+      achievement->type = RC_ACHIEVEMENT_TYPE_STANDARD;
+    else if (rc_json_field_string_matches(&achievement_fields[10], "progression"))
+      achievement->type = RC_ACHIEVEMENT_TYPE_PROGRESSION;
+    else if (rc_json_field_string_matches(&achievement_fields[10], "missable"))
+      achievement->type = RC_ACHIEVEMENT_TYPE_MISSABLE;
+    else if (rc_json_field_string_matches(&achievement_fields[10], "win_condition"))
+      achievement->type = RC_ACHIEVEMENT_TYPE_WIN;
+    else
+      achievement->type = RC_ACHIEVEMENT_TYPE_STANDARD;
 
     /* legacy support : if title contains[m], change type to missable and remove[m] from title */
     if (memcmp(achievement->title, "[m]", 3) == 0) {
@@ -237,7 +224,7 @@ static int rc_api_process_fetch_game_data_achievements(rc_api_fetch_game_data_re
   return RC_OK;
 }
 
-static int rc_api_process_fetch_game_data_leaderboards(rc_api_fetch_game_data_response_t* response, rc_api_leaderboard_definition_t* leaderboard, rc_json_field_t* array_field) {
+static int rc_api_process_fetch_game_data_leaderboards(rc_api_response_t* response, rc_api_leaderboard_definition_t* leaderboard, rc_json_field_t* array_field) {
   rc_json_iterator_t iterator;
   size_t len;
   int result;
@@ -258,13 +245,13 @@ static int rc_api_process_fetch_game_data_leaderboards(rc_api_fetch_game_data_re
   iterator.end = array_field->value_end;
 
   while (rc_json_get_array_entry_object(leaderboard_fields, sizeof(leaderboard_fields) / sizeof(leaderboard_fields[0]), &iterator)) {
-    if (!rc_json_get_required_unum(&leaderboard->id, &response->response, &leaderboard_fields[0], "ID"))
+    if (!rc_json_get_required_unum(&leaderboard->id, response, &leaderboard_fields[0], "ID"))
       return RC_MISSING_VALUE;
-    if (!rc_json_get_required_string(&leaderboard->title, &response->response, &leaderboard_fields[1], "Title"))
+    if (!rc_json_get_required_string(&leaderboard->title, response, &leaderboard_fields[1], "Title"))
       return RC_MISSING_VALUE;
-    if (!rc_json_get_required_string(&leaderboard->description, &response->response, &leaderboard_fields[2], "Description"))
+    if (!rc_json_get_required_string(&leaderboard->description, response, &leaderboard_fields[2], "Description"))
       return RC_MISSING_VALUE;
-    if (!rc_json_get_required_string(&leaderboard->definition, &response->response, &leaderboard_fields[3], "Mem"))
+    if (!rc_json_get_required_string(&leaderboard->definition, response, &leaderboard_fields[3], "Mem"))
       return RC_MISSING_VALUE;
     rc_json_get_optional_bool(&result, &leaderboard_fields[5], "LowerIsBetter", 0);
     leaderboard->lower_is_better = (uint8_t)result;
@@ -284,81 +271,6 @@ static int rc_api_process_fetch_game_data_leaderboards(rc_api_fetch_game_data_re
     }
 
     ++leaderboard;
-  }
-
-  return RC_OK;
-}
-
-static int rc_api_process_fetch_game_data_subsets(rc_api_fetch_game_data_response_t* response, rc_api_subset_definition_t* subset, rc_json_field_t* subset_array_field) {
-  rc_json_iterator_t iterator;
-  rc_json_field_t array_field;
-  size_t len;
-  int result;
-
-  rc_json_field_t subset_fields[] = {
-    RC_JSON_NEW_FIELD("GameAchievementSetID"),
-    RC_JSON_NEW_FIELD("SetTitle"),
-    RC_JSON_NEW_FIELD("ImageIcon"),
-    RC_JSON_NEW_FIELD("ImageIconURL"),
-    RC_JSON_NEW_FIELD("Achievements"), /* array */
-    RC_JSON_NEW_FIELD("Leaderboards") /* array */
-  };
-
-  memset(&iterator, 0, sizeof(iterator));
-  iterator.json = subset_array_field->value_start;
-  iterator.end = subset_array_field->value_end;
-
-  while (rc_json_get_array_entry_object(subset_fields, sizeof(subset_fields) / sizeof(subset_fields[0]), &iterator)) {
-    if (!rc_json_get_required_unum(&subset->id, &response->response, &subset_fields[0], "GameAchievementSetID"))
-      return RC_MISSING_VALUE;
-    if (!rc_json_get_required_string(&subset->title, &response->response, &subset_fields[1], "SetTitle"))
-      return RC_MISSING_VALUE;
-
-    /* ImageIcon will be '/Images/0123456.png' - only return the '0123456' */
-    rc_json_extract_filename(&subset_fields[2]);
-    rc_json_get_optional_string(&subset->image_name, &response->response, &subset_fields[2], "ImageIcon", "");
-
-    if (!rc_json_get_required_string(&subset->image_url, &response->response, &subset_fields[3], "ImageIconURL"))
-      return RC_MISSING_VALUE;
-
-    /* estimate the amount of space necessary to store the achievements, and leaderboards.
-       determine how much space each takes as a string in the JSON, then subtract out the non-data (field names, punctuation)
-       and add space for the structures. */
-    len = (subset_fields[4].value_end - subset_fields[4].value_start) - /* achievements */
-      subset_fields[4].array_size * (80 - sizeof(rc_api_achievement_definition_t));
-    len += (subset_fields[5].value_end - subset_fields[5].value_start) - /* leaderboards */
-      subset_fields[5].array_size * (60 - sizeof(rc_api_leaderboard_definition_t));
-
-    rc_buffer_reserve(&response->response.buffer, len);
-    /* end estimation */
-
-    if (!rc_json_get_required_array(&subset->num_achievements, &array_field, &response->response, &subset_fields[4], "Achievements"))
-      return RC_MISSING_VALUE;
-
-    if (subset->num_achievements) {
-      subset->achievements = (rc_api_achievement_definition_t*)rc_buffer_alloc(&response->response.buffer, subset->num_achievements * sizeof(rc_api_achievement_definition_t));
-      if (!subset->achievements)
-        return RC_OUT_OF_MEMORY;
-
-      result = rc_api_process_fetch_game_data_achievements(response, subset->achievements, &array_field);
-      if (result != RC_OK)
-        return result;
-    }
-
-    if (!rc_json_get_required_array(&subset->num_leaderboards, &array_field, &response->response, &subset_fields[5], "Leaderboards"))
-      return RC_MISSING_VALUE;
-
-    if (subset->num_leaderboards) {
-      subset->leaderboards = (rc_api_leaderboard_definition_t*)rc_buffer_alloc(&response->response.buffer, subset->num_leaderboards * sizeof(rc_api_leaderboard_definition_t));
-      if (!subset->leaderboards)
-        return RC_OUT_OF_MEMORY;
-
-      result = rc_api_process_fetch_game_data_leaderboards(response, subset->leaderboards, &array_field);
-      if (result != RC_OK)
-        return result;
-    }
-
-    ++subset;
   }
 
   return RC_OK;
@@ -385,7 +297,6 @@ int rc_api_process_fetch_game_data_server_response(rc_api_fetch_game_data_respon
     RC_JSON_NEW_FIELD("RichPresencePatch"),
     RC_JSON_NEW_FIELD("Achievements"), /* array */
     RC_JSON_NEW_FIELD("Leaderboards"), /* array */
-    RC_JSON_NEW_FIELD("Sets") /* array */
   };
 
   memset(response, 0, sizeof(*response));
@@ -438,7 +349,7 @@ int rc_api_process_fetch_game_data_server_response(rc_api_fetch_game_data_respon
     if (!response->achievements)
       return RC_OUT_OF_MEMORY;
 
-    result = rc_api_process_fetch_game_data_achievements(response, response->achievements, &array_field);
+    result = rc_api_process_fetch_game_data_achievements(&response->response, response->achievements, &array_field);
     if (result != RC_OK)
       return result;
   }
@@ -451,18 +362,7 @@ int rc_api_process_fetch_game_data_server_response(rc_api_fetch_game_data_respon
     if (!response->leaderboards)
       return RC_OUT_OF_MEMORY;
 
-    result = rc_api_process_fetch_game_data_leaderboards(response, response->leaderboards, &array_field);
-    if (result != RC_OK)
-      return result;
-  }
-
-  rc_json_get_optional_array(&response->num_subsets, &array_field, &patchdata_fields[8], "Sets");
-  if (response->num_subsets) {
-    response->subsets = (rc_api_subset_definition_t*)rc_buffer_alloc(&response->response.buffer, response->num_subsets * sizeof(rc_api_subset_definition_t));
-    if (!response->subsets)
-      return RC_OUT_OF_MEMORY;
-
-    result = rc_api_process_fetch_game_data_subsets(response, response->subsets, &array_field);
+    result = rc_api_process_fetch_game_data_leaderboards(&response->response, response->leaderboards, &array_field);
     if (result != RC_OK)
       return result;
   }
@@ -471,6 +371,190 @@ int rc_api_process_fetch_game_data_server_response(rc_api_fetch_game_data_respon
 }
 
 void rc_api_destroy_fetch_game_data_response(rc_api_fetch_game_data_response_t* response) {
+  rc_buffer_destroy(&response->response.buffer);
+}
+
+/* --- Fetch Game Sets --- */
+
+int rc_api_init_fetch_game_sets_request(rc_api_request_t* request, const rc_api_fetch_game_sets_request_t* api_params) {
+  return rc_api_init_fetch_game_sets_request_hosted(request, api_params, &g_host);
+}
+
+int rc_api_init_fetch_game_sets_request_hosted(rc_api_request_t* request,
+                                               const rc_api_fetch_game_sets_request_t* api_params,
+                                               const rc_api_host_t* host) {
+  rc_api_url_builder_t builder;
+
+  rc_api_url_build_dorequest_url(request, host);
+
+  if (!api_params->game_hash || !api_params->game_hash[0])
+    return RC_INVALID_STATE;
+
+  rc_url_builder_init(&builder, &request->buffer, 48);
+  if (rc_api_url_build_dorequest(&builder, "hashdata", api_params->username, api_params->api_token)) {
+    rc_url_builder_append_str_param(&builder, "m", api_params->game_hash);
+
+    request->post_data = rc_url_builder_finalize(&builder);
+    request->content_type = RC_CONTENT_TYPE_URLENCODED;
+  }
+
+  return builder.result;
+}
+
+static int rc_api_process_fetch_game_sets_achievement_sets(rc_api_fetch_game_sets_response_t* response,
+                                                           rc_api_achievement_set_definition_t* subset,
+                                                           rc_json_field_t* subset_array_field) {
+  rc_json_iterator_t iterator;
+  rc_json_field_t array_field;
+  size_t len;
+  int result;
+
+  rc_json_field_t subset_fields[] = {
+    RC_JSON_NEW_FIELD("AchievementSetId"),
+    RC_JSON_NEW_FIELD("GameId"),
+    RC_JSON_NEW_FIELD("Title"),
+    RC_JSON_NEW_FIELD("Type"),
+    RC_JSON_NEW_FIELD("ImageIconUrl"),
+    RC_JSON_NEW_FIELD("Achievements"), /* array */
+    RC_JSON_NEW_FIELD("Leaderboards") /* array */
+  };
+
+  memset(&iterator, 0, sizeof(iterator));
+  iterator.json = subset_array_field->value_start;
+  iterator.end = subset_array_field->value_end;
+
+  while (rc_json_get_array_entry_object(subset_fields, sizeof(subset_fields) / sizeof(subset_fields[0]), &iterator)) {
+    if (!rc_json_get_required_unum(&subset->id, &response->response, &subset_fields[0], "AchievementSetId"))
+      return RC_MISSING_VALUE;
+    if (!rc_json_get_required_unum(&subset->game_id, &response->response, &subset_fields[1], "GameId"))
+      return RC_MISSING_VALUE;
+
+    if (!rc_json_get_required_string(&subset->title, &response->response, &subset_fields[2], "Title"))
+      return RC_MISSING_VALUE;
+    if (!subset->title || !subset->title[0])
+      subset->title = response->title;
+
+    if (rc_json_field_string_matches(&subset_fields[3], "core"))
+      subset->type = RC_ACHIEVEMENT_SET_TYPE_CORE;
+    else if (rc_json_field_string_matches(&subset_fields[3], "bonus"))
+      subset->type = RC_ACHIEVEMENT_SET_TYPE_BONUS;
+    else if (rc_json_field_string_matches(&subset_fields[3], "specialty"))
+      subset->type = RC_ACHIEVEMENT_SET_TYPE_SPECIALTY;
+    else if (rc_json_field_string_matches(&subset_fields[3], "exclusive"))
+      subset->type = RC_ACHIEVEMENT_SET_TYPE_EXCLUSIVE;
+    else
+      subset->type = RC_ACHIEVEMENT_SET_TYPE_BONUS;
+
+    if (rc_json_field_string_matches(&subset_fields[4], response->image_url)) {
+      subset->image_url = response->image_url;
+      subset->image_name = response->image_name;
+    }
+    else {
+      if (!rc_json_get_required_string(&subset->image_url, &response->response, &subset_fields[4], "ImageIconUrl"))
+        return RC_MISSING_VALUE;
+      rc_json_extract_filename(&subset_fields[4]);
+      rc_json_get_optional_string(&subset->image_name, &response->response, &subset_fields[4], "ImageIconUrl", "");
+    }
+
+    /* estimate the amount of space necessary to store the achievements, and leaderboards.
+       determine how much space each takes as a string in the JSON, then subtract out the non-data (field names, punctuation)
+       and add space for the structures. */
+    len = (subset_fields[5].value_end - subset_fields[5].value_start) - /* achievements */
+      subset_fields[5].array_size * (80 - sizeof(rc_api_achievement_definition_t));
+    len += (subset_fields[6].value_end - subset_fields[6].value_start) - /* leaderboards */
+      subset_fields[6].array_size * (60 - sizeof(rc_api_leaderboard_definition_t));
+
+    rc_buffer_reserve(&response->response.buffer, len);
+    /* end estimation */
+
+    if (!rc_json_get_required_array(&subset->num_achievements, &array_field, &response->response, &subset_fields[5], "Achievements"))
+      return RC_MISSING_VALUE;
+
+    if (subset->num_achievements) {
+      subset->achievements = (rc_api_achievement_definition_t*)rc_buffer_alloc(&response->response.buffer, subset->num_achievements * sizeof(rc_api_achievement_definition_t));
+      if (!subset->achievements)
+        return RC_OUT_OF_MEMORY;
+
+      result = rc_api_process_fetch_game_data_achievements(&response->response, subset->achievements, &array_field);
+      if (result != RC_OK)
+        return result;
+    }
+
+    if (!rc_json_get_required_array(&subset->num_leaderboards, &array_field, &response->response, &subset_fields[6], "Leaderboards"))
+      return RC_MISSING_VALUE;
+
+    if (subset->num_leaderboards) {
+      subset->leaderboards = (rc_api_leaderboard_definition_t*)rc_buffer_alloc(&response->response.buffer, subset->num_leaderboards * sizeof(rc_api_leaderboard_definition_t));
+      if (!subset->leaderboards)
+        return RC_OUT_OF_MEMORY;
+
+      result = rc_api_process_fetch_game_data_leaderboards(&response->response, subset->leaderboards, &array_field);
+      if (result != RC_OK)
+        return result;
+    }
+
+    ++subset;
+  }
+
+  return RC_OK;
+}
+
+int rc_api_process_fetch_game_sets_server_response(rc_api_fetch_game_sets_response_t* response, const rc_api_server_response_t* server_response) {
+  rc_json_field_t array_field;
+  int result;
+
+  rc_json_field_t fields[] = {
+    RC_JSON_NEW_FIELD("Success"),
+    RC_JSON_NEW_FIELD("Error"),
+    RC_JSON_NEW_FIELD("Code"),
+    RC_JSON_NEW_FIELD("GameId"),
+    RC_JSON_NEW_FIELD("Title"),
+    RC_JSON_NEW_FIELD("ConsoleId"),
+    RC_JSON_NEW_FIELD("ImageIconUrl"),
+    RC_JSON_NEW_FIELD("RichPresenceGameId"),
+    RC_JSON_NEW_FIELD("RichPresencePatch"),
+    RC_JSON_NEW_FIELD("Sets") /* array */
+  };
+
+  memset(response, 0, sizeof(*response));
+  rc_buffer_init(&response->response.buffer);
+
+  result = rc_json_parse_server_response(&response->response, server_response, fields, sizeof(fields) / sizeof(fields[0]));
+  if (result != RC_OK || !response->response.succeeded)
+    return result;
+
+  if (!rc_json_get_required_unum(&response->id, &response->response, &fields[3], "GameId"))
+    return RC_MISSING_VALUE;
+  if (!rc_json_get_required_string(&response->title, &response->response, &fields[4], "Title"))
+    return RC_MISSING_VALUE;
+  if (!rc_json_get_required_unum(&response->console_id, &response->response, &fields[5], "ConsoleId"))
+    return RC_MISSING_VALUE;
+
+  rc_json_get_required_string(&response->image_url, &response->response, &fields[6], "ImageIconUrl");
+  rc_json_extract_filename(&fields[6]);
+  rc_json_get_required_string(&response->image_name, &response->response, &fields[6], "ImageIconUrl");
+
+  rc_json_get_optional_unum(&response->session_game_id, &fields[7], "RichPresenceGameId", response->id);
+
+  rc_json_get_optional_string(&response->rich_presence_script, &response->response, &fields[8], "RichPresencePatch", "");
+  if (!response->rich_presence_script)
+    response->rich_presence_script = "";
+
+  rc_json_get_optional_array(&response->num_sets, &array_field, &fields[9], "Sets");
+  if (response->num_sets) {
+    response->sets = (rc_api_achievement_set_definition_t*)rc_buffer_alloc(&response->response.buffer, response->num_sets * sizeof(rc_api_achievement_set_definition_t));
+    if (!response->sets)
+      return RC_OUT_OF_MEMORY;
+
+    result = rc_api_process_fetch_game_sets_achievement_sets(response, response->sets, &array_field);
+    if (result != RC_OK)
+      return result;
+  }
+
+  return RC_OK;
+}
+
+void rc_api_destroy_fetch_game_sets_response(rc_api_fetch_game_sets_response_t* response) {
   rc_buffer_destroy(&response->response.buffer);
 }
 

--- a/src/rc_client.c
+++ b/src/rc_client.c
@@ -2123,9 +2123,9 @@ static void rc_client_fetch_game_data_callback(const rc_api_server_response_t* s
     rc_client_process_resolved_hash(load_state);
   }
   else {
-    rc_client_subset_info_t** next_subset;
+    //rc_client_subset_info_t** next_subset;
     rc_client_subset_info_t* core_subset;
-    uint32_t subset_index;
+    //uint32_t subset_index;
 
     /* hash exists outside the load state - always update it */
     load_state->hash->game_id = fetch_game_data_response.id;
@@ -2185,25 +2185,25 @@ static void rc_client_fetch_game_data_callback(const rc_api_server_response_t* s
       }
     }
 
-    next_subset = &core_subset->next;
-    for (subset_index = 0; subset_index < fetch_game_data_response.num_subsets; ++subset_index) {
-      rc_api_subset_definition_t* api_subset = &fetch_game_data_response.subsets[subset_index];
-      rc_client_subset_info_t* subset;
+    //next_subset = &core_subset->next;
+    //for (subset_index = 0; subset_index < fetch_game_data_response.num_subsets; ++subset_index) {
+    //  rc_api_subset_definition_t* api_subset = &fetch_game_data_response.subsets[subset_index];
+    //  rc_client_subset_info_t* subset;
 
-      subset = (rc_client_subset_info_t*)rc_buffer_alloc(&load_state->game->buffer, sizeof(rc_client_subset_info_t));
-      memset(subset, 0, sizeof(*subset));
-      subset->public_.id = api_subset->id;
-      subset->active = 1;
-      snprintf(subset->public_.badge_name, sizeof(subset->public_.badge_name), "%s", api_subset->image_name);
-      subset->public_.badge_url = rc_buffer_strcpy(&load_state->game->buffer, api_subset->image_url);
-      subset->public_.title = rc_buffer_strcpy(&load_state->game->buffer, api_subset->title);
+    //  subset = (rc_client_subset_info_t*)rc_buffer_alloc(&load_state->game->buffer, sizeof(rc_client_subset_info_t));
+    //  memset(subset, 0, sizeof(*subset));
+    //  subset->public_.id = api_subset->id;
+    //  subset->active = 1;
+    //  snprintf(subset->public_.badge_name, sizeof(subset->public_.badge_name), "%s", api_subset->image_name);
+    //  subset->public_.badge_url = rc_buffer_strcpy(&load_state->game->buffer, api_subset->image_url);
+    //  subset->public_.title = rc_buffer_strcpy(&load_state->game->buffer, api_subset->title);
 
-      rc_client_copy_achievements(load_state, subset, api_subset->achievements, api_subset->num_achievements);
-      rc_client_copy_leaderboards(load_state, subset, api_subset->leaderboards, api_subset->num_leaderboards);
+    //  rc_client_copy_achievements(load_state, subset, api_subset->achievements, api_subset->num_achievements);
+    //  rc_client_copy_leaderboards(load_state, subset, api_subset->leaderboards, api_subset->num_leaderboards);
 
-      *next_subset = subset;
-      next_subset = &subset->next;
-    }
+    //  *next_subset = subset;
+    //  next_subset = &subset->next;
+    //}
 
     if (load_state->client->callbacks.post_process_game_data_response) {
       load_state->client->callbacks.post_process_game_data_response(server_response,

--- a/src/rc_client.c
+++ b/src/rc_client.c
@@ -80,7 +80,7 @@ typedef struct rc_client_load_state_t
 } rc_client_load_state_t;
 
 static void rc_client_process_resolved_hash(rc_client_load_state_t* load_state);
-static void rc_client_begin_fetch_game_data(rc_client_load_state_t* callback_data);
+static void rc_client_begin_fetch_game_sets(rc_client_load_state_t* callback_data);
 static void rc_client_hide_progress_tracker(rc_client_t* client, rc_client_game_info_t* game);
 static void rc_client_load_error(rc_client_load_state_t* load_state, int result, const char* error_message);
 static rc_client_async_handle_t* rc_client_load_game(rc_client_load_state_t* load_state, const char* hash, const char* file_path);
@@ -693,7 +693,7 @@ static void rc_client_login_callback(const rc_api_server_response_t* server_resp
       login_callback_data->callback(result, error_message, client, login_callback_data->callback_userdata);
 
     if (load_state && load_state->progress == RC_CLIENT_LOAD_GAME_STATE_AWAIT_LOGIN)
-      rc_client_begin_fetch_game_data(load_state);
+      rc_client_begin_fetch_game_sets(load_state);
   }
   else {
     client->user.username = rc_buffer_strcpy(&client->state.buffer, login_response.username);
@@ -717,7 +717,7 @@ static void rc_client_login_callback(const rc_api_server_response_t* server_resp
     RC_CLIENT_LOG_INFO_FORMATTED(client, "%s logged in successfully", login_response.display_name);
 
     if (load_state && load_state->progress == RC_CLIENT_LOAD_GAME_STATE_AWAIT_LOGIN)
-      rc_client_begin_fetch_game_data(load_state);
+      rc_client_begin_fetch_game_sets(load_state);
 
     if (login_callback_data->callback)
       login_callback_data->callback(RC_OK, NULL, client, login_callback_data->callback_userdata);
@@ -2087,10 +2087,10 @@ static void rc_client_copy_leaderboards(rc_client_load_state_t* load_state,
   subset->leaderboards = leaderboards;
 }
 
-static void rc_client_fetch_game_data_callback(const rc_api_server_response_t* server_response, void* callback_data)
+static void rc_client_fetch_game_sets_callback(const rc_api_server_response_t* server_response, void* callback_data)
 {
   rc_client_load_state_t* load_state = (rc_client_load_state_t*)callback_data;
-  rc_api_fetch_game_data_response_t fetch_game_data_response;
+  rc_api_fetch_game_sets_response_t fetch_game_sets_response;
   int outstanding_requests;
   const char* error_message;
   int result;
@@ -2107,8 +2107,8 @@ static void rc_client_fetch_game_data_callback(const rc_api_server_response_t* s
     return;
   }
 
-  result = rc_api_process_fetch_game_data_server_response(&fetch_game_data_response, server_response);
-  error_message = rc_client_server_error_message(&result, server_response->http_status_code, &fetch_game_data_response.response);
+  result = rc_api_process_fetch_game_sets_server_response(&fetch_game_sets_response, server_response);
+  error_message = rc_client_server_error_message(&result, server_response->http_status_code, &fetch_game_sets_response.response);
 
   outstanding_requests = rc_client_end_load_state(load_state);
 
@@ -2118,18 +2118,18 @@ static void rc_client_fetch_game_data_callback(const rc_api_server_response_t* s
   else if (outstanding_requests < 0) {
     /* previous load state was aborted, load_state was free'd */
   }
-  else if (fetch_game_data_response.id == 0) {
+  else if (fetch_game_sets_response.id == 0) {
     load_state->hash->game_id = 0;
     rc_client_process_resolved_hash(load_state);
   }
   else {
-    //rc_client_subset_info_t** next_subset;
-    rc_client_subset_info_t* core_subset;
-    //uint32_t subset_index;
+    rc_client_subset_info_t** next_subset;
+    rc_client_subset_info_t* first_subset = NULL;
+    uint32_t set_index;
 
     /* hash exists outside the load state - always update it */
-    load_state->hash->game_id = fetch_game_data_response.id;
-    RC_CLIENT_LOG_INFO_FORMATTED(load_state->client, "Identified game: %u \"%s\" (%s)", load_state->hash->game_id, fetch_game_data_response.title, load_state->hash->hash);
+    load_state->hash->game_id = fetch_game_sets_response.id;
+    RC_CLIENT_LOG_INFO_FORMATTED(load_state->client, "Identified game: %u \"%s\" (%s)", load_state->hash->game_id, fetch_game_sets_response.title, load_state->hash->hash);
 
     if (load_state->hash->hash[0] != '[') {
       /* not [NO HASH] or [SUBSETxx] */
@@ -2137,18 +2137,10 @@ static void rc_client_fetch_game_data_callback(const rc_api_server_response_t* s
       load_state->game->public_.hash = load_state->hash->hash;
     }
 
-    core_subset = (rc_client_subset_info_t*)rc_buffer_alloc(&load_state->game->buffer, sizeof(rc_client_subset_info_t));
-    memset(core_subset, 0, sizeof(*core_subset));
-    core_subset->public_.id = fetch_game_data_response.id;
-    core_subset->active = 1;
-    snprintf(core_subset->public_.badge_name, sizeof(core_subset->public_.badge_name), "%s", fetch_game_data_response.image_name);
-    core_subset->public_.badge_url = rc_buffer_strcpy(&load_state->game->buffer, fetch_game_data_response.image_url);
-    load_state->subset = core_subset;
-
     if (load_state->game->public_.console_id != RC_CONSOLE_UNKNOWN &&
-        fetch_game_data_response.console_id != load_state->game->public_.console_id) {
+        fetch_game_sets_response.console_id != load_state->game->public_.console_id) {
       RC_CLIENT_LOG_WARN_FORMATTED(load_state->client, "Data for game %u is for console %u, expecting console %u",
-        fetch_game_data_response.id, fetch_game_data_response.console_id, load_state->game->public_.console_id);
+        fetch_game_sets_response.id, fetch_game_sets_response.console_id, load_state->game->public_.console_id);
     }
 
     /* kick off the start session request while we process the game data */
@@ -2162,52 +2154,59 @@ static void rc_client_fetch_game_data_callback(const rc_api_server_response_t* s
     }
 
     /* process the game data */
-    rc_client_copy_achievements(load_state, core_subset,
-        fetch_game_data_response.achievements, fetch_game_data_response.num_achievements);
-    rc_client_copy_leaderboards(load_state, core_subset,
-        fetch_game_data_response.leaderboards, fetch_game_data_response.num_leaderboards);
+    next_subset = &first_subset;
+    for (set_index = 0; set_index < fetch_game_sets_response.num_sets; ++set_index) {
+      rc_api_achievement_set_definition_t* set = &fetch_game_sets_response.sets[set_index];
+      rc_client_subset_info_t* subset;
 
-    /* core set */
-    rc_mutex_lock(&load_state->client->state.mutex);
-    load_state->game->public_.title = rc_buffer_strcpy(&load_state->game->buffer, fetch_game_data_response.title);
-    load_state->game->subsets = core_subset;
-    load_state->game->public_.badge_name = core_subset->public_.badge_name;
-    load_state->game->public_.badge_url = core_subset->public_.badge_url;
-    load_state->game->public_.console_id = fetch_game_data_response.console_id;
-    rc_mutex_unlock(&load_state->client->state.mutex);
+      subset = (rc_client_subset_info_t*)rc_buffer_alloc(&load_state->game->buffer, sizeof(rc_client_subset_info_t));
+      memset(subset, 0, sizeof(*subset));
+      subset->public_.id = set->id;
+      subset->active = 1;
+      snprintf(subset->public_.badge_name, sizeof(subset->public_.badge_name), "%s", set->image_name);
+      subset->public_.badge_url = rc_buffer_strcpy(&load_state->game->buffer, set->image_url);
+      subset->public_.title = rc_buffer_strcpy(&load_state->game->buffer, set->title);
 
-    core_subset->public_.title = load_state->game->public_.title;
+      rc_client_copy_achievements(load_state, subset, set->achievements, set->num_achievements);
+      rc_client_copy_leaderboards(load_state, subset, set->leaderboards, set->num_leaderboards);
 
-    if (fetch_game_data_response.rich_presence_script && fetch_game_data_response.rich_presence_script[0]) {
-      result = rc_runtime_activate_richpresence(&load_state->game->runtime, fetch_game_data_response.rich_presence_script, NULL, 0);
-      if (result != RC_OK) {
-        RC_CLIENT_LOG_WARN_FORMATTED(load_state->client, "Parse error %d processing rich presence", result);
+      if (set->type == RC_ACHIEVEMENT_SET_TYPE_CORE) {
+        if (!first_subset)
+          next_subset = &subset->next;
+        subset->next = first_subset;
+        first_subset = subset;
+      }
+      else {
+        *next_subset = subset;
+        next_subset = &subset->next;
       }
     }
 
-    //next_subset = &core_subset->next;
-    //for (subset_index = 0; subset_index < fetch_game_data_response.num_subsets; ++subset_index) {
-    //  rc_api_subset_definition_t* api_subset = &fetch_game_data_response.subsets[subset_index];
-    //  rc_client_subset_info_t* subset;
+    if (!first_subset) {
+      rc_client_load_error(load_state, RC_NOT_FOUND, "Response contained no sets");
+    } else {
+      load_state->subset = first_subset;
 
-    //  subset = (rc_client_subset_info_t*)rc_buffer_alloc(&load_state->game->buffer, sizeof(rc_client_subset_info_t));
-    //  memset(subset, 0, sizeof(*subset));
-    //  subset->public_.id = api_subset->id;
-    //  subset->active = 1;
-    //  snprintf(subset->public_.badge_name, sizeof(subset->public_.badge_name), "%s", api_subset->image_name);
-    //  subset->public_.badge_url = rc_buffer_strcpy(&load_state->game->buffer, api_subset->image_url);
-    //  subset->public_.title = rc_buffer_strcpy(&load_state->game->buffer, api_subset->title);
+      /* core set */
+      rc_mutex_lock(&load_state->client->state.mutex);
+      load_state->game->public_.title = rc_buffer_strcpy(&load_state->game->buffer, fetch_game_sets_response.title);
+      load_state->game->subsets = first_subset;
+      load_state->game->public_.badge_name = first_subset->public_.badge_name;
+      load_state->game->public_.badge_url = first_subset->public_.badge_url;
+      load_state->game->public_.console_id = fetch_game_sets_response.console_id;
+      rc_mutex_unlock(&load_state->client->state.mutex);
 
-    //  rc_client_copy_achievements(load_state, subset, api_subset->achievements, api_subset->num_achievements);
-    //  rc_client_copy_leaderboards(load_state, subset, api_subset->leaderboards, api_subset->num_leaderboards);
+      if (fetch_game_sets_response.rich_presence_script && fetch_game_sets_response.rich_presence_script[0]) {
+        result = rc_runtime_activate_richpresence(&load_state->game->runtime, fetch_game_sets_response.rich_presence_script, NULL, 0);
+        if (result != RC_OK) {
+          RC_CLIENT_LOG_WARN_FORMATTED(load_state->client, "Parse error %d processing rich presence", result);
+        }
+      }
 
-    //  *next_subset = subset;
-    //  next_subset = &subset->next;
-    //}
-
-    if (load_state->client->callbacks.post_process_game_data_response) {
-      load_state->client->callbacks.post_process_game_data_response(server_response,
-        &fetch_game_data_response, load_state->client, load_state->callback_userdata);
+      if (load_state->client->callbacks.post_process_game_sets_response) {
+        load_state->client->callbacks.post_process_game_sets_response(server_response,
+          &fetch_game_sets_response, load_state->client, load_state->callback_userdata);
+      }
     }
 
     outstanding_requests = rc_client_end_load_state(load_state);
@@ -2220,7 +2219,7 @@ static void rc_client_fetch_game_data_callback(const rc_api_server_response_t* s
     }
   }
 
-  rc_api_destroy_fetch_game_data_response(&fetch_game_data_response);
+  rc_api_destroy_fetch_game_sets_response(&fetch_game_sets_response);
 }
 
 static rc_client_game_info_t* rc_client_allocate_game(void)
@@ -2449,7 +2448,7 @@ static void rc_client_process_resolved_hash(rc_client_load_state_t* load_state)
   }
 #endif
 
-  rc_client_begin_fetch_game_data(load_state);
+  rc_client_begin_fetch_game_sets(load_state);
 }
 
 void rc_client_load_unknown_game(rc_client_t* client, const char* tried_hashes)
@@ -2476,9 +2475,9 @@ void rc_client_load_unknown_game(rc_client_t* client, const char* tried_hashes)
   client->game = game;
 }
 
-static void rc_client_begin_fetch_game_data(rc_client_load_state_t* load_state)
+static void rc_client_begin_fetch_game_sets(rc_client_load_state_t* load_state)
 {
-  rc_api_fetch_game_data_request_t fetch_game_data_request;
+  rc_api_fetch_game_sets_request_t fetch_game_sets_request;
   rc_client_t* client = load_state->client;
   rc_api_request_t request;
   int result;
@@ -2502,26 +2501,26 @@ static void rc_client_begin_fetch_game_data(rc_client_load_state_t* load_state)
       return;
   }
 
-  memset(&fetch_game_data_request, 0, sizeof(fetch_game_data_request));
-  fetch_game_data_request.username = client->user.username;
-  fetch_game_data_request.api_token = client->user.token;
+  memset(&fetch_game_sets_request, 0, sizeof(fetch_game_sets_request));
+  fetch_game_sets_request.username = client->user.username;
+  fetch_game_sets_request.api_token = client->user.token;
 
   if (load_state->hash->is_unknown) /* lookup failed, but client provided a mapping */
-    fetch_game_data_request.game_id = load_state->hash->game_id;
+    fetch_game_sets_request.game_id = load_state->hash->game_id;
   else
-    fetch_game_data_request.game_hash = load_state->hash->hash;
+    fetch_game_sets_request.game_hash = load_state->hash->hash;
 
-  result = rc_api_init_fetch_game_data_request_hosted(&request, &fetch_game_data_request, &client->state.host);
+  result = rc_api_init_fetch_game_sets_request_hosted(&request, &fetch_game_sets_request, &client->state.host);
   if (result != RC_OK) {
     rc_client_load_error(load_state, result, rc_error_str(result));
     return;
   }
 
   rc_client_begin_load_state(load_state, RC_CLIENT_LOAD_GAME_STATE_IDENTIFYING_GAME, 1);
-  RC_CLIENT_LOG_VERBOSE_FORMATTED(client, "Fetching data for hash %s", fetch_game_data_request.game_hash);
+  RC_CLIENT_LOG_VERBOSE_FORMATTED(client, "Fetching data for hash %s", fetch_game_sets_request.game_hash);
 
   rc_client_begin_async(client, &load_state->async_handle);
-  client->callbacks.server_call(&request, rc_client_fetch_game_data_callback, load_state, client);
+  client->callbacks.server_call(&request, rc_client_fetch_game_sets_callback, load_state, client);
 
   rc_api_destroy_request(&request);
 }
@@ -2693,7 +2692,7 @@ static rc_client_async_handle_t* rc_client_load_game(rc_client_load_state_t* loa
   }
 #endif
   else {
-    rc_client_begin_fetch_game_data(load_state);
+    rc_client_begin_fetch_game_sets(load_state);
   }
 
   return (client->state.load == load_state) ? &load_state->async_handle : NULL;

--- a/src/rc_client_internal.h
+++ b/src/rc_client_internal.h
@@ -21,8 +21,8 @@ RC_BEGIN_C_DECLS
 \*****************************************************************************/
 
 struct rc_api_fetch_game_data_response_t;
-typedef void (RC_CCONV *rc_client_post_process_game_data_response_t)(const rc_api_server_response_t* server_response,
-              struct rc_api_fetch_game_data_response_t* game_data_response, rc_client_t* client, void* userdata);
+typedef void (RC_CCONV *rc_client_post_process_game_sets_response_t)(const rc_api_server_response_t* server_response,
+              struct rc_api_fetch_game_sets_response_t* game_sets_response, rc_client_t* client, void* userdata);
 typedef int (RC_CCONV *rc_client_can_submit_achievement_unlock_t)(uint32_t achievement_id, rc_client_t* client);
 typedef int (RC_CCONV *rc_client_can_submit_leaderboard_entry_t)(uint32_t leaderboard_id, rc_client_t* client);
 typedef int (RC_CCONV *rc_client_rich_presence_override_t)(rc_client_t* client, char buffer[], size_t buffersize);
@@ -36,7 +36,7 @@ typedef struct rc_client_callbacks_t {
   rc_client_message_callback_t log_call;
   rc_get_time_millisecs_func_t get_time_millisecs;
   rc_client_identify_hash_func_t identify_unknown_hash;
-  rc_client_post_process_game_data_response_t post_process_game_data_response;
+  rc_client_post_process_game_sets_response_t post_process_game_sets_response;
   rc_client_can_submit_achievement_unlock_t can_submit_achievement_unlock;
   rc_client_can_submit_leaderboard_entry_t can_submit_leaderboard_entry;
   rc_client_rich_presence_override_t rich_presence_override;

--- a/src/rc_client_internal.h
+++ b/src/rc_client_internal.h
@@ -20,7 +20,7 @@ RC_BEGIN_C_DECLS
 | Callbacks                                                                   |
 \*****************************************************************************/
 
-struct rc_api_fetch_game_data_response_t;
+struct rc_api_fetch_game_sets_response_t;
 typedef void (RC_CCONV *rc_client_post_process_game_sets_response_t)(const rc_api_server_response_t* server_response,
               struct rc_api_fetch_game_sets_response_t* game_sets_response, rc_client_t* client, void* userdata);
 typedef int (RC_CCONV *rc_client_can_submit_achievement_unlock_t)(uint32_t achievement_id, rc_client_t* client);

--- a/src/rcheevos/operand.c
+++ b/src/rcheevos/operand.c
@@ -307,6 +307,9 @@ void rc_operand_set_float_const(rc_operand_t* self, double value) {
 }
 
 int rc_operands_are_equal(const rc_operand_t* left, const rc_operand_t* right) {
+  if (left == right)
+    return 1;
+
   if (left->type != right->type)
     return 0;
 

--- a/test/rapi/test_rc_api_runtime.c
+++ b/test/rapi/test_rc_api_runtime.c
@@ -8,6 +8,16 @@
 
 #define DOREQUEST_URL "https://retroachievements.org/dorequest.php"
 
+static void init_server_response(rc_api_server_response_t* server_response,
+                                 int status_code, const char* body, size_t body_length) {
+  memset(server_response, 0, sizeof(*server_response));
+  server_response->body = body;
+  server_response->body_length = body_length;
+  server_response->http_status_code = status_code;
+}
+
+/* ----- resolve hash ----- */
+
 static void test_init_resolve_hash_request() {
   rc_api_resolve_hash_request_t resolve_hash_request;
   rc_api_request_t request;
@@ -90,6 +100,8 @@ static void test_process_resolve_hash_response_no_match() {
 
   rc_api_destroy_resolve_hash_response(&resolve_hash_response);
 }
+
+/* ----- fetch game data ----- */
 
 static void test_init_fetch_game_data_request() {
   rc_api_fetch_game_data_request_t fetch_game_data_request;
@@ -475,7 +487,7 @@ static void test_process_fetch_game_data_response_achievement_null_author()
   ASSERT_STR_EQUALS(fetch_game_data_response.rich_presence_script, "");
   ASSERT_NUM_EQUALS(fetch_game_data_response.num_achievements, 4);
   ASSERT_NUM_EQUALS(fetch_game_data_response.num_leaderboards, 0);
-  ASSERT_NUM_EQUALS(fetch_game_data_response.num_subsets, 0);
+  //ASSERT_NUM_EQUALS(fetch_game_data_response.num_subsets, 0);
 
   ASSERT_PTR_NOT_NULL(fetch_game_data_response.achievements);
   achievement = fetch_game_data_response.achievements;
@@ -563,7 +575,7 @@ static void test_process_fetch_game_data_response_leaderboards() {
   ASSERT_STR_EQUALS(fetch_game_data_response.rich_presence_script, "");
   ASSERT_NUM_EQUALS(fetch_game_data_response.num_achievements, 0);
   ASSERT_NUM_EQUALS(fetch_game_data_response.num_leaderboards, 3);
-  ASSERT_NUM_EQUALS(fetch_game_data_response.num_subsets, 0);
+  //ASSERT_NUM_EQUALS(fetch_game_data_response.num_subsets, 0);
 
   ASSERT_PTR_NOT_NULL(fetch_game_data_response.leaderboards);
   leaderboard = fetch_game_data_response.leaderboards;
@@ -670,66 +682,342 @@ static void test_process_fetch_game_data_response_rich_presence_tab() {
   rc_api_destroy_fetch_game_data_response(&fetch_game_data_response);
 }
 
-static void test_process_fetch_game_data_response_subsets() {
-  rc_api_fetch_game_data_response_t fetch_game_data_response;
-  const char* server_response = "{\"Success\":true,\"PatchData\":{"
-    "\"ID\":20,\"Title\":\"Another Amazing Game\",\"ConsoleID\":19,\"ImageIcon\":\"/Images/112233.png\","
-    "\"Achievements\":["
-      "{\"ID\":5501,\"Title\":\"Ach1\",\"Description\":\"Desc1\",\"Flags\":3,\"Points\":5,"
-       "\"MemAddr\":\"0=1\",\"Author\":\"User1\",\"BadgeName\":\"00234\",\"Rarity\":100.0,\"RarityHardcore\":66.67,"
-       "\"Created\":1367266583,\"Modified\":1376929305},"
-      "{\"ID\":5502,\"Title\":\"Ach2\",\"Description\":\"Desc2\",\"Flags\":3,\"Points\":2,"
-       "\"MemAddr\":\"0=2\",\"Author\":\"User1\",\"BadgeName\":\"00235\",\"Rarity\":57.43,\"RarityHardcore\":57.43,"
-       "\"Created\":1376970283,\"Modified\":1376970283}"
-    "],\"Leaderboards\":["
-      "{\"ID\":4401,\"Title\":\"Leaderboard1\",\"Description\":\"Desc1\","
-       "\"Mem\":\"0=1\",\"Format\":\"SCORE\"}"
-    "],\"Sets\":["
-      "{\"GameAchievementSetID\":9999,\"SetTitle\":\"Bonus\",\"ImageIcon\":\"/Images/332233.png\","
-       "\"ImageIconURL\":\"http://host/Images/332233.png\","
-       "\"Achievements\":["
-        "{\"ID\":5503,\"Title\":\"Ach3\",\"Description\":\"Desc3\",\"Flags\":5,\"Points\":0,"
-         "\"MemAddr\":\"0=3\",\"Author\":\"User2\",\"BadgeName\":\"00236\",\"Rarity\":6.8,\"RarityHardcore\":0,"
-         "\"Created\":1376969412,\"Modified\":1376969412},"
-        "{\"ID\":5504,\"Title\":\"Ach4\",\"Description\":\"Desc4\",\"Flags\":5,\"Points\":0,"
-         "\"MemAddr\":\"0=3\",\"Author\":\"User2\",\"BadgeName\":\"00236\","
-         "\"Created\":1376969412,\"Modified\":1376969412}"
-       "],\"Leaderboards\":["
-        "{\"ID\":4402,\"Title\":\"Leaderboard2\",\"Description\":\"Desc2\","
-         "\"Mem\":\"0=1\",\"Format\":\"SECS\",\"LowerIsBetter\":false,\"Hidden\":true},"
-        "{\"ID\":4403,\"Title\":\"Leaderboard3\",\"Description\":\"Desc3\","
-         "\"Mem\":\"0=1\",\"Format\":\"UNKNOWN\",\"LowerIsBetter\":true,\"Hidden\":false}"
-       "]"
-      "}"
-    "]}}";
+/* ----- fetch game sets ----- */
+
+static void test_init_fetch_game_sets_request() {
+  rc_api_fetch_game_sets_request_t fetch_game_sets_request;
+  rc_api_request_t request;
+
+  memset(&fetch_game_sets_request, 0, sizeof(fetch_game_sets_request));
+  fetch_game_sets_request.username = "Username";
+  fetch_game_sets_request.api_token = "API_TOKEN";
+  fetch_game_sets_request.game_hash = "ABCDEF0123456789";
+
+  ASSERT_NUM_EQUALS(rc_api_init_fetch_game_sets_request(&request, &fetch_game_sets_request), RC_OK);
+  ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
+  ASSERT_STR_EQUALS(request.post_data, "r=hashdata&u=Username&t=API_TOKEN&m=ABCDEF0123456789");
+  ASSERT_STR_EQUALS(request.content_type, RC_CONTENT_TYPE_URLENCODED);
+
+  rc_api_destroy_request(&request);
+}
+
+static void test_init_fetch_game_sets_request_no_hash() {
+  rc_api_fetch_game_sets_request_t fetch_game_sets_request;
+  rc_api_request_t request;
+
+  memset(&fetch_game_sets_request, 0, sizeof(fetch_game_sets_request));
+  fetch_game_sets_request.username = "Username";
+  fetch_game_sets_request.api_token = "API_TOKEN";
+
+  ASSERT_NUM_EQUALS(rc_api_init_fetch_game_sets_request(&request, &fetch_game_sets_request), RC_INVALID_STATE);
+
+  rc_api_destroy_request(&request);
+}
+
+static void test_process_fetch_game_sets_response_empty() {
+  rc_api_achievement_set_definition_t* set;
+  rc_api_fetch_game_sets_response_t fetch_game_sets_response;
+  const char server_response[] = "{\"Success\":true,"
+    "\"GameId\":177,\"Title\":\"My Game\",\"ConsoleId\":23,"
+    "\"ImageIconUrl\":\"http://server/Images/012345.png\","
+    "\"RichPresenceGameId\":177,\"RichPresencePatch\":\"\",\"Sets\":[{"
+        "\"AchievementSetId\":192,\"GameId\":177,\"Title\":null,\"Type\":\"core\","
+        "\"ImageIconUrl\":\"http://server/Images/012345.png\","
+        "\"Achievements\":[],\"Leaderboards\":[]"
+    "}]}";
+
+  rc_api_server_response_t fetch_game_sets_server_response;
+  init_server_response(&fetch_game_sets_server_response, 200, server_response, sizeof(server_response) - 1);
+
+  memset(&fetch_game_sets_response, 0, sizeof(fetch_game_sets_response));
+
+  ASSERT_NUM_EQUALS(rc_api_process_fetch_game_sets_server_response(&fetch_game_sets_response, &fetch_game_sets_server_response), RC_OK);
+  ASSERT_NUM_EQUALS(fetch_game_sets_response.response.succeeded, 1);
+  ASSERT_PTR_NULL(fetch_game_sets_response.response.error_message);
+  ASSERT_NUM_EQUALS(fetch_game_sets_response.id, 177);
+  ASSERT_STR_EQUALS(fetch_game_sets_response.title, "My Game");
+  ASSERT_NUM_EQUALS(fetch_game_sets_response.console_id, 23);
+  ASSERT_STR_EQUALS(fetch_game_sets_response.image_name, "012345");
+  ASSERT_STR_EQUALS(fetch_game_sets_response.image_url, "http://server/Images/012345.png");
+  ASSERT_STR_EQUALS(fetch_game_sets_response.rich_presence_script, "");
+  ASSERT_NUM_EQUALS(fetch_game_sets_response.session_game_id, 177);
+
+  ASSERT_NUM_EQUALS(fetch_game_sets_response.num_sets, 1);
+  set = &fetch_game_sets_response.sets[0];
+  ASSERT_NUM_EQUALS(set->id, 192);
+  ASSERT_NUM_EQUALS(set->game_id, 177);
+  ASSERT_STR_EQUALS(set->title, "My Game");
+  ASSERT_NUM_EQUALS(set->type, RC_ACHIEVEMENT_SET_TYPE_CORE);
+  ASSERT_STR_EQUALS(set->image_name, "012345");
+  ASSERT_STR_EQUALS(set->image_url, "http://server/Images/012345.png");
+  ASSERT_NUM_EQUALS(set->num_achievements, 0);
+  ASSERT_NUM_EQUALS(set->num_leaderboards, 0);
+
+  rc_api_destroy_fetch_game_sets_response(&fetch_game_sets_response);
+}
+
+static void test_process_fetch_game_sets_response_invalid_credentials() {
+  rc_api_fetch_game_sets_response_t fetch_game_sets_response;
+  const char server_response[] = "{\"Success\":false,\"Error\":\"Credentials invalid (0)\"}";
+  rc_api_server_response_t fetch_game_sets_server_response;
+  init_server_response(&fetch_game_sets_server_response, 403, server_response, sizeof(server_response) - 1);
+
+  memset(&fetch_game_sets_response, 0, sizeof(fetch_game_sets_response));
+
+  ASSERT_NUM_EQUALS(rc_api_process_fetch_game_sets_server_response(&fetch_game_sets_response, &fetch_game_sets_server_response), RC_OK);
+  ASSERT_NUM_EQUALS(fetch_game_sets_response.response.succeeded, 0);
+  ASSERT_STR_EQUALS(fetch_game_sets_response.response.error_message, "Credentials invalid (0)");
+  ASSERT_NUM_EQUALS(fetch_game_sets_response.id, 0);
+  ASSERT_PTR_NULL(fetch_game_sets_response.title);
+  ASSERT_NUM_EQUALS(fetch_game_sets_response.console_id, 0);
+  ASSERT_PTR_NULL(fetch_game_sets_response.image_name);
+  ASSERT_PTR_NULL(fetch_game_sets_response.rich_presence_script);
+  ASSERT_NUM_EQUALS(fetch_game_sets_response.num_sets, 0);
+
+  rc_api_destroy_fetch_game_sets_response(&fetch_game_sets_response);
+}
+
+static void test_process_fetch_game_sets_response_not_found() {
+  rc_api_fetch_game_sets_response_t fetch_game_sets_response;
+  const char server_response[] = "{\"Success\":false,\"Error\":\"Unknown game\",\"Code\":\"not_found\",\"Status\":404}";
+  rc_api_server_response_t fetch_game_sets_server_response;
+  init_server_response(&fetch_game_sets_server_response, 404, server_response, sizeof(server_response) - 1);
+
+  memset(&fetch_game_sets_response, 0, sizeof(fetch_game_sets_response));
+
+  ASSERT_NUM_EQUALS(rc_api_process_fetch_game_sets_server_response(&fetch_game_sets_response, &fetch_game_sets_server_response), RC_NOT_FOUND);
+  ASSERT_NUM_EQUALS(fetch_game_sets_response.response.succeeded, 0);
+  ASSERT_STR_EQUALS(fetch_game_sets_response.response.error_message, "Unknown game");
+  ASSERT_NUM_EQUALS(fetch_game_sets_response.id, 0);
+  ASSERT_PTR_NULL(fetch_game_sets_response.title);
+  ASSERT_NUM_EQUALS(fetch_game_sets_response.console_id, 0);
+  ASSERT_PTR_NULL(fetch_game_sets_response.image_name);
+  ASSERT_PTR_NULL(fetch_game_sets_response.rich_presence_script);
+  ASSERT_NUM_EQUALS(fetch_game_sets_response.num_sets, 0);
+
+  rc_api_destroy_fetch_game_sets_response(&fetch_game_sets_response);
+}
+
+static void test_process_fetch_game_sets_response_achievements() {
+  rc_api_achievement_set_definition_t* set;
   rc_api_achievement_definition_t* achievement;
-  rc_api_leaderboard_definition_t* leaderboard;
-  rc_api_subset_definition_t* subset;
+  rc_api_fetch_game_sets_response_t fetch_game_sets_response;
+  const char server_response[] = "{\"Success\":true,"
+    "\"GameId\":20,\"Title\":\"Another Amazing Game\",\"ConsoleId\":19,"
+    "\"ImageIconUrl\":\"http://server/Images/112233.png\","
+    "\"RichPresenceGameId\":20,\"RichPresencePatch\":\"\",\"Sets\":[{"
+        "\"AchievementSetId\":192,\"GameId\":20,\"Title\":null,\"Type\":\"core\","
+        "\"ImageIconUrl\":\"http://server/Images/112233.png\","
+        "\"Achievements\":["
+            "{\"ID\":5501,\"Title\":\"Ach1\",\"Description\":\"Desc1\",\"Flags\":3,\"Points\":5,"
+             "\"MemAddr\":\"0=1\",\"Author\":\"User1\",\"BadgeName\":\"00234\",\"Type\":\"\","
+             "\"Rarity\":100.0,\"RarityHardcore\":66.67,\"Created\":1367266583,\"Modified\":1376929305},"
+            "{\"ID\":5502,\"Title\":\"Ach2\",\"Description\":\"Desc2\",\"Flags\":3,\"Points\":2,"
+             "\"MemAddr\":\"0=2\",\"Author\":\"User1\",\"BadgeName\":\"00235\",\"Type\":\"missable\","
+             "\"Rarity\":57.43,\"RarityHardcore\":57.43,\"Created\":1376970283,\"Modified\":1376970283},"
+            "{\"ID\":5503,\"Title\":\"Ach3\",\"Description\":\"Desc3\",\"Flags\":5,\"Points\":0,"
+             "\"MemAddr\":\"0=3\",\"Author\":\"User2\",\"BadgeName\":\"00236\",\"Type\":\"progression\","
+             "\"Rarity\":6.8,\"RarityHardcore\":0,\"Created\":1376969412,\"Modified\":1376969412},"
+            "{\"ID\":5504,\"Title\":\"Ach4\",\"Description\":\"Desc4\",\"Flags\":3,\"Points\":10,"
+             "\"MemAddr\":\"0=4\",\"Author\":null,\"BadgeName\":\"00236\",\"Type\":\"win_condition\","
+             "\"Created\":1504474554,\"Modified\":1504474554},"
+            "{\"ID\":5505,\"Title\":\"Ach5 [m]\",\"Description\":\"Desc5\",\"Flags\":3,\"Points\":10,"
+             "\"MemAddr\":\"0=4\",\"Author\":\"User1\",\"BadgeName\":\"00236\",\"Type\":\"\","
+             "\"Created\":1504474554,\"Modified\":1504474554},"
+            "{\"ID\":5506,\"Title\":\"[m] Ach6\",\"Description\":\"Desc6\",\"Flags\":3,\"Points\":10,"
+             "\"MemAddr\":\"0=4\",\"Author\":\"User1\",\"BadgeName\":\"00236\",\"Type\":\"\","
+             "\"Created\":1504474554,\"Modified\":1504474554},"
+            "{\"ID\":5507,\"Title\":\"Ach7\",\"Description\":\"Desc7\",\"Flags\":3,\"Points\":5,"
+             "\"MemAddr\":\"0=1\",\"Author\":\"User1\",\"BadgeName\":\"00234\","
+             "\"Created\":1367266583,\"Modified\":1376929305}"
+        "],\"Leaderboards\":[]"
+    "}]}";
+  rc_api_server_response_t fetch_game_sets_server_response;
+  init_server_response(&fetch_game_sets_server_response, 200, server_response, sizeof(server_response) - 1);
 
-  memset(&fetch_game_data_response, 0, sizeof(fetch_game_data_response));
+  memset(&fetch_game_sets_response, 0, sizeof(fetch_game_sets_response));
 
-  ASSERT_NUM_EQUALS(rc_api_process_fetch_game_data_response(&fetch_game_data_response, server_response), RC_OK);
-  ASSERT_NUM_EQUALS(fetch_game_data_response.response.succeeded, 1);
-  ASSERT_PTR_NULL(fetch_game_data_response.response.error_message);
+  ASSERT_NUM_EQUALS(rc_api_process_fetch_game_sets_server_response(&fetch_game_sets_response, &fetch_game_sets_server_response), RC_OK);
+  ASSERT_NUM_EQUALS(fetch_game_sets_response.response.succeeded, 1);
+  ASSERT_PTR_NULL(fetch_game_sets_response.response.error_message);
+  ASSERT_NUM_EQUALS(fetch_game_sets_response.id, 20);
+  ASSERT_STR_EQUALS(fetch_game_sets_response.title, "Another Amazing Game");
+  ASSERT_NUM_EQUALS(fetch_game_sets_response.console_id, 19);
+  ASSERT_STR_EQUALS(fetch_game_sets_response.image_name, "112233");
+  ASSERT_STR_EQUALS(fetch_game_sets_response.image_url, "http://server/Images/112233.png");
+  ASSERT_STR_EQUALS(fetch_game_sets_response.rich_presence_script, "");
+  ASSERT_NUM_EQUALS(fetch_game_sets_response.session_game_id, 20);
 
-  ASSERT_NUM_EQUALS(fetch_game_data_response.num_achievements, 2);
-  ASSERT_PTR_NOT_NULL(fetch_game_data_response.achievements);
-  achievement = fetch_game_data_response.achievements;
+  ASSERT_NUM_EQUALS(fetch_game_sets_response.num_sets, 1);
+  set = &fetch_game_sets_response.sets[0];
+  ASSERT_NUM_EQUALS(set->id, 192);
+  ASSERT_NUM_EQUALS(set->game_id, 20);
+  ASSERT_STR_EQUALS(set->title, "Another Amazing Game");
+  ASSERT_NUM_EQUALS(set->type, RC_ACHIEVEMENT_SET_TYPE_CORE);
+  ASSERT_STR_EQUALS(set->image_name, "112233");
+  ASSERT_STR_EQUALS(set->image_url, "http://server/Images/112233.png");
+  ASSERT_NUM_EQUALS(set->num_achievements, 7);
+  ASSERT_NUM_EQUALS(set->num_leaderboards, 0);
+
+  ASSERT_PTR_NOT_NULL(set->achievements);
+  achievement = set->achievements;
 
   ASSERT_NUM_EQUALS(achievement->id, 5501);
   ASSERT_STR_EQUALS(achievement->title, "Ach1");
+  ASSERT_STR_EQUALS(achievement->description, "Desc1");
+  ASSERT_NUM_EQUALS(achievement->category, RC_ACHIEVEMENT_CATEGORY_CORE);
+  ASSERT_NUM_EQUALS(achievement->points, 5);
+  ASSERT_STR_EQUALS(achievement->definition, "0=1");
+  ASSERT_STR_EQUALS(achievement->author, "User1");
+  ASSERT_STR_EQUALS(achievement->badge_name, "00234");
+  ASSERT_NUM_EQUALS(achievement->type, RC_ACHIEVEMENT_TYPE_STANDARD);
   ASSERT_FLOAT_EQUALS(achievement->rarity, 100.0f);
   ASSERT_FLOAT_EQUALS(achievement->rarity_hardcore, 66.67f);
+  ASSERT_NUM_EQUALS(achievement->created, 1367266583);
+  ASSERT_NUM_EQUALS(achievement->updated, 1376929305);
 
   ++achievement;
   ASSERT_NUM_EQUALS(achievement->id, 5502);
   ASSERT_STR_EQUALS(achievement->title, "Ach2");
+  ASSERT_STR_EQUALS(achievement->description, "Desc2");
+  ASSERT_NUM_EQUALS(achievement->category, RC_ACHIEVEMENT_CATEGORY_CORE);
+  ASSERT_NUM_EQUALS(achievement->points, 2);
+  ASSERT_STR_EQUALS(achievement->definition, "0=2");
+  ASSERT_STR_EQUALS(achievement->author, "User1");
+  ASSERT_STR_EQUALS(achievement->badge_name, "00235");
+  ASSERT_NUM_EQUALS(achievement->type, RC_ACHIEVEMENT_TYPE_MISSABLE);
   ASSERT_FLOAT_EQUALS(achievement->rarity, 57.43f);
   ASSERT_FLOAT_EQUALS(achievement->rarity_hardcore, 57.43f);
+  ASSERT_NUM_EQUALS(achievement->created, 1376970283);
+  ASSERT_NUM_EQUALS(achievement->updated, 1376970283);
 
-  ASSERT_NUM_EQUALS(fetch_game_data_response.num_leaderboards, 1);
-  ASSERT_PTR_NOT_NULL(fetch_game_data_response.leaderboards);
-  leaderboard = fetch_game_data_response.leaderboards;
+  ++achievement;
+  ASSERT_NUM_EQUALS(achievement->id, 5503);
+  ASSERT_STR_EQUALS(achievement->title, "Ach3");
+  ASSERT_STR_EQUALS(achievement->description, "Desc3");
+  ASSERT_NUM_EQUALS(achievement->category, RC_ACHIEVEMENT_CATEGORY_UNOFFICIAL);
+  ASSERT_NUM_EQUALS(achievement->points, 0);
+  ASSERT_STR_EQUALS(achievement->definition, "0=3");
+  ASSERT_STR_EQUALS(achievement->author, "User2");
+  ASSERT_STR_EQUALS(achievement->badge_name, "00236");
+  ASSERT_NUM_EQUALS(achievement->type, RC_ACHIEVEMENT_TYPE_PROGRESSION);
+  ASSERT_FLOAT_EQUALS(achievement->rarity, 6.8f);
+  ASSERT_FLOAT_EQUALS(achievement->rarity_hardcore, 0.0f);
+  ASSERT_NUM_EQUALS(achievement->created, 1376969412);
+  ASSERT_NUM_EQUALS(achievement->updated, 1376969412);
+
+  ++achievement;
+  ASSERT_NUM_EQUALS(achievement->id, 5504);
+  ASSERT_STR_EQUALS(achievement->title, "Ach4");
+  ASSERT_STR_EQUALS(achievement->description, "Desc4");
+  ASSERT_NUM_EQUALS(achievement->category, RC_ACHIEVEMENT_CATEGORY_CORE);
+  ASSERT_NUM_EQUALS(achievement->points, 10);
+  ASSERT_STR_EQUALS(achievement->definition, "0=4");
+  ASSERT_STR_EQUALS(achievement->author, ""); /* null author */
+  ASSERT_STR_EQUALS(achievement->badge_name, "00236");
+  ASSERT_NUM_EQUALS(achievement->type, RC_ACHIEVEMENT_TYPE_WIN);
+  ASSERT_FLOAT_EQUALS(achievement->rarity, 100.0f);
+  ASSERT_FLOAT_EQUALS(achievement->rarity_hardcore, 100.0f);
+  ASSERT_NUM_EQUALS(achievement->created, 1504474554);
+  ASSERT_NUM_EQUALS(achievement->updated, 1504474554);
+
+  ++achievement;
+  ASSERT_NUM_EQUALS(achievement->id, 5505);
+  ASSERT_STR_EQUALS(achievement->title, "Ach5"); /* [m] stripped */
+  ASSERT_STR_EQUALS(achievement->description, "Desc5");
+  ASSERT_NUM_EQUALS(achievement->category, RC_ACHIEVEMENT_CATEGORY_CORE);
+  ASSERT_NUM_EQUALS(achievement->points, 10);
+  ASSERT_STR_EQUALS(achievement->definition, "0=4");
+  ASSERT_STR_EQUALS(achievement->author, "User1");
+  ASSERT_STR_EQUALS(achievement->badge_name, "00236");
+  ASSERT_NUM_EQUALS(achievement->type, RC_ACHIEVEMENT_TYPE_MISSABLE);
+  ASSERT_FLOAT_EQUALS(achievement->rarity, 100.0f);
+  ASSERT_FLOAT_EQUALS(achievement->rarity_hardcore, 100.0f);
+  ASSERT_NUM_EQUALS(achievement->created, 1504474554);
+  ASSERT_NUM_EQUALS(achievement->updated, 1504474554);
+
+  ++achievement;
+  ASSERT_NUM_EQUALS(achievement->id, 5506);
+  ASSERT_STR_EQUALS(achievement->title, "Ach6"); /* [m] stripped */
+  ASSERT_STR_EQUALS(achievement->description, "Desc6");
+  ASSERT_NUM_EQUALS(achievement->category, RC_ACHIEVEMENT_CATEGORY_CORE);
+  ASSERT_NUM_EQUALS(achievement->points, 10);
+  ASSERT_STR_EQUALS(achievement->definition, "0=4");
+  ASSERT_STR_EQUALS(achievement->author, "User1");
+  ASSERT_STR_EQUALS(achievement->badge_name, "00236");
+  ASSERT_NUM_EQUALS(achievement->type, RC_ACHIEVEMENT_TYPE_MISSABLE);
+  ASSERT_FLOAT_EQUALS(achievement->rarity, 100.0f);
+  ASSERT_FLOAT_EQUALS(achievement->rarity_hardcore, 100.0f);
+  ASSERT_NUM_EQUALS(achievement->created, 1504474554);
+  ASSERT_NUM_EQUALS(achievement->updated, 1504474554);
+
+  ++achievement;
+  ASSERT_NUM_EQUALS(achievement->id, 5507);
+  ASSERT_STR_EQUALS(achievement->title, "Ach7");
+  ASSERT_STR_EQUALS(achievement->description, "Desc7");
+  ASSERT_NUM_EQUALS(achievement->category, RC_ACHIEVEMENT_CATEGORY_CORE);
+  ASSERT_NUM_EQUALS(achievement->points, 5);
+  ASSERT_STR_EQUALS(achievement->definition, "0=1");
+  ASSERT_STR_EQUALS(achievement->author, "User1");
+  ASSERT_STR_EQUALS(achievement->badge_name, "00234");
+  ASSERT_NUM_EQUALS(achievement->type, RC_ACHIEVEMENT_TYPE_STANDARD); /* no type specified */
+  ASSERT_FLOAT_EQUALS(achievement->rarity, 100.0f);
+  ASSERT_FLOAT_EQUALS(achievement->rarity_hardcore, 100.0f);
+  ASSERT_NUM_EQUALS(achievement->created, 1367266583);
+  ASSERT_NUM_EQUALS(achievement->updated, 1376929305);
+
+  rc_api_destroy_fetch_game_sets_response(&fetch_game_sets_response);
+}
+
+static void test_process_fetch_game_sets_response_leaderboards() {
+  rc_api_achievement_set_definition_t* set;
+  rc_api_leaderboard_definition_t* leaderboard;
+  rc_api_fetch_game_sets_response_t fetch_game_sets_response;
+  const char server_response[] = "{\"Success\":true,"
+    "\"GameId\":20,\"Title\":\"Another Amazing Game\",\"ConsoleId\":19,"
+    "\"ImageIconUrl\":\"http://server/Images/112233.png\","
+    "\"RichPresenceGameId\":20,\"RichPresencePatch\":\"\",\"Sets\":[{"
+        "\"AchievementSetId\":192,\"GameId\":20,\"Title\":null,\"Type\":\"core\","
+        "\"ImageIconUrl\":\"http://server/Images/112233.png\","
+        "\"Achievements\":[],\"Leaderboards\":["
+            "{\"ID\":4401,\"Title\":\"Leaderboard1\",\"Description\":\"Desc1\","
+             "\"Mem\":\"0=1\",\"Format\":\"SCORE\"},"
+            "{\"ID\":4402,\"Title\":\"Leaderboard2\",\"Description\":\"Desc2\","
+             "\"Mem\":\"0=1\",\"Format\":\"SECS\",\"LowerIsBetter\":false,\"Hidden\":true},"
+            "{\"ID\":4403,\"Title\":\"Leaderboard3\",\"Description\":\"Desc3\","
+             "\"Mem\":\"0=1\",\"Format\":\"UNKNOWN\",\"LowerIsBetter\":true,\"Hidden\":false}"
+        "]"
+    "}]}";
+
+  rc_api_server_response_t fetch_game_sets_server_response;
+  init_server_response(&fetch_game_sets_server_response, 200, server_response, sizeof(server_response) - 1);
+
+  memset(&fetch_game_sets_response, 0, sizeof(fetch_game_sets_response));
+
+  ASSERT_NUM_EQUALS(rc_api_process_fetch_game_sets_server_response(&fetch_game_sets_response, &fetch_game_sets_server_response), RC_OK);
+  ASSERT_NUM_EQUALS(fetch_game_sets_response.response.succeeded, 1);
+  ASSERT_PTR_NULL(fetch_game_sets_response.response.error_message);
+  ASSERT_NUM_EQUALS(fetch_game_sets_response.id, 20);
+  ASSERT_STR_EQUALS(fetch_game_sets_response.title, "Another Amazing Game");
+  ASSERT_NUM_EQUALS(fetch_game_sets_response.console_id, 19);
+  ASSERT_STR_EQUALS(fetch_game_sets_response.image_name, "112233");
+  ASSERT_STR_EQUALS(fetch_game_sets_response.image_url, "http://server/Images/112233.png");
+  ASSERT_STR_EQUALS(fetch_game_sets_response.rich_presence_script, "");
+  ASSERT_NUM_EQUALS(fetch_game_sets_response.session_game_id, 20);
+
+  ASSERT_NUM_EQUALS(fetch_game_sets_response.num_sets, 1);
+  set = &fetch_game_sets_response.sets[0];
+  ASSERT_NUM_EQUALS(set->id, 192);
+  ASSERT_NUM_EQUALS(set->game_id, 20);
+  ASSERT_STR_EQUALS(set->title, "Another Amazing Game");
+  ASSERT_NUM_EQUALS(set->type, RC_ACHIEVEMENT_SET_TYPE_CORE);
+  ASSERT_STR_EQUALS(set->image_name, "112233");
+  ASSERT_STR_EQUALS(set->image_url, "http://server/Images/112233.png");
+  ASSERT_NUM_EQUALS(set->num_achievements, 0);
+  ASSERT_NUM_EQUALS(set->num_leaderboards, 3);
+
+  ASSERT_PTR_NOT_NULL(set->leaderboards);
+  leaderboard = set->leaderboards;
 
   ASSERT_NUM_EQUALS(leaderboard->id, 4401);
   ASSERT_STR_EQUALS(leaderboard->title, "Leaderboard1");
@@ -739,34 +1027,7 @@ static void test_process_fetch_game_data_response_subsets() {
   ASSERT_NUM_EQUALS(leaderboard->lower_is_better, 0);
   ASSERT_NUM_EQUALS(leaderboard->hidden, 0);
 
-  ASSERT_NUM_EQUALS(fetch_game_data_response.num_subsets, 1);
-  ASSERT_PTR_NOT_NULL(fetch_game_data_response.subsets);
-  subset = fetch_game_data_response.subsets;
-
-  ASSERT_NUM_EQUALS(subset->id, 9999);
-  ASSERT_STR_EQUALS(subset->title, "Bonus");
-  ASSERT_STR_EQUALS(subset->image_name, "332233");
-  ASSERT_STR_EQUALS(subset->image_url, "http://host/Images/332233.png");
-
-  ASSERT_NUM_EQUALS(subset->num_achievements, 2);
-  ASSERT_PTR_NOT_NULL(subset->achievements);
-  achievement = subset->achievements;
-
-  ASSERT_NUM_EQUALS(achievement->id, 5503);
-  ASSERT_STR_EQUALS(achievement->title, "Ach3");
-  ASSERT_FLOAT_EQUALS(achievement->rarity, 6.8f);
-  ASSERT_FLOAT_EQUALS(achievement->rarity_hardcore, 0.0f);
-
-  ++achievement;
-  ASSERT_NUM_EQUALS(achievement->id, 5504);
-  ASSERT_STR_EQUALS(achievement->title, "Ach4");
-  ASSERT_FLOAT_EQUALS(achievement->rarity, 100.0f);
-  ASSERT_FLOAT_EQUALS(achievement->rarity_hardcore, 100.0f);
-
-  ASSERT_NUM_EQUALS(subset->num_leaderboards, 2);
-  ASSERT_PTR_NOT_NULL(subset->leaderboards);
-  leaderboard = subset->leaderboards;
-
+  ++leaderboard;
   ASSERT_NUM_EQUALS(leaderboard->id, 4402);
   ASSERT_STR_EQUALS(leaderboard->title, "Leaderboard2");
   ASSERT_STR_EQUALS(leaderboard->description, "Desc2");
@@ -784,8 +1045,385 @@ static void test_process_fetch_game_data_response_subsets() {
   ASSERT_NUM_EQUALS(leaderboard->lower_is_better, 1);
   ASSERT_NUM_EQUALS(leaderboard->hidden, 0);
 
-  rc_api_destroy_fetch_game_data_response(&fetch_game_data_response);
+  rc_api_destroy_fetch_game_sets_response(&fetch_game_sets_response);
 }
+
+static void test_process_fetch_game_sets_response_rich_presence() {
+  rc_api_achievement_set_definition_t* set;
+  rc_api_fetch_game_sets_response_t fetch_game_sets_response;
+  const char server_response[] = "{\"Success\":true,"
+    "\"GameId\":99,\"Title\":\"Some Other Game\",\"ConsoleId\":2,"
+    "\"ImageIconUrl\":\"http://server/Images/000001.png\","
+    "\"RichPresenceGameId\":99,\"RichPresencePatch\":\"Display:\\r\\nTest\\r\\n\",\"Sets\":[{"
+        "\"AchievementSetId\":106,\"GameId\":99,\"Title\":null,\"Type\":\"core\","
+        "\"ImageIconUrl\":\"http://server/Images/000001.png\","
+        "\"Achievements\":[],\"Leaderboards\":[]"
+    "}]}";
+
+  memset(&fetch_game_sets_response, 0, sizeof(fetch_game_sets_response));
+  rc_api_server_response_t fetch_game_sets_server_response;
+  init_server_response(&fetch_game_sets_server_response, 200, server_response, sizeof(server_response) - 1);
+
+  ASSERT_NUM_EQUALS(rc_api_process_fetch_game_sets_server_response(&fetch_game_sets_response, &fetch_game_sets_server_response), RC_OK);
+  ASSERT_NUM_EQUALS(fetch_game_sets_response.response.succeeded, 1);
+  ASSERT_PTR_NULL(fetch_game_sets_response.response.error_message);
+  ASSERT_NUM_EQUALS(fetch_game_sets_response.id, 99);
+  ASSERT_STR_EQUALS(fetch_game_sets_response.title, "Some Other Game");
+  ASSERT_NUM_EQUALS(fetch_game_sets_response.console_id, 2);
+  ASSERT_STR_EQUALS(fetch_game_sets_response.image_name, "000001");
+  ASSERT_STR_EQUALS(fetch_game_sets_response.image_url, "http://server/Images/000001.png");
+  ASSERT_STR_EQUALS(fetch_game_sets_response.rich_presence_script, "Display:\r\nTest\r\n");
+  ASSERT_NUM_EQUALS(fetch_game_sets_response.session_game_id, 99);
+
+  ASSERT_NUM_EQUALS(fetch_game_sets_response.num_sets, 1);
+  set = &fetch_game_sets_response.sets[0];
+  ASSERT_NUM_EQUALS(set->id, 106);
+  ASSERT_NUM_EQUALS(set->game_id, 99);
+  ASSERT_STR_EQUALS(set->title, "Some Other Game");
+  ASSERT_NUM_EQUALS(set->type, RC_ACHIEVEMENT_SET_TYPE_CORE);
+  ASSERT_STR_EQUALS(set->image_name, "000001");
+  ASSERT_STR_EQUALS(set->image_url, "http://server/Images/000001.png");
+  ASSERT_NUM_EQUALS(set->num_achievements, 0);
+  ASSERT_NUM_EQUALS(set->num_leaderboards, 0);
+
+  rc_api_destroy_fetch_game_sets_response(&fetch_game_sets_response);
+}
+
+static void test_process_fetch_game_sets_response_rich_presence_null() {
+  rc_api_achievement_set_definition_t* set;
+  rc_api_fetch_game_sets_response_t fetch_game_sets_response;
+  const char server_response[] = "{\"Success\":true,"
+    "\"GameId\":99,\"Title\":\"Some Other Game\",\"ConsoleId\":2,"
+    "\"ImageIconUrl\":\"http://server/Images/000001.png\","
+    "\"RichPresenceGameId\":99,\"RichPresencePatch\":null,\"Sets\":[{"
+        "\"AchievementSetId\":106,\"GameId\":99,\"Title\":null,\"Type\":\"core\","
+        "\"ImageIconUrl\":\"http://server/Images/000001.png\","
+        "\"Achievements\":[],\"Leaderboards\":[]"
+    "}]}";
+
+  memset(&fetch_game_sets_response, 0, sizeof(fetch_game_sets_response));
+  rc_api_server_response_t fetch_game_sets_server_response;
+  init_server_response(&fetch_game_sets_server_response, 200, server_response, sizeof(server_response) - 1);
+
+  ASSERT_NUM_EQUALS(rc_api_process_fetch_game_sets_server_response(&fetch_game_sets_response, &fetch_game_sets_server_response), RC_OK);
+  ASSERT_NUM_EQUALS(fetch_game_sets_response.response.succeeded, 1);
+  ASSERT_PTR_NULL(fetch_game_sets_response.response.error_message);
+  ASSERT_NUM_EQUALS(fetch_game_sets_response.id, 99);
+  ASSERT_STR_EQUALS(fetch_game_sets_response.title, "Some Other Game");
+  ASSERT_NUM_EQUALS(fetch_game_sets_response.console_id, 2);
+  ASSERT_STR_EQUALS(fetch_game_sets_response.image_name, "000001");
+  ASSERT_STR_EQUALS(fetch_game_sets_response.image_url, "http://server/Images/000001.png");
+  ASSERT_STR_EQUALS(fetch_game_sets_response.rich_presence_script, "");
+  ASSERT_NUM_EQUALS(fetch_game_sets_response.session_game_id, 99);
+
+  ASSERT_NUM_EQUALS(fetch_game_sets_response.num_sets, 1);
+  set = &fetch_game_sets_response.sets[0];
+  ASSERT_NUM_EQUALS(set->id, 106);
+  ASSERT_NUM_EQUALS(set->game_id, 99);
+  ASSERT_STR_EQUALS(set->title, "Some Other Game");
+  ASSERT_NUM_EQUALS(set->type, RC_ACHIEVEMENT_SET_TYPE_CORE);
+  ASSERT_STR_EQUALS(set->image_name, "000001");
+  ASSERT_STR_EQUALS(set->image_url, "http://server/Images/000001.png");
+  ASSERT_NUM_EQUALS(set->num_achievements, 0);
+  ASSERT_NUM_EQUALS(set->num_leaderboards, 0);
+
+  rc_api_destroy_fetch_game_sets_response(&fetch_game_sets_response);
+}
+
+static void test_process_fetch_game_sets_response_specialty_subset() {
+  rc_api_achievement_set_definition_t* set;
+  rc_api_achievement_definition_t* achievement;
+  rc_api_leaderboard_definition_t* leaderboard;
+  rc_api_fetch_game_sets_response_t fetch_game_sets_response;
+  const char server_response[] = "{\"Success\":true,"
+    "\"GameId\":20,\"Title\":\"Another Amazing Game\",\"ConsoleId\":19,"
+    "\"ImageIconUrl\":\"http://server/Images/112233.png\","
+    "\"RichPresenceGameId\":20,\"RichPresencePatch\":\"\",\"Sets\":["
+      "{"
+        "\"AchievementSetId\":98,\"GameId\":26,\"Title\":\"Low Level Run\",\"Type\":\"specialty\","
+        "\"ImageIconUrl\":\"http://server/Images/112236.png\","
+        "\"Achievements\":["
+            "{\"ID\":5507,\"Title\":\"Ach7\",\"Description\":\"Desc7\",\"Flags\":3,\"Points\":5,"
+             "\"MemAddr\":\"0=1\",\"Author\":\"User1\",\"BadgeName\":\"00234\","
+             "\"Created\":1367266583,\"Modified\":1376929305}"
+        "],\"Leaderboards\":[]"
+      "},{"
+        "\"AchievementSetId\":192,\"GameId\":20,\"Title\":null,\"Type\":\"core\","
+        "\"ImageIconUrl\":\"http://server/Images/112233.png\","
+        "\"Achievements\":["
+            "{\"ID\":5501,\"Title\":\"Ach1\",\"Description\":\"Desc1\",\"Flags\":3,\"Points\":5,"
+             "\"MemAddr\":\"0=1\",\"Author\":\"User1\",\"BadgeName\":\"00234\",\"Type\":\"progression\","
+             "\"Rarity\":100.0,\"RarityHardcore\":66.67,\"Created\":1367266583,\"Modified\":1376929305},"
+            "{\"ID\":5502,\"Title\":\"Ach2\",\"Description\":\"Desc2\",\"Flags\":3,\"Points\":2,"
+             "\"MemAddr\":\"0=2\",\"Author\":\"User1\",\"BadgeName\":\"00235\",\"Type\":\"missable\","
+             "\"Rarity\":57.43,\"RarityHardcore\":57.43,\"Created\":1376970283,\"Modified\":1376970283},"
+            "{\"ID\":5503,\"Title\":\"Ach3\",\"Description\":\"Desc3\",\"Flags\":5,\"Points\":0,"
+             "\"MemAddr\":\"0=3\",\"Author\":\"User2\",\"BadgeName\":\"00236\",\"Type\":\"win_condition\","
+             "\"Rarity\":6.8,\"RarityHardcore\":0,\"Created\":1376969412,\"Modified\":1376969412}"
+        "],\"Leaderboards\":["
+            "{\"ID\":4401,\"Title\":\"Leaderboard1\",\"Description\":\"Desc1\","
+             "\"Mem\":\"0=1\",\"Format\":\"SCORE\"}"
+        "]"
+      "},{"
+        "\"AchievementSetId\":77,\"GameId\":21,\"Title\":\"Bonus\",\"Type\":\"bonus\","
+        "\"ImageIconUrl\":\"http://server/Images/112236.png\","
+        "\"Achievements\":["
+            "{\"ID\":5504,\"Title\":\"Ach4\",\"Description\":\"Desc4\",\"Flags\":3,\"Points\":10,"
+             "\"MemAddr\":\"0=4\",\"Author\":null,\"BadgeName\":\"00236\",\"Type\":\"\","
+             "\"Created\":1504474554,\"Modified\":1504474554},"
+            "{\"ID\":5505,\"Title\":\"Ach5 [m]\",\"Description\":\"Desc5\",\"Flags\":3,\"Points\":10,"
+             "\"MemAddr\":\"0=4\",\"Author\":\"User1\",\"BadgeName\":\"00236\",\"Type\":\"\","
+             "\"Created\":1504474554,\"Modified\":1504474554},"
+            "{\"ID\":5506,\"Title\":\"[m] Ach6\",\"Description\":\"Desc6\",\"Flags\":3,\"Points\":10,"
+             "\"MemAddr\":\"0=4\",\"Author\":\"User1\",\"BadgeName\":\"00236\",\"Type\":\"\","
+             "\"Created\":1504474554,\"Modified\":1504474554}"
+        "],\"Leaderboards\":["
+            "{\"ID\":4402,\"Title\":\"Leaderboard2\",\"Description\":\"Desc2\","
+             "\"Mem\":\"0=1\",\"Format\":\"SECS\",\"LowerIsBetter\":false,\"Hidden\":true}"
+        "]"
+      "}"
+    "]}";
+  rc_api_server_response_t fetch_game_sets_server_response;
+  init_server_response(&fetch_game_sets_server_response, 200, server_response, sizeof(server_response) - 1);
+
+  memset(&fetch_game_sets_response, 0, sizeof(fetch_game_sets_response));
+
+  ASSERT_NUM_EQUALS(rc_api_process_fetch_game_sets_server_response(&fetch_game_sets_response, &fetch_game_sets_server_response), RC_OK);
+  ASSERT_NUM_EQUALS(fetch_game_sets_response.response.succeeded, 1);
+  ASSERT_PTR_NULL(fetch_game_sets_response.response.error_message);
+  ASSERT_NUM_EQUALS(fetch_game_sets_response.id, 20);
+  ASSERT_STR_EQUALS(fetch_game_sets_response.title, "Another Amazing Game");
+  ASSERT_NUM_EQUALS(fetch_game_sets_response.console_id, 19);
+  ASSERT_STR_EQUALS(fetch_game_sets_response.image_name, "112233");
+  ASSERT_STR_EQUALS(fetch_game_sets_response.image_url, "http://server/Images/112233.png");
+  ASSERT_STR_EQUALS(fetch_game_sets_response.rich_presence_script, "");
+  ASSERT_NUM_EQUALS(fetch_game_sets_response.session_game_id, 20);
+  ASSERT_NUM_EQUALS(fetch_game_sets_response.num_sets, 3);
+
+  set = &fetch_game_sets_response.sets[0];
+  ASSERT_NUM_EQUALS(set->id, 98);
+  ASSERT_NUM_EQUALS(set->game_id, 26);
+  ASSERT_STR_EQUALS(set->title, "Low Level Run");
+  ASSERT_NUM_EQUALS(set->type, RC_ACHIEVEMENT_SET_TYPE_SPECIALTY);
+  ASSERT_STR_EQUALS(set->image_name, "112236");
+  ASSERT_STR_EQUALS(set->image_url, "http://server/Images/112236.png");
+  ASSERT_NUM_EQUALS(set->num_achievements, 1);
+  ASSERT_NUM_EQUALS(set->num_leaderboards, 0);
+
+  ASSERT_PTR_NOT_NULL(set->achievements);
+  achievement = set->achievements;
+
+  ASSERT_NUM_EQUALS(achievement->id, 5507);
+  ASSERT_STR_EQUALS(achievement->title, "Ach7");
+  ASSERT_STR_EQUALS(achievement->description, "Desc7");
+  ASSERT_NUM_EQUALS(achievement->category, RC_ACHIEVEMENT_CATEGORY_CORE);
+  ASSERT_NUM_EQUALS(achievement->points, 5);
+  ASSERT_STR_EQUALS(achievement->definition, "0=1");
+  ASSERT_STR_EQUALS(achievement->author, "User1");
+  ASSERT_STR_EQUALS(achievement->badge_name, "00234");
+  ASSERT_NUM_EQUALS(achievement->type, RC_ACHIEVEMENT_TYPE_STANDARD); /* no type specified */
+  ASSERT_NUM_EQUALS(achievement->created, 1367266583);
+  ASSERT_NUM_EQUALS(achievement->updated, 1376929305);
+
+  set = &fetch_game_sets_response.sets[1];
+  ASSERT_NUM_EQUALS(set->id, 192);
+  ASSERT_NUM_EQUALS(set->game_id, 20);
+  ASSERT_STR_EQUALS(set->title, "Another Amazing Game");
+  ASSERT_NUM_EQUALS(set->type, RC_ACHIEVEMENT_SET_TYPE_CORE);
+  ASSERT_STR_EQUALS(set->image_name, "112233");
+  ASSERT_STR_EQUALS(set->image_url, "http://server/Images/112233.png");
+  ASSERT_NUM_EQUALS(set->num_achievements, 3);
+  ASSERT_NUM_EQUALS(set->num_leaderboards, 1);
+
+  ASSERT_PTR_NOT_NULL(set->achievements);
+  achievement = set->achievements;
+  ASSERT_NUM_EQUALS(achievement->id, 5501);
+  ASSERT_STR_EQUALS(achievement->title, "Ach1");
+  ASSERT_STR_EQUALS(achievement->description, "Desc1");
+  ASSERT_NUM_EQUALS(achievement->category, RC_ACHIEVEMENT_CATEGORY_CORE);
+  ASSERT_NUM_EQUALS(achievement->points, 5);
+  ASSERT_STR_EQUALS(achievement->definition, "0=1");
+  ASSERT_STR_EQUALS(achievement->author, "User1");
+  ASSERT_STR_EQUALS(achievement->badge_name, "00234");
+  ASSERT_NUM_EQUALS(achievement->type, RC_ACHIEVEMENT_TYPE_PROGRESSION);
+  ASSERT_FLOAT_EQUALS(achievement->rarity, 100.0f);
+  ASSERT_FLOAT_EQUALS(achievement->rarity_hardcore, 66.67f);
+  ASSERT_NUM_EQUALS(achievement->created, 1367266583);
+  ASSERT_NUM_EQUALS(achievement->updated, 1376929305);
+
+  ++achievement;
+  ASSERT_NUM_EQUALS(achievement->id, 5502);
+  ASSERT_STR_EQUALS(achievement->title, "Ach2");
+  ASSERT_STR_EQUALS(achievement->description, "Desc2");
+  ASSERT_NUM_EQUALS(achievement->category, RC_ACHIEVEMENT_CATEGORY_CORE);
+  ASSERT_NUM_EQUALS(achievement->points, 2);
+  ASSERT_STR_EQUALS(achievement->definition, "0=2");
+  ASSERT_STR_EQUALS(achievement->author, "User1");
+  ASSERT_STR_EQUALS(achievement->badge_name, "00235");
+  ASSERT_NUM_EQUALS(achievement->type, RC_ACHIEVEMENT_TYPE_MISSABLE);
+  ASSERT_FLOAT_EQUALS(achievement->rarity, 57.43f);
+  ASSERT_FLOAT_EQUALS(achievement->rarity_hardcore, 57.43f);
+  ASSERT_NUM_EQUALS(achievement->created, 1376970283);
+  ASSERT_NUM_EQUALS(achievement->updated, 1376970283);
+
+  ++achievement;
+  ASSERT_NUM_EQUALS(achievement->id, 5503);
+  ASSERT_STR_EQUALS(achievement->title, "Ach3");
+  ASSERT_STR_EQUALS(achievement->description, "Desc3");
+  ASSERT_NUM_EQUALS(achievement->category, RC_ACHIEVEMENT_CATEGORY_UNOFFICIAL);
+  ASSERT_NUM_EQUALS(achievement->points, 0);
+  ASSERT_STR_EQUALS(achievement->definition, "0=3");
+  ASSERT_STR_EQUALS(achievement->author, "User2");
+  ASSERT_STR_EQUALS(achievement->badge_name, "00236");
+  ASSERT_NUM_EQUALS(achievement->type, RC_ACHIEVEMENT_TYPE_WIN);
+  ASSERT_FLOAT_EQUALS(achievement->rarity, 6.8f);
+  ASSERT_FLOAT_EQUALS(achievement->rarity_hardcore, 0.0f);
+  ASSERT_NUM_EQUALS(achievement->created, 1376969412);
+  ASSERT_NUM_EQUALS(achievement->updated, 1376969412);
+
+  ASSERT_PTR_NOT_NULL(set->leaderboards);
+  leaderboard = set->leaderboards;
+
+  ASSERT_NUM_EQUALS(leaderboard->id, 4401);
+  ASSERT_STR_EQUALS(leaderboard->title, "Leaderboard1");
+  ASSERT_STR_EQUALS(leaderboard->description, "Desc1");
+  ASSERT_STR_EQUALS(leaderboard->definition, "0=1");
+  ASSERT_NUM_EQUALS(leaderboard->format, RC_FORMAT_SCORE);
+  ASSERT_NUM_EQUALS(leaderboard->lower_is_better, 0);
+  ASSERT_NUM_EQUALS(leaderboard->hidden, 0);
+
+  set = &fetch_game_sets_response.sets[2];
+  ASSERT_NUM_EQUALS(set->id, 77);
+  ASSERT_NUM_EQUALS(set->game_id, 21);
+  ASSERT_STR_EQUALS(set->title, "Bonus");
+  ASSERT_NUM_EQUALS(set->type, RC_ACHIEVEMENT_SET_TYPE_BONUS);
+  ASSERT_STR_EQUALS(set->image_name, "112236");
+  ASSERT_STR_EQUALS(set->image_url, "http://server/Images/112236.png");
+  ASSERT_NUM_EQUALS(set->num_achievements, 3);
+  ASSERT_NUM_EQUALS(set->num_leaderboards, 1);
+
+  ASSERT_PTR_NOT_NULL(set->achievements);
+  achievement = set->achievements;
+  ASSERT_NUM_EQUALS(achievement->id, 5504);
+  ASSERT_STR_EQUALS(achievement->title, "Ach4");
+  ASSERT_STR_EQUALS(achievement->description, "Desc4");
+  ASSERT_NUM_EQUALS(achievement->category, RC_ACHIEVEMENT_CATEGORY_CORE);
+  ASSERT_NUM_EQUALS(achievement->points, 10);
+  ASSERT_STR_EQUALS(achievement->definition, "0=4");
+  ASSERT_STR_EQUALS(achievement->author, ""); /* null author */
+  ASSERT_STR_EQUALS(achievement->badge_name, "00236");
+  ASSERT_NUM_EQUALS(achievement->type, RC_ACHIEVEMENT_TYPE_STANDARD);
+  ASSERT_FLOAT_EQUALS(achievement->rarity, 100.0f);
+  ASSERT_FLOAT_EQUALS(achievement->rarity_hardcore, 100.0f);
+  ASSERT_NUM_EQUALS(achievement->created, 1504474554);
+  ASSERT_NUM_EQUALS(achievement->updated, 1504474554);
+
+  ++achievement;
+  ASSERT_NUM_EQUALS(achievement->id, 5505);
+  ASSERT_STR_EQUALS(achievement->title, "Ach5"); /* [m] stripped */
+  ASSERT_STR_EQUALS(achievement->description, "Desc5");
+  ASSERT_NUM_EQUALS(achievement->category, RC_ACHIEVEMENT_CATEGORY_CORE);
+  ASSERT_NUM_EQUALS(achievement->points, 10);
+  ASSERT_STR_EQUALS(achievement->definition, "0=4");
+  ASSERT_STR_EQUALS(achievement->author, "User1");
+  ASSERT_STR_EQUALS(achievement->badge_name, "00236");
+  ASSERT_NUM_EQUALS(achievement->type, RC_ACHIEVEMENT_TYPE_MISSABLE);
+  ASSERT_FLOAT_EQUALS(achievement->rarity, 100.0f);
+  ASSERT_FLOAT_EQUALS(achievement->rarity_hardcore, 100.0f);
+  ASSERT_NUM_EQUALS(achievement->created, 1504474554);
+  ASSERT_NUM_EQUALS(achievement->updated, 1504474554);
+
+  ++achievement;
+  ASSERT_NUM_EQUALS(achievement->id, 5506);
+  ASSERT_STR_EQUALS(achievement->title, "Ach6"); /* [m] stripped */
+  ASSERT_STR_EQUALS(achievement->description, "Desc6");
+  ASSERT_NUM_EQUALS(achievement->category, RC_ACHIEVEMENT_CATEGORY_CORE);
+  ASSERT_NUM_EQUALS(achievement->points, 10);
+  ASSERT_STR_EQUALS(achievement->definition, "0=4");
+  ASSERT_STR_EQUALS(achievement->author, "User1");
+  ASSERT_STR_EQUALS(achievement->badge_name, "00236");
+  ASSERT_NUM_EQUALS(achievement->type, RC_ACHIEVEMENT_TYPE_MISSABLE);
+  ASSERT_FLOAT_EQUALS(achievement->rarity, 100.0f);
+  ASSERT_FLOAT_EQUALS(achievement->rarity_hardcore, 100.0f);
+  ASSERT_NUM_EQUALS(achievement->created, 1504474554);
+  ASSERT_NUM_EQUALS(achievement->updated, 1504474554);
+
+  ASSERT_PTR_NOT_NULL(set->leaderboards);
+  leaderboard = set->leaderboards;
+
+  ASSERT_NUM_EQUALS(leaderboard->id, 4402);
+  ASSERT_STR_EQUALS(leaderboard->title, "Leaderboard2");
+  ASSERT_STR_EQUALS(leaderboard->description, "Desc2");
+  ASSERT_STR_EQUALS(leaderboard->definition, "0=1");
+  ASSERT_NUM_EQUALS(leaderboard->format, RC_FORMAT_SECONDS);
+  ASSERT_NUM_EQUALS(leaderboard->lower_is_better, 0);
+  ASSERT_NUM_EQUALS(leaderboard->hidden, 1);
+
+  rc_api_destroy_fetch_game_sets_response(&fetch_game_sets_response);
+}
+
+static void test_process_fetch_game_sets_response_exclusive_subset() {
+  rc_api_achievement_set_definition_t* set;
+  rc_api_achievement_definition_t* achievement;
+  rc_api_fetch_game_sets_response_t fetch_game_sets_response;
+  const char server_response[] = "{\"Success\":true,"
+    "\"GameId\":20,\"Title\":\"Another Amazing Game\",\"ConsoleId\":19,"
+    "\"ImageIconUrl\":\"http://server/Images/112233.png\","
+    "\"RichPresenceGameId\":26,\"RichPresencePatch\":\"\",\"Sets\":[{"
+        "\"AchievementSetId\":98,\"GameId\":26,\"Title\":\"Low Level Run\",\"Type\":\"exclusive\","
+        "\"ImageIconUrl\":\"http://server/Images/112236.png\","
+        "\"Achievements\":["
+            "{\"ID\":5507,\"Title\":\"Ach7\",\"Description\":\"Desc7\",\"Flags\":3,\"Points\":5,"
+             "\"MemAddr\":\"0=1\",\"Author\":\"User1\",\"BadgeName\":\"00234\","
+             "\"Created\":1367266583,\"Modified\":1376929305}"
+        "],\"Leaderboards\":[]"
+    "}]}";
+  rc_api_server_response_t fetch_game_sets_server_response;
+  init_server_response(&fetch_game_sets_server_response, 200, server_response, sizeof(server_response) - 1);
+
+  memset(&fetch_game_sets_response, 0, sizeof(fetch_game_sets_response));
+
+  ASSERT_NUM_EQUALS(rc_api_process_fetch_game_sets_server_response(&fetch_game_sets_response, &fetch_game_sets_server_response), RC_OK);
+  ASSERT_NUM_EQUALS(fetch_game_sets_response.response.succeeded, 1);
+  ASSERT_PTR_NULL(fetch_game_sets_response.response.error_message);
+  ASSERT_NUM_EQUALS(fetch_game_sets_response.id, 20);
+  ASSERT_STR_EQUALS(fetch_game_sets_response.title, "Another Amazing Game");
+  ASSERT_NUM_EQUALS(fetch_game_sets_response.console_id, 19);
+  ASSERT_STR_EQUALS(fetch_game_sets_response.image_name, "112233");
+  ASSERT_STR_EQUALS(fetch_game_sets_response.image_url, "http://server/Images/112233.png");
+  ASSERT_STR_EQUALS(fetch_game_sets_response.rich_presence_script, "");
+  ASSERT_NUM_EQUALS(fetch_game_sets_response.session_game_id, 26);
+  ASSERT_NUM_EQUALS(fetch_game_sets_response.num_sets, 1);
+
+  set = &fetch_game_sets_response.sets[0];
+  ASSERT_NUM_EQUALS(set->id, 98);
+  ASSERT_NUM_EQUALS(set->game_id, 26);
+  ASSERT_STR_EQUALS(set->title, "Low Level Run");
+  ASSERT_NUM_EQUALS(set->type, RC_ACHIEVEMENT_SET_TYPE_EXCLUSIVE);
+  ASSERT_STR_EQUALS(set->image_name, "112236");
+  ASSERT_STR_EQUALS(set->image_url, "http://server/Images/112236.png");
+  ASSERT_NUM_EQUALS(set->num_achievements, 1);
+  ASSERT_NUM_EQUALS(set->num_leaderboards, 0);
+
+  ASSERT_PTR_NOT_NULL(set->achievements);
+  achievement = set->achievements;
+
+  ASSERT_NUM_EQUALS(achievement->id, 5507);
+  ASSERT_STR_EQUALS(achievement->title, "Ach7");
+  ASSERT_STR_EQUALS(achievement->description, "Desc7");
+  ASSERT_NUM_EQUALS(achievement->category, RC_ACHIEVEMENT_CATEGORY_CORE);
+  ASSERT_NUM_EQUALS(achievement->points, 5);
+  ASSERT_STR_EQUALS(achievement->definition, "0=1");
+  ASSERT_STR_EQUALS(achievement->author, "User1");
+  ASSERT_STR_EQUALS(achievement->badge_name, "00234");
+  ASSERT_NUM_EQUALS(achievement->type, RC_ACHIEVEMENT_TYPE_STANDARD); /* no type specified */
+  ASSERT_NUM_EQUALS(achievement->created, 1367266583);
+  ASSERT_NUM_EQUALS(achievement->updated, 1376929305);
+
+  rc_api_destroy_fetch_game_sets_response(&fetch_game_sets_response);
+}
+
+/* ----- ping ----- */
 
 static void test_init_ping_request() {
   rc_api_ping_request_t ping_request;
@@ -920,6 +1558,8 @@ static void test_process_ping_response() {
 
   rc_api_destroy_ping_response(&ping_response);
 }
+
+/* ----- award achievement ----- */
 
 static void test_init_award_achievement_request_hardcore() {
   rc_api_award_achievement_request_t award_achievement_request;
@@ -1264,6 +1904,8 @@ static void test_process_award_achievement_response_522_simple() {
   rc_api_destroy_award_achievement_response(&award_achievement_response);
 }
 
+/* ----- submit lboard entry ----- */
+
 static void test_init_submit_lboard_entry_request() {
   rc_api_submit_lboard_entry_request_t submit_lboard_entry_request;
   rc_api_request_t request;
@@ -1443,6 +2085,8 @@ static void test_process_submit_lb_entry_response_entries_not_array() {
   rc_api_destroy_submit_lboard_entry_response(&submit_lb_entry_response);
 }
 
+/* ----- harness ----- */
+
 void test_rapi_runtime(void) {
   TEST_SUITE_BEGIN();
 
@@ -1471,8 +2115,20 @@ void test_rapi_runtime(void) {
   TEST(test_process_fetch_game_data_response_leaderboards);
   TEST(test_process_fetch_game_data_response_rich_presence);
   TEST(test_process_fetch_game_data_response_rich_presence_null);
-  TEST(test_process_fetch_game_data_response_rich_presence_tab);
-  TEST(test_process_fetch_game_data_response_subsets);
+
+  /* hashdata */
+  TEST(test_init_fetch_game_sets_request);
+  TEST(test_init_fetch_game_sets_request_no_hash);
+
+  TEST(test_process_fetch_game_sets_response_empty);
+  TEST(test_process_fetch_game_sets_response_invalid_credentials);
+  TEST(test_process_fetch_game_sets_response_not_found);
+  TEST(test_process_fetch_game_sets_response_achievements);
+  TEST(test_process_fetch_game_sets_response_leaderboards);
+  TEST(test_process_fetch_game_sets_response_rich_presence);
+  TEST(test_process_fetch_game_sets_response_rich_presence_null);
+  TEST(test_process_fetch_game_sets_response_specialty_subset);
+  TEST(test_process_fetch_game_sets_response_exclusive_subset);
 
   /* ping */
   TEST(test_init_ping_request);

--- a/test/rapi/test_rc_api_runtime.c
+++ b/test/rapi/test_rc_api_runtime.c
@@ -695,7 +695,7 @@ static void test_init_fetch_game_sets_request() {
 
   ASSERT_NUM_EQUALS(rc_api_init_fetch_game_sets_request(&request, &fetch_game_sets_request), RC_OK);
   ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
-  ASSERT_STR_EQUALS(request.post_data, "r=hashdata&u=Username&t=API_TOKEN&m=ABCDEF0123456789");
+  ASSERT_STR_EQUALS(request.post_data, "r=achievementsets&u=Username&t=API_TOKEN&m=ABCDEF0123456789");
   ASSERT_STR_EQUALS(request.content_type, RC_CONTENT_TYPE_URLENCODED);
 
   rc_api_destroy_request(&request);
@@ -725,7 +725,7 @@ static void test_init_fetch_game_sets_request_by_id() {
 
   ASSERT_NUM_EQUALS(rc_api_init_fetch_game_sets_request(&request, &fetch_game_sets_request), RC_OK);
   ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
-  ASSERT_STR_EQUALS(request.post_data, "r=hashdata&u=Username&t=API_TOKEN&g=953");
+  ASSERT_STR_EQUALS(request.post_data, "r=achievementsets&u=Username&t=API_TOKEN&g=953");
   ASSERT_STR_EQUALS(request.content_type, RC_CONTENT_TYPE_URLENCODED);
 
   rc_api_destroy_request(&request);
@@ -743,7 +743,7 @@ static void test_init_fetch_game_sets_request_by_hash_and_id() {
 
   ASSERT_NUM_EQUALS(rc_api_init_fetch_game_sets_request(&request, &fetch_game_sets_request), RC_OK);
   ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
-  ASSERT_STR_EQUALS(request.post_data, "r=hashdata&u=Username&t=API_TOKEN&g=953");
+  ASSERT_STR_EQUALS(request.post_data, "r=achievementsets&u=Username&t=API_TOKEN&g=953");
   ASSERT_STR_EQUALS(request.content_type, RC_CONTENT_TYPE_URLENCODED);
 
   rc_api_destroy_request(&request);

--- a/test/rapi/test_rc_api_runtime.c
+++ b/test/rapi/test_rc_api_runtime.c
@@ -714,6 +714,41 @@ static void test_init_fetch_game_sets_request_no_hash() {
   rc_api_destroy_request(&request);
 }
 
+static void test_init_fetch_game_sets_request_by_id() {
+  rc_api_fetch_game_sets_request_t fetch_game_sets_request;
+  rc_api_request_t request;
+
+  memset(&fetch_game_sets_request, 0, sizeof(fetch_game_sets_request));
+  fetch_game_sets_request.username = "Username";
+  fetch_game_sets_request.api_token = "API_TOKEN";
+  fetch_game_sets_request.game_id = 953;
+
+  ASSERT_NUM_EQUALS(rc_api_init_fetch_game_sets_request(&request, &fetch_game_sets_request), RC_OK);
+  ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
+  ASSERT_STR_EQUALS(request.post_data, "r=hashdata&u=Username&t=API_TOKEN&g=953");
+  ASSERT_STR_EQUALS(request.content_type, RC_CONTENT_TYPE_URLENCODED);
+
+  rc_api_destroy_request(&request);
+}
+
+static void test_init_fetch_game_sets_request_by_hash_and_id() {
+  rc_api_fetch_game_sets_request_t fetch_game_sets_request;
+  rc_api_request_t request;
+
+  memset(&fetch_game_sets_request, 0, sizeof(fetch_game_sets_request));
+  fetch_game_sets_request.username = "Username";
+  fetch_game_sets_request.api_token = "API_TOKEN";
+  fetch_game_sets_request.game_id = 953;
+  fetch_game_sets_request.game_hash = "ABCDEF0123456789";
+
+  ASSERT_NUM_EQUALS(rc_api_init_fetch_game_sets_request(&request, &fetch_game_sets_request), RC_OK);
+  ASSERT_STR_EQUALS(request.url, DOREQUEST_URL);
+  ASSERT_STR_EQUALS(request.post_data, "r=hashdata&u=Username&t=API_TOKEN&g=953");
+  ASSERT_STR_EQUALS(request.content_type, RC_CONTENT_TYPE_URLENCODED);
+
+  rc_api_destroy_request(&request);
+}
+
 static void test_process_fetch_game_sets_response_empty() {
   rc_api_achievement_set_definition_t* set;
   rc_api_fetch_game_sets_response_t fetch_game_sets_response;
@@ -2119,6 +2154,8 @@ void test_rapi_runtime(void) {
   /* hashdata */
   TEST(test_init_fetch_game_sets_request);
   TEST(test_init_fetch_game_sets_request_no_hash);
+  TEST(test_init_fetch_game_sets_request_by_id);
+  TEST(test_init_fetch_game_data_request_by_id_and_hash);
 
   TEST(test_process_fetch_game_sets_response_empty);
   TEST(test_process_fetch_game_sets_response_invalid_credentials);

--- a/test/rapi/test_rc_api_runtime.c
+++ b/test/rapi/test_rc_api_runtime.c
@@ -487,7 +487,6 @@ static void test_process_fetch_game_data_response_achievement_null_author()
   ASSERT_STR_EQUALS(fetch_game_data_response.rich_presence_script, "");
   ASSERT_NUM_EQUALS(fetch_game_data_response.num_achievements, 4);
   ASSERT_NUM_EQUALS(fetch_game_data_response.num_leaderboards, 0);
-  //ASSERT_NUM_EQUALS(fetch_game_data_response.num_subsets, 0);
 
   ASSERT_PTR_NOT_NULL(fetch_game_data_response.achievements);
   achievement = fetch_game_data_response.achievements;
@@ -575,7 +574,6 @@ static void test_process_fetch_game_data_response_leaderboards() {
   ASSERT_STR_EQUALS(fetch_game_data_response.rich_presence_script, "");
   ASSERT_NUM_EQUALS(fetch_game_data_response.num_achievements, 0);
   ASSERT_NUM_EQUALS(fetch_game_data_response.num_leaderboards, 3);
-  //ASSERT_NUM_EQUALS(fetch_game_data_response.num_subsets, 0);
 
   ASSERT_PTR_NOT_NULL(fetch_game_data_response.leaderboards);
   leaderboard = fetch_game_data_response.leaderboards;
@@ -2150,12 +2148,13 @@ void test_rapi_runtime(void) {
   TEST(test_process_fetch_game_data_response_leaderboards);
   TEST(test_process_fetch_game_data_response_rich_presence);
   TEST(test_process_fetch_game_data_response_rich_presence_null);
+  TEST(test_process_fetch_game_data_response_rich_presence_tab);
 
   /* hashdata */
   TEST(test_init_fetch_game_sets_request);
   TEST(test_init_fetch_game_sets_request_no_hash);
   TEST(test_init_fetch_game_sets_request_by_id);
-  TEST(test_init_fetch_game_data_request_by_id_and_hash);
+  TEST(test_init_fetch_game_sets_request_by_hash_and_id);
 
   TEST(test_process_fetch_game_sets_response_empty);
   TEST(test_process_fetch_game_sets_response_invalid_credentials);

--- a/test/rcheevos/test_rc_validate.c
+++ b/test/rcheevos/test_rc_validate.c
@@ -335,6 +335,7 @@ void test_conflicting_conditions() {
   TEST_PARAMS2(test_validate_trigger, "O:0xH0000<5_0xH0000=5", ""); /* ignore combining conditions */
   TEST_PARAMS2(test_validate_trigger, "A:0xH0000<5_0xH0000=5", ""); /* ignore combining conditions */
   TEST_PARAMS2(test_validate_trigger, "N:0xH0000<5_R:0xH0001=8_T:0xH0000=0", ""); /* ignore combining conditions */
+  TEST_PARAMS2(test_validate_trigger, "T:0xH0000=8_N:d0xH0000=0_R:0xH0000=8", ""); /* ignore combining conditions - individually, third conditions is conflicting (second allowed because of delta) */
   TEST_PARAMS2(test_validate_trigger, "0xH0001=58_N:0xH0001!=58_N:0xH0001!=4_R:0xH0001!=18", ""); /* ignore combining conditions */
   TEST_PARAMS2(test_validate_trigger, "0xH0000<=5_0xH0000>=5", "");
   TEST_PARAMS2(test_validate_trigger, "0xH0000>1_0xH0000<3", "");

--- a/test/test_rc_client.c
+++ b/test/test_rc_client.c
@@ -42,223 +42,282 @@ static void* g_callback_userdata = &g_client; /* dummy object to use for callbac
 #define GENERIC_LEADERBOARD_JSON(id, memaddr, format) "{\"ID\":" id ",\"Title\":\"Leaderboard " id "\"," \
       "\"Description\":\"Desc " id "\",\"Mem\":\"" memaddr "\",\"Format\":\"" format "\"}"
 
-static const char* patchdata_empty = "{\"Success\":true,\"PatchData\":{"
-    "\"ID\":1234,\"Title\":\"Sample Game\",\"ConsoleID\":17,\"ImageIcon\":\"/Images/112233.png\","
-    "\"Achievements\":[],"
-    "\"Leaderboards\":[]"
-    "}}";
+static const char* patchdata_empty = "{\"Success\":true,"
+    "\"GameId\":1234,\"Title\":\"Sample Game\",\"ConsoleId\":17,"
+    "\"ImageIconUrl\":\"http://server/Images/112233.png\","
+    "\"RichPresenceGameId\":1234,\"RichPresencePatch\":\"\",\"Sets\":[{"
+      "\"AchievementSetId\":1111,\"GameId\":1234,\"Title\":null,\"Type\":\"core\","
+      "\"ImageIconUrl\":\"http://server/Images/112233.png\","
+      "\"Achievements\":[],"
+      "\"Leaderboards\":[]"
+    "}]}";
 
-static const char* patchdata_2ach_0lbd = "{\"Success\":true,\"PatchData\":{"
-    "\"ID\":1234,\"Title\":\"Sample Game\",\"ConsoleID\":17,\"ImageIcon\":\"/Images/112233.png\","
-    "\"Achievements\":["
-     "{\"ID\":5501,\"Title\":\"Ach1\",\"Description\":\"Desc1\",\"Flags\":3,\"Points\":5,"
-      "\"MemAddr\":\"0xH0001=3_0xH0002=7\",\"Author\":\"User1\",\"BadgeName\":\"00234\","
-      "\"Created\":1367266583,\"Modified\":1376929305},"
-     "{\"ID\":5502,\"Title\":\"Ach2\",\"Description\":\"Desc2\",\"Flags\":3,\"Points\":2,"
-      "\"MemAddr\":\"0xH0001=2_0x0002=9\",\"Author\":\"User1\",\"BadgeName\":\"00235\","
-      "\"Created\":1376970283,\"Modified\":1376970283}"
-    "],"
-    "\"Leaderboards\":[]"
-    "}}";
+static const char* patchdata_2ach_0lbd = "{\"Success\":true,"
+    "\"GameId\":1234,\"Title\":\"Sample Game\",\"ConsoleId\":17,"
+    "\"ImageIconUrl\":\"http://server/Images/112233.png\","
+    "\"RichPresenceGameId\":1234,\"RichPresencePatch\":\"\",\"Sets\":[{"
+      "\"AchievementSetId\":1111,\"GameId\":1234,\"Title\":null,\"Type\":\"core\","
+      "\"ImageIconUrl\":\"http://server/Images/112233.png\","
+      "\"Achievements\":["
+       "{\"ID\":5501,\"Title\":\"Ach1\",\"Description\":\"Desc1\",\"Flags\":3,\"Points\":5,"
+        "\"MemAddr\":\"0xH0001=3_0xH0002=7\",\"Author\":\"User1\",\"BadgeName\":\"00234\","
+        "\"Created\":1367266583,\"Modified\":1376929305},"
+       "{\"ID\":5502,\"Title\":\"Ach2\",\"Description\":\"Desc2\",\"Flags\":3,\"Points\":2,"
+        "\"MemAddr\":\"0xH0001=2_0x0002=9\",\"Author\":\"User1\",\"BadgeName\":\"00235\","
+        "\"Created\":1376970283,\"Modified\":1376970283}"
+      "],"
+      "\"Leaderboards\":[]"
+    "}]}";
 
-static const char* patchdata_2ach_1lbd = "{\"Success\":true,\"PatchData\":{"
-    "\"ID\":1234,\"Title\":\"Sample Game\",\"ConsoleID\":17,\"ImageIcon\":\"/Images/112233.png\","
-    "\"Achievements\":["
-     "{\"ID\":5501,\"Title\":\"Ach1\",\"Description\":\"Desc1\",\"Flags\":3,\"Points\":5,"
-      "\"MemAddr\":\"0xH0001=3_0xH0002=7\",\"Author\":\"User1\",\"BadgeName\":\"00234\","
-      "\"Created\":1367266583,\"Modified\":1376929305},"
-     "{\"ID\":5502,\"Title\":\"Ach2\",\"Description\":\"Desc2\",\"Flags\":3,\"Points\":2,"
-      "\"MemAddr\":\"0xH0001=2_0x0002=9\",\"Author\":\"User1\",\"BadgeName\":\"00235\","
-      "\"Created\":1376970283,\"Modified\":1376970283}"
-    "],"
-    "\"Leaderboards\":["
-     "{\"ID\":4401,\"Title\":\"Leaderboard1\",\"Description\":\"Desc1\","
-      "\"Mem\":\"STA:0xH000C=1::CAN:0xH000D=1::SUB:0xH000D=2::VAL:0x 000E\",\"Format\":\"SCORE\"}"
-    "]"
-    "}}";
+static const char* patchdata_2ach_1lbd = "{\"Success\":true,"
+    "\"GameId\":1234,\"Title\":\"Sample Game\",\"ConsoleId\":17,"
+    "\"ImageIconUrl\":\"http://server/Images/112233.png\","
+    "\"RichPresenceGameId\":1234,\"RichPresencePatch\":\"\",\"Sets\":[{"
+      "\"AchievementSetId\":1111,\"GameId\":1234,\"Title\":null,\"Type\":\"core\","
+      "\"ImageIconUrl\":\"http://server/Images/112233.png\","
+      "\"Achievements\":["
+       "{\"ID\":5501,\"Title\":\"Ach1\",\"Description\":\"Desc1\",\"Flags\":3,\"Points\":5,"
+        "\"MemAddr\":\"0xH0001=3_0xH0002=7\",\"Author\":\"User1\",\"BadgeName\":\"00234\","
+        "\"Created\":1367266583,\"Modified\":1376929305},"
+       "{\"ID\":5502,\"Title\":\"Ach2\",\"Description\":\"Desc2\",\"Flags\":3,\"Points\":2,"
+        "\"MemAddr\":\"0xH0001=2_0x0002=9\",\"Author\":\"User1\",\"BadgeName\":\"00235\","
+        "\"Created\":1376970283,\"Modified\":1376970283}"
+      "],"
+      "\"Leaderboards\":["
+       "{\"ID\":4401,\"Title\":\"Leaderboard1\",\"Description\":\"Desc1\","
+        "\"Mem\":\"STA:0xH000C=1::CAN:0xH000D=1::SUB:0xH000D=2::VAL:0x 000E\",\"Format\":\"SCORE\"}"
+      "]"
+    "}]}";
 
-static const char* patchdata_rich_presence_only = "{\"Success\":true,\"PatchData\":{"
-    "\"ID\":1234,\"Title\":\"Sample Game\",\"ConsoleID\":17,\"ImageIcon\":\"/Images/112233.png\","
-    "\"Achievements\":[],"
-    "\"Leaderboards\":[],"
-    "\"RichPresencePatch\":\"Display:\\r\\n@Number(0xH0001)\""
-    "}}";
+static const char* patchdata_rich_presence_only = "{\"Success\":true,"
+    "\"GameId\":1234,\"Title\":\"Sample Game\",\"ConsoleId\":17,"
+    "\"ImageIconUrl\":\"http://server/Images/112233.png\","
+    "\"RichPresenceGameId\":1234,\"RichPresencePatch\":\"Display:\\r\\n@Number(0xH0001)\","
+    "\"Sets\":[{"
+      "\"AchievementSetId\":1111,\"GameId\":1234,\"Title\":null,\"Type\":\"core\","
+      "\"ImageIconUrl\":\"http://server/Images/112233.png\","
+      "\"Achievements\":[],"
+      "\"Leaderboards\":[]"
+    "}]}";
 
-static const char* patchdata_leaderboard_only = "{\"Success\":true,\"PatchData\":{"
-    "\"ID\":1234,\"Title\":\"Sample Game\",\"ConsoleID\":17,\"ImageIcon\":\"/Images/112233.png\","
-    "\"Achievements\":[],"
-    "\"Leaderboards\":["
-      GENERIC_LEADERBOARD_JSON("44", "STA:0xH000B=1::CAN:0xH000C=1::SUB:0xH000D=1::VAL:0x 000E", "SCORE")
-    "]"
-    "}}";
+static const char* patchdata_leaderboard_only = "{\"Success\":true,"
+    "\"GameId\":1234,\"Title\":\"Sample Game\",\"ConsoleId\":17,"
+    "\"ImageIconUrl\":\"http://server/Images/112233.png\","
+    "\"RichPresenceGameId\":1234,\"RichPresencePatch\":\"Display:\\r\\n@Number(0xH0001)\","
+    "\"Sets\":[{"
+      "\"AchievementSetId\":1111,\"GameId\":1234,\"Title\":null,\"Type\":\"core\","
+      "\"ImageIconUrl\":\"http://server/Images/112233.png\","
+      "\"Achievements\":[],"
+      "\"Leaderboards\":["
+        GENERIC_LEADERBOARD_JSON("44", "STA:0xH000B=1::CAN:0xH000C=1::SUB:0xH000D=1::VAL:0x 000E", "SCORE")
+      "]"
+    "}]}";
 
-static const char* patchdata_leaderboard_immediate_submit = "{\"Success\":true,\"PatchData\":{"
-    "\"ID\":1234,\"Title\":\"Sample Game\",\"ConsoleID\":17,\"ImageIcon\":\"/Images/112233.png\","
-    "\"Achievements\":[],"
-    "\"Leaderboards\":["
-      GENERIC_LEADERBOARD_JSON("44", "STA:0xH000B=1::CAN:0=1::SUB:1=1::VAL:0x 000E", "SCORE")
-    "]"
-    "}}";
+static const char* patchdata_leaderboard_immediate_submit = "{\"Success\":true,"
+    "\"GameId\":1234,\"Title\":\"Sample Game\",\"ConsoleId\":17,"
+    "\"ImageIconUrl\":\"http://server/Images/112233.png\","
+    "\"RichPresenceGameId\":1234,\"RichPresencePatch\":\"Display:\\r\\n@Number(0xH0001)\","
+    "\"Sets\":[{"
+      "\"AchievementSetId\":1111,\"GameId\":1234,\"Title\":null,\"Type\":\"core\","
+      "\"ImageIconUrl\":\"http://server/Images/112233.png\","
+      "\"Achievements\":[],"
+      "\"Leaderboards\":["
+        GENERIC_LEADERBOARD_JSON("44", "STA:0xH000B=1::CAN:0=1::SUB:1=1::VAL:0x 000E", "SCORE")
+      "]"
+    "}]}";
 
-static const char* patchdata_bounds_check_system = "{\"Success\":true,\"PatchData\":{"
-    "\"ID\":1234,\"Title\":\"Sample Game\",\"ConsoleID\":7,\"ImageIcon\":\"/Images/112233.png\","
-    "\"Achievements\":["
-      GENERIC_ACHIEVEMENT_JSON("1", "0xH0000=5") ","
-      GENERIC_ACHIEVEMENT_JSON("2", "0xHFFFF=5") ","
-      GENERIC_ACHIEVEMENT_JSON("3", "0xH10000=5") ","
-      GENERIC_ACHIEVEMENT_JSON("4", "0x FFFE=5") ","
-      GENERIC_ACHIEVEMENT_JSON("5", "0x FFFF=5") ","
-      GENERIC_ACHIEVEMENT_JSON("6", "0x 10000=5") ","
-      GENERIC_ACHIEVEMENT_JSON("7", "I:0xH0000_0xHFFFF=5")
-    "],"
-    "\"Leaderboards\":[]"
-    "}}";
+static const char* patchdata_bounds_check_system = "{\"Success\":true,"
+    "\"GameId\":1234,\"Title\":\"Sample Game\",\"ConsoleId\":7,"
+    "\"ImageIconUrl\":\"http://server/Images/112233.png\","
+    "\"RichPresenceGameId\":1234,\"RichPresencePatch\":\"\",\"Sets\":[{"
+      "\"AchievementSetId\":1111,\"GameId\":1234,\"Title\":null,\"Type\":\"core\","
+      "\"ImageIconUrl\":\"http://server/Images/112233.png\","
+      "\"Achievements\":["
+        GENERIC_ACHIEVEMENT_JSON("1", "0xH0000=5") ","
+        GENERIC_ACHIEVEMENT_JSON("2", "0xHFFFF=5") ","
+        GENERIC_ACHIEVEMENT_JSON("3", "0xH10000=5") ","
+        GENERIC_ACHIEVEMENT_JSON("4", "0x FFFE=5") ","
+        GENERIC_ACHIEVEMENT_JSON("5", "0x FFFF=5") ","
+        GENERIC_ACHIEVEMENT_JSON("6", "0x 10000=5") ","
+        GENERIC_ACHIEVEMENT_JSON("7", "I:0xH0000_0xHFFFF=5")
+      "],"
+      "\"Leaderboards\":[]"
+    "}]}";
 
-static const char* patchdata_bounds_check_8 = "{\"Success\":true,\"PatchData\":{"
-    "\"ID\":1234,\"Title\":\"Sample Game\",\"ConsoleID\":7,\"ImageIcon\":\"/Images/112233.png\","
-    "\"Achievements\":["
-      GENERIC_ACHIEVEMENT_JSON("408", "0xH0004=5") ","
-      GENERIC_ACHIEVEMENT_JSON("508", "0xH0005=5") ","
-      GENERIC_ACHIEVEMENT_JSON("608", "0xH0006=5") ","
-      GENERIC_ACHIEVEMENT_JSON("708", "0xH0007=5") ","
-      GENERIC_ACHIEVEMENT_JSON("808", "0xH0008=5") ","
-      GENERIC_ACHIEVEMENT_JSON("416", "0x 0004=5") ","
-      GENERIC_ACHIEVEMENT_JSON("516", "0x 0005=5") ","
-      GENERIC_ACHIEVEMENT_JSON("616", "0x 0006=5") ","
-      GENERIC_ACHIEVEMENT_JSON("716", "0x 0007=5") ","
-      GENERIC_ACHIEVEMENT_JSON("816", "0x 0008=5") ","
-      GENERIC_ACHIEVEMENT_JSON("424", "0xW0004=5") ","
-      GENERIC_ACHIEVEMENT_JSON("524", "0xW0005=5") ","
-      GENERIC_ACHIEVEMENT_JSON("624", "0xW0006=5") ","
-      GENERIC_ACHIEVEMENT_JSON("724", "0xW0007=5") ","
-      GENERIC_ACHIEVEMENT_JSON("824", "0xW0008=5") ","
-      GENERIC_ACHIEVEMENT_JSON("432", "0xX0004=5") ","
-      GENERIC_ACHIEVEMENT_JSON("532", "0xX0005=5") ","
-      GENERIC_ACHIEVEMENT_JSON("632", "0xX0006=5") ","
-      GENERIC_ACHIEVEMENT_JSON("732", "0xX0007=5") ","
-      GENERIC_ACHIEVEMENT_JSON("832", "0xX0008=5")
-    "],"
-    "\"Leaderboards\":[]"
-    "}}";
+static const char* patchdata_bounds_check_8 = "{\"Success\":true,"
+    "\"GameId\":1234,\"Title\":\"Sample Game\",\"ConsoleId\":7,"
+    "\"ImageIconUrl\":\"http://server/Images/112233.png\","
+    "\"RichPresenceGameId\":1234,\"RichPresencePatch\":\"\",\"Sets\":[{"
+      "\"AchievementSetId\":1111,\"GameId\":1234,\"Title\":null,\"Type\":\"core\","
+      "\"ImageIconUrl\":\"http://server/Images/112233.png\","
+      "\"Achievements\":["
+        GENERIC_ACHIEVEMENT_JSON("408", "0xH0004=5") ","
+        GENERIC_ACHIEVEMENT_JSON("508", "0xH0005=5") ","
+        GENERIC_ACHIEVEMENT_JSON("608", "0xH0006=5") ","
+        GENERIC_ACHIEVEMENT_JSON("708", "0xH0007=5") ","
+        GENERIC_ACHIEVEMENT_JSON("808", "0xH0008=5") ","
+        GENERIC_ACHIEVEMENT_JSON("416", "0x 0004=5") ","
+        GENERIC_ACHIEVEMENT_JSON("516", "0x 0005=5") ","
+        GENERIC_ACHIEVEMENT_JSON("616", "0x 0006=5") ","
+        GENERIC_ACHIEVEMENT_JSON("716", "0x 0007=5") ","
+        GENERIC_ACHIEVEMENT_JSON("816", "0x 0008=5") ","
+        GENERIC_ACHIEVEMENT_JSON("424", "0xW0004=5") ","
+        GENERIC_ACHIEVEMENT_JSON("524", "0xW0005=5") ","
+        GENERIC_ACHIEVEMENT_JSON("624", "0xW0006=5") ","
+        GENERIC_ACHIEVEMENT_JSON("724", "0xW0007=5") ","
+        GENERIC_ACHIEVEMENT_JSON("824", "0xW0008=5") ","
+        GENERIC_ACHIEVEMENT_JSON("432", "0xX0004=5") ","
+        GENERIC_ACHIEVEMENT_JSON("532", "0xX0005=5") ","
+        GENERIC_ACHIEVEMENT_JSON("632", "0xX0006=5") ","
+        GENERIC_ACHIEVEMENT_JSON("732", "0xX0007=5") ","
+        GENERIC_ACHIEVEMENT_JSON("832", "0xX0008=5")
+      "],"
+      "\"Leaderboards\":[]"
+    "}]}";
 
-static const char* patchdata_exhaustive = "{\"Success\":true,\"PatchData\":{"
-    "\"ID\":1234,\"Title\":\"Sample Game\",\"ConsoleID\":7,\"ImageIcon\":\"/Images/112233.png\","
-    "\"Achievements\":["
-      GENERIC_ACHIEVEMENT_JSON("5", "0xH0005=5") ","
-      GENERIC_ACHIEVEMENT_JSON("6", "M:0xH0006=6") ","
-      GENERIC_ACHIEVEMENT_JSON("7", "T:0xH0007=7_0xH0001=1") ","
-      GENERIC_ACHIEVEMENT_JSON("8", "0xH0008=8") ","
-      GENERIC_ACHIEVEMENT_JSON("9", "0xH0009=9") ","
-      GENERIC_ACHIEVEMENT_JSON("70", "M:0xX0010=100000") ","
-      GENERIC_ACHIEVEMENT_JSON("71", "G:0xX0010=100000")
-    "],"
-    "\"Leaderboards\":["
-      GENERIC_LEADERBOARD_JSON("44", "STA:0xH000B=1::CAN:0xH000C=1::SUB:0xH000D=1::VAL:0x 000E", "SCORE") ","
-      GENERIC_LEADERBOARD_JSON("45", "STA:0xH000A=1::CAN:0xH000C=2::SUB:0xH000D=1::VAL:0xH000E", "SCORE") ","   /* different size */
-      GENERIC_LEADERBOARD_JSON("46", "STA:0xH000A=1::CAN:0xH000C=3::SUB:0xH000D=1::VAL:0x 000E", "VALUE") ","   /* different format */
-      GENERIC_LEADERBOARD_JSON("47", "STA:0xH000A=1::CAN:0xH000C=4::SUB:0xH000D=2::VAL:0x 000E", "SCORE") ","   /* different submit */
-      GENERIC_LEADERBOARD_JSON("48", "STA:0xH000A=2::CAN:0xH000C=5::SUB:0xH000D=1::VAL:0x 000E", "SCORE") ","   /* different start */
-      GENERIC_LEADERBOARD_JSON("51", "STA:0xH000A=3::CAN:0xH000C=6::SUB:0xH000D=1::VAL:M:0xH0009=1", "VALUE") "," /* hit count */
-      GENERIC_LEADERBOARD_JSON("52", "STA:0xH000B=3::CAN:0xH000C=7::SUB:0xH000D=1::VAL:M:0xH0009=1", "VALUE")     /* hit count */
-    "],"
-    "\"RichPresencePatch\":\"Display:\\r\\nPoints:@Number(0xH0003)\\r\\n\""
-    "}}";
+static const char* patchdata_exhaustive = "{\"Success\":true,"
+    "\"GameId\":1234,\"Title\":\"Sample Game\",\"ConsoleId\":17,"
+    "\"ImageIconUrl\":\"http://server/Images/112233.png\","
+    "\"RichPresenceGameId\":1234,\"RichPresencePatch\":\"Display:\\r\\nPoints:@Number(0xH0003)\\r\\n\","
+    "\"Sets\":[{"
+      "\"AchievementSetId\":1111,\"GameId\":1234,\"Title\":null,\"Type\":\"core\","
+      "\"ImageIconUrl\":\"http://server/Images/112233.png\","
+      "\"Achievements\":["
+        GENERIC_ACHIEVEMENT_JSON("5", "0xH0005=5") ","
+        GENERIC_ACHIEVEMENT_JSON("6", "M:0xH0006=6") ","
+        GENERIC_ACHIEVEMENT_JSON("7", "T:0xH0007=7_0xH0001=1") ","
+        GENERIC_ACHIEVEMENT_JSON("8", "0xH0008=8") ","
+        GENERIC_ACHIEVEMENT_JSON("9", "0xH0009=9") ","
+        GENERIC_ACHIEVEMENT_JSON("70", "M:0xX0010=100000") ","
+        GENERIC_ACHIEVEMENT_JSON("71", "G:0xX0010=100000")
+      "],"
+      "\"Leaderboards\":["
+        GENERIC_LEADERBOARD_JSON("44", "STA:0xH000B=1::CAN:0xH000C=1::SUB:0xH000D=1::VAL:0x 000E", "SCORE") ","
+        GENERIC_LEADERBOARD_JSON("45", "STA:0xH000A=1::CAN:0xH000C=2::SUB:0xH000D=1::VAL:0xH000E", "SCORE") ","   /* different size */
+        GENERIC_LEADERBOARD_JSON("46", "STA:0xH000A=1::CAN:0xH000C=3::SUB:0xH000D=1::VAL:0x 000E", "VALUE") ","   /* different format */
+        GENERIC_LEADERBOARD_JSON("47", "STA:0xH000A=1::CAN:0xH000C=4::SUB:0xH000D=2::VAL:0x 000E", "SCORE") ","   /* different submit */
+        GENERIC_LEADERBOARD_JSON("48", "STA:0xH000A=2::CAN:0xH000C=5::SUB:0xH000D=1::VAL:0x 000E", "SCORE") ","   /* different start */
+        GENERIC_LEADERBOARD_JSON("51", "STA:0xH000A=3::CAN:0xH000C=6::SUB:0xH000D=1::VAL:M:0xH0009=1", "VALUE") "," /* hit count */
+        GENERIC_LEADERBOARD_JSON("52", "STA:0xH000B=3::CAN:0xH000C=7::SUB:0xH000D=1::VAL:M:0xH0009=1", "VALUE")     /* hit count */
+      "]"
+    "}]}";
 
 
-static const char* patchdata_exhaustive_typed = "{\"Success\":true,\"PatchData\":{"
-    "\"ID\":1234,\"Title\":\"Sample Game\",\"ConsoleID\":7,\"ImageIcon\":\"/Images/112233.png\","
-    "\"Achievements\":["
-      TYPED_ACHIEVEMENT_JSON("5", "0xH0005=5", "", "100.0", "99.5") ","
-      TYPED_ACHIEVEMENT_JSON("6", "M:0xH0006=6", "progression", "95.3", "84.7") ","
-      TYPED_ACHIEVEMENT_JSON("7", "T:0xH0007=7_0xH0001=1", "missable", "47.6", "38.2") ","
-      TYPED_ACHIEVEMENT_JSON("8", "0xH0008=8", "progression", "86.0", "73.1") ","
-      TYPED_ACHIEVEMENT_JSON("9", "0xH0009=9", "win_condition", "81.4", "66.4") ","
-      TYPED_ACHIEVEMENT_JSON("70", "M:0xX0010=100000", "missable", "11.4", "6.3") ","
-      TYPED_ACHIEVEMENT_JSON("71", "G:0xX0010=100000", "", "8.7", "3.8")
-    "],"
-    "\"Leaderboards\":["
-      GENERIC_LEADERBOARD_JSON("44", "STA:0xH000B=1::CAN:0xH000C=1::SUB:0xH000D=1::VAL:0x 000E", "SCORE") ","
-      GENERIC_LEADERBOARD_JSON("45", "STA:0xH000A=1::CAN:0xH000C=2::SUB:0xH000D=1::VAL:0xH000E", "SCORE") ","   /* different size */
-      GENERIC_LEADERBOARD_JSON("46", "STA:0xH000A=1::CAN:0xH000C=3::SUB:0xH000D=1::VAL:0x 000E", "VALUE") ","   /* different format */
-      GENERIC_LEADERBOARD_JSON("47", "STA:0xH000A=1::CAN:0xH000C=4::SUB:0xH000D=2::VAL:0x 000E", "SCORE") ","   /* different submit */
-      GENERIC_LEADERBOARD_JSON("48", "STA:0xH000A=2::CAN:0xH000C=5::SUB:0xH000D=1::VAL:0x 000E", "SCORE") ","   /* different start */
-      GENERIC_LEADERBOARD_JSON("51", "STA:0xH000A=3::CAN:0xH000C=6::SUB:0xH000D=1::VAL:M:0xH0009=1", "VALUE") "," /* hit count */
-      GENERIC_LEADERBOARD_JSON("52", "STA:0xH000B=3::CAN:0xH000C=7::SUB:0xH000D=1::VAL:M:0xH0009=1", "VALUE")     /* hit count */
-    "],"
-    "\"RichPresencePatch\":\"Display:\\r\\nPoints:@Number(0xH0003)\\r\\n\""
-    "}}";
+static const char* patchdata_exhaustive_typed = "{\"Success\":true,"
+    "\"GameId\":1234,\"Title\":\"Sample Game\",\"ConsoleId\":17,"
+    "\"ImageIconUrl\":\"http://server/Images/112233.png\","
+    "\"RichPresenceGameId\":1234,\"RichPresencePatch\":\"Display:\\r\\nPoints:@Number(0xH0003)\\r\\n\","
+    "\"Sets\":[{"
+      "\"AchievementSetId\":1111,\"GameId\":1234,\"Title\":null,\"Type\":\"core\","
+      "\"ImageIconUrl\":\"http://server/Images/112233.png\","
+      "\"Achievements\":["
+        TYPED_ACHIEVEMENT_JSON("5", "0xH0005=5", "", "100.0", "99.5") ","
+        TYPED_ACHIEVEMENT_JSON("6", "M:0xH0006=6", "progression", "95.3", "84.7") ","
+        TYPED_ACHIEVEMENT_JSON("7", "T:0xH0007=7_0xH0001=1", "missable", "47.6", "38.2") ","
+        TYPED_ACHIEVEMENT_JSON("8", "0xH0008=8", "progression", "86.0", "73.1") ","
+        TYPED_ACHIEVEMENT_JSON("9", "0xH0009=9", "win_condition", "81.4", "66.4") ","
+        TYPED_ACHIEVEMENT_JSON("70", "M:0xX0010=100000", "missable", "11.4", "6.3") ","
+        TYPED_ACHIEVEMENT_JSON("71", "G:0xX0010=100000", "", "8.7", "3.8")
+      "],"
+      "\"Leaderboards\":["
+        GENERIC_LEADERBOARD_JSON("44", "STA:0xH000B=1::CAN:0xH000C=1::SUB:0xH000D=1::VAL:0x 000E", "SCORE") ","
+        GENERIC_LEADERBOARD_JSON("45", "STA:0xH000A=1::CAN:0xH000C=2::SUB:0xH000D=1::VAL:0xH000E", "SCORE") ","   /* different size */
+        GENERIC_LEADERBOARD_JSON("46", "STA:0xH000A=1::CAN:0xH000C=3::SUB:0xH000D=1::VAL:0x 000E", "VALUE") ","   /* different format */
+        GENERIC_LEADERBOARD_JSON("47", "STA:0xH000A=1::CAN:0xH000C=4::SUB:0xH000D=2::VAL:0x 000E", "SCORE") ","   /* different submit */
+        GENERIC_LEADERBOARD_JSON("48", "STA:0xH000A=2::CAN:0xH000C=5::SUB:0xH000D=1::VAL:0x 000E", "SCORE") ","   /* different start */
+        GENERIC_LEADERBOARD_JSON("51", "STA:0xH000A=3::CAN:0xH000C=6::SUB:0xH000D=1::VAL:M:0xH0009=1", "VALUE") "," /* hit count */
+        GENERIC_LEADERBOARD_JSON("52", "STA:0xH000B=3::CAN:0xH000C=7::SUB:0xH000D=1::VAL:M:0xH0009=1", "VALUE")     /* hit count */
+      "]"
+    "}]}";
 
-static const char* patchdata_big_ids = "{\"Success\":true,\"PatchData\":{"
-    "\"ID\":1234,\"Title\":\"Sample Game\",\"ConsoleID\":7,\"ImageIcon\":\"/Images/112233.png\","
-    "\"Achievements\":["
-      GENERIC_ACHIEVEMENT_JSON("5", "0xH0005=5") ","
-      GENERIC_ACHIEVEMENT_JSON("6", "M:0xH0006=6") ","
-      GENERIC_ACHIEVEMENT_JSON("4294967295", "0xH0009=9") "," /* UINT_MAX */
-      GENERIC_ACHIEVEMENT_JSON("71", "G:0xX0010=100000")
-    "],"
-    "\"Leaderboards\":[]"
-    "}}";
+static const char* patchdata_big_ids = "{\"Success\":true,"
+    "\"GameId\":1234,\"Title\":\"Sample Game\",\"ConsoleId\":17,"
+    "\"ImageIconUrl\":\"http://server/Images/112233.png\","
+    "\"RichPresenceGameId\":1234,\"RichPresencePatch\":\"Display:\\r\\nPoints:@Number(0xH0003)\\r\\n\","
+    "\"Sets\":[{"
+      "\"AchievementSetId\":1111,\"GameId\":1234,\"Title\":null,\"Type\":\"core\","
+      "\"ImageIconUrl\":\"http://server/Images/112233.png\","
+      "\"Achievements\":["
+        GENERIC_ACHIEVEMENT_JSON("5", "0xH0005=5") ","
+        GENERIC_ACHIEVEMENT_JSON("6", "M:0xH0006=6") ","
+        GENERIC_ACHIEVEMENT_JSON("4294967295", "0xH0009=9") "," /* UINT_MAX */
+        GENERIC_ACHIEVEMENT_JSON("71", "G:0xX0010=100000")
+      "],"
+      "\"Leaderboards\":[]"
+    "}]}";
 
 #define HIDDEN_LEADERBOARD_JSON(id, memaddr, format) "{\"ID\":" id ",\"Title\":\"Leaderboard " id "\"," \
       "\"Description\":\"Desc " id "\",\"Mem\":\"" memaddr "\",\"Format\":\"" format "\",\"Hidden\":true}"
 
-static const char* patchdata_leaderboards_hidden = "{\"Success\":true,\"PatchData\":{"
-    "\"ID\":1234,\"Title\":\"Sample Game\",\"ConsoleID\":7,\"ImageIcon\":\"/Images/112233.png\","
-    "\"Achievements\":["
-    "],"
-    "\"Leaderboards\":["
-      GENERIC_LEADERBOARD_JSON("44", "STA:0xH000B=1::CAN:0xH000C=1::SUB:0xH000D=1::VAL:0x 000E", "SCORE") ","
-      HIDDEN_LEADERBOARD_JSON("45", "STA:0xH000A=1::CAN:0xH000C=2::SUB:0xH000D=1::VAL:0xH000E", "SCORE") ","
-      GENERIC_LEADERBOARD_JSON("46", "STA:0xH000A=1::CAN:0xH000C=3::SUB:0xH000D=1::VAL:0x 000E", "VALUE") ","
-      GENERIC_LEADERBOARD_JSON("47", "STA:0xH000A=1::CAN:0xH000C=4::SUB:0xH000D=2::VAL:0x 000E", "SCORE") ","
-      HIDDEN_LEADERBOARD_JSON("48", "STA:0xH000A=2::CAN:0xH000C=5::SUB:0xH000D=1::VAL:0x 000E", "SCORE")
-    "],"
-    "\"RichPresencePatch\":\"Display:\\r\\nPoints:@Number(0xH0003)\\r\\n\""
-    "}}";
-
-static const char* patchdata_unofficial_unsupported = "{\"Success\":true,\"PatchData\":{"
-    "\"ID\":1234,\"Title\":\"Sample Game\",\"ConsoleID\":17,\"ImageIcon\":\"/Images/112233.png\","
-    "\"Achievements\":["
-     "{\"ID\":5501,\"Title\":\"Ach1\",\"Description\":\"Desc1\",\"Flags\":3,\"Points\":5,"
-      "\"MemAddr\":\"0xH0001=1_0xH0002=7\",\"Author\":\"User1\",\"BadgeName\":\"00234\","
-      "\"Created\":1367266583,\"Modified\":1376929305},"
-     "{\"ID\":5502,\"Title\":\"Ach2\",\"Description\":\"Desc2\",\"Flags\":5,\"Points\":2,"
-      "\"MemAddr\":\"0xH0001=2_0x0002=9\",\"Author\":\"User1\",\"BadgeName\":\"00235\","
-      "\"Created\":1376970283,\"Modified\":1376970283},"
-     "{\"ID\":5503,\"Title\":\"Ach3\",\"Description\":\"Desc3\",\"Flags\":3,\"Points\":2,"
-      "\"MemAddr\":\"0xHFEFEFEFE=2_0x0002=9\",\"Author\":\"User1\",\"BadgeName\":\"00236\","
-      "\"Created\":1376971283,\"Modified\":1376971283}"
-    "],"
-    "\"Leaderboards\":["
-     "{\"ID\":4401,\"Title\":\"Leaderboard1\",\"Description\":\"Desc1\","
-      "\"Mem\":\"STA:0xH000C=1::CAN:0xH000D=1::SUB:0xHFEFEFEFE=2::VAL:0x 000E\",\"Format\":\"SCORE\"}"
-    "]"
-    "}}";
-
-static const char* patchdata_subset = "{\"Success\":true,\"PatchData\":{"
-    "\"ID\":1234,\"Title\":\"Sample Game\",\"ConsoleID\":17,\"ImageIcon\":\"/Images/112233.png\","
-    "\"Achievements\":["
-      GENERIC_ACHIEVEMENT_JSON("5", "0xH0005=5") ","
-      GENERIC_ACHIEVEMENT_JSON("6", "M:0xH0006=6") ","
-      GENERIC_ACHIEVEMENT_JSON("7", "T:0xH0007=7_0xH0001=1") ","
-      GENERIC_ACHIEVEMENT_JSON("8", "0xH0008=8") ","
-      GENERIC_ACHIEVEMENT_JSON("9", "0xH0009=9") ","
-      GENERIC_ACHIEVEMENT_JSON("70", "M:0xX0010=100000") ","
-      GENERIC_ACHIEVEMENT_JSON("71", "G:0xX0010=100000")
-    "],"
-    "\"Leaderboards\":["
-      GENERIC_LEADERBOARD_JSON("44", "STA:0xH000B=1::CAN:0xH000C=1::SUB:0xH000D=1::VAL:0x 000E", "SCORE") ","
-      GENERIC_LEADERBOARD_JSON("45", "STA:0xH000A=1::CAN:0xH000C=2::SUB:0xH000D=1::VAL:0xH000E", "SCORE") ","   /* different size */
-      GENERIC_LEADERBOARD_JSON("46", "STA:0xH000A=1::CAN:0xH000C=3::SUB:0xH000D=1::VAL:0x 000E", "VALUE") ","   /* different format */
-      GENERIC_LEADERBOARD_JSON("47", "STA:0xH000A=1::CAN:0xH000C=4::SUB:0xH000D=2::VAL:0x 000E", "SCORE") ","   /* different submit */
-      GENERIC_LEADERBOARD_JSON("48", "STA:0xH000A=2::CAN:0xH000C=5::SUB:0xH000D=1::VAL:0x 000E", "SCORE") ","   /* different start */
-      GENERIC_LEADERBOARD_JSON("51", "STA:0xH000A=3::CAN:0xH000C=6::SUB:0xH000D=1::VAL:M:0xH0009=1", "VALUE") "," /* hit count */
-      GENERIC_LEADERBOARD_JSON("52", "STA:0xH000B=3::CAN:0xH000C=7::SUB:0xH000D=1::VAL:M:0xH0009=1", "VALUE")     /* hit count */
-    "],"
-    "\"RichPresencePatch\":\"Display:\\r\\nPoints:@Number(0xH0003)\\r\\n\","
+static const char* patchdata_leaderboards_hidden = "{\"Success\":true,"
+    "\"GameId\":1234,\"Title\":\"Sample Game\",\"ConsoleId\":17,"
+    "\"ImageIconUrl\":\"http://server/Images/112233.png\","
+    "\"RichPresenceGameId\":1234,\"RichPresencePatch\":\"Display:\\r\\nPoints:@Number(0xH0003)\\r\\n\","
     "\"Sets\":[{"
-      "\"GameAchievementSetID\":2345,\"SetTitle\":\"Bonus\",\"ImageIcon\":\"/Images/112234.png\","
-      "\"ImageIconURL\":\"http://host/Images/112234.png\","
+      "\"AchievementSetId\":1111,\"GameId\":1234,\"Title\":null,\"Type\":\"core\","
+      "\"ImageIconUrl\":\"http://server/Images/112233.png\","
+      "\"Achievements\":[],"
+      "\"Leaderboards\":["
+        GENERIC_LEADERBOARD_JSON("44", "STA:0xH000B=1::CAN:0xH000C=1::SUB:0xH000D=1::VAL:0x 000E", "SCORE") ","
+        HIDDEN_LEADERBOARD_JSON("45", "STA:0xH000A=1::CAN:0xH000C=2::SUB:0xH000D=1::VAL:0xH000E", "SCORE") ","
+        GENERIC_LEADERBOARD_JSON("46", "STA:0xH000A=1::CAN:0xH000C=3::SUB:0xH000D=1::VAL:0x 000E", "VALUE") ","
+        GENERIC_LEADERBOARD_JSON("47", "STA:0xH000A=1::CAN:0xH000C=4::SUB:0xH000D=2::VAL:0x 000E", "SCORE") ","
+        HIDDEN_LEADERBOARD_JSON("48", "STA:0xH000A=2::CAN:0xH000C=5::SUB:0xH000D=1::VAL:0x 000E", "SCORE")
+      "]"
+    "}]}";
+
+static const char* patchdata_unofficial_unsupported = "{\"Success\":true,"
+    "\"GameId\":1234,\"Title\":\"Sample Game\",\"ConsoleId\":17,"
+    "\"ImageIconUrl\":\"http://server/Images/112233.png\","
+    "\"RichPresenceGameId\":1234,\"RichPresencePatch\":\"Display:\\r\\nPoints:@Number(0xH0003)\\r\\n\","
+    "\"Sets\":[{"
+      "\"AchievementSetId\":1111,\"GameId\":1234,\"Title\":null,\"Type\":\"core\","
+      "\"ImageIconUrl\":\"http://server/Images/112233.png\","
+      "\"Achievements\":["
+       "{\"ID\":5501,\"Title\":\"Ach1\",\"Description\":\"Desc1\",\"Flags\":3,\"Points\":5,"
+        "\"MemAddr\":\"0xH0001=1_0xH0002=7\",\"Author\":\"User1\",\"BadgeName\":\"00234\","
+        "\"Created\":1367266583,\"Modified\":1376929305},"
+       "{\"ID\":5502,\"Title\":\"Ach2\",\"Description\":\"Desc2\",\"Flags\":5,\"Points\":2,"
+        "\"MemAddr\":\"0xH0001=2_0x0002=9\",\"Author\":\"User1\",\"BadgeName\":\"00235\","
+        "\"Created\":1376970283,\"Modified\":1376970283},"
+       "{\"ID\":5503,\"Title\":\"Ach3\",\"Description\":\"Desc3\",\"Flags\":3,\"Points\":2,"
+        "\"MemAddr\":\"0xHFEFEFEFE=2_0x0002=9\",\"Author\":\"User1\",\"BadgeName\":\"00236\","
+        "\"Created\":1376971283,\"Modified\":1376971283}"
+      "],"
+      "\"Leaderboards\":["
+       "{\"ID\":4401,\"Title\":\"Leaderboard1\",\"Description\":\"Desc1\","
+        "\"Mem\":\"STA:0xH000C=1::CAN:0xH000D=1::SUB:0xHFEFEFEFE=2::VAL:0x 000E\",\"Format\":\"SCORE\"}"
+      "]"
+    "}]}";
+
+static const char* patchdata_subset = "{\"Success\":true,"
+    "\"GameId\":1234,\"Title\":\"Sample Game\",\"ConsoleId\":17,"
+    "\"ImageIconUrl\":\"http://server/Images/112233.png\","
+    "\"RichPresenceGameId\":1234,\"RichPresencePatch\":\"Display:\\r\\nPoints:@Number(0xH0003)\\r\\n\","
+    "\"Sets\":[{"
+      "\"AchievementSetId\":1111,\"GameId\":1234,\"Title\":null,\"Type\":\"core\","
+      "\"ImageIconUrl\":\"http://server/Images/112233.png\","
+      "\"Achievements\":["
+        GENERIC_ACHIEVEMENT_JSON("5", "0xH0005=5") ","
+        GENERIC_ACHIEVEMENT_JSON("6", "M:0xH0006=6") ","
+        GENERIC_ACHIEVEMENT_JSON("7", "T:0xH0007=7_0xH0001=1") ","
+        GENERIC_ACHIEVEMENT_JSON("8", "0xH0008=8") ","
+        GENERIC_ACHIEVEMENT_JSON("9", "0xH0009=9") ","
+        GENERIC_ACHIEVEMENT_JSON("70", "M:0xX0010=100000") ","
+        GENERIC_ACHIEVEMENT_JSON("71", "G:0xX0010=100000")
+      "],"
+      "\"Leaderboards\":["
+        GENERIC_LEADERBOARD_JSON("44", "STA:0xH000B=1::CAN:0xH000C=1::SUB:0xH000D=1::VAL:0x 000E", "SCORE") ","
+        GENERIC_LEADERBOARD_JSON("45", "STA:0xH000A=1::CAN:0xH000C=2::SUB:0xH000D=1::VAL:0xH000E", "SCORE") ","   /* different size */
+        GENERIC_LEADERBOARD_JSON("46", "STA:0xH000A=1::CAN:0xH000C=3::SUB:0xH000D=1::VAL:0x 000E", "VALUE") ","   /* different format */
+        GENERIC_LEADERBOARD_JSON("47", "STA:0xH000A=1::CAN:0xH000C=4::SUB:0xH000D=2::VAL:0x 000E", "SCORE") ","   /* different submit */
+        GENERIC_LEADERBOARD_JSON("48", "STA:0xH000A=2::CAN:0xH000C=5::SUB:0xH000D=1::VAL:0x 000E", "SCORE") ","   /* different start */
+        GENERIC_LEADERBOARD_JSON("51", "STA:0xH000A=3::CAN:0xH000C=6::SUB:0xH000D=1::VAL:M:0xH0009=1", "VALUE") "," /* hit count */
+        GENERIC_LEADERBOARD_JSON("52", "STA:0xH000B=3::CAN:0xH000C=7::SUB:0xH000D=1::VAL:M:0xH0009=1", "VALUE")     /* hit count */
+      "]"
+    "},{"
+      "\"AchievementSetId\":2345,\"GameId\":1235,\"Title\":\"Bonus\",\"Type\":\"bonus\","
+      "\"ImageIconUrl\":\"http://server/Images/112234.png\","
       "\"Achievements\":["
         GENERIC_ACHIEVEMENT_JSON("5501", "0xH0017=7") ","
         GENERIC_ACHIEVEMENT_JSON("5502", "0xH0018=8") ","
@@ -267,34 +326,37 @@ static const char* patchdata_subset = "{\"Success\":true,\"PatchData\":{"
       "\"Leaderboards\":["
         GENERIC_LEADERBOARD_JSON("81", "STA:0xH0008=1::CAN:0xH000C=1::SUB:0xH000D=1::VAL:0x 000E", "SCORE") ","
         GENERIC_LEADERBOARD_JSON("82", "STA:0xH0008=2::CAN:0xH000C=1::SUB:0xH000D=1::VAL:0x 000E", "SCORE")
-      "]}"
-    "]"
-    "}}";
+      "]"
+    "}]}";
 
-static const char* patchdata_subset_unofficial_unsupported = "{\"Success\":true,\"PatchData\":{"
-    "\"ID\":1234,\"Title\":\"Sample Game\",\"ConsoleID\":17,\"ImageIcon\":\"/Images/112233.png\","
-    "\"Achievements\":["
-      GENERIC_ACHIEVEMENT_JSON("5", "0xH0005=5") ","
-      GENERIC_ACHIEVEMENT_JSON("6", "M:0xH0006=6") ","
-      GENERIC_ACHIEVEMENT_JSON("7", "T:0xH0007=7_0xH0001=1") ","
-      UNOFFICIAL_ACHIEVEMENT_JSON("8", "0xH0008=8") ","
-      GENERIC_ACHIEVEMENT_JSON("9", "0xH0009=9") ","
-      GENERIC_ACHIEVEMENT_JSON("70", "M:0xX0010=100000") ","
-      GENERIC_ACHIEVEMENT_JSON("71", "G:0xX0010=100000")
-    "],"
-    "\"Leaderboards\":["
-      GENERIC_LEADERBOARD_JSON("44", "STA:0xH000B=1::CAN:0xH000C=1::SUB:0xH000D=1::VAL:0x 000E", "SCORE") ","
-      GENERIC_LEADERBOARD_JSON("45", "STA:0xH000A=1::CAN:0xH000C=2::SUB:0xH000D=1::VAL:0xH000E", "SCORE") ","   /* different size */
-      GENERIC_LEADERBOARD_JSON("46", "STA:0xH000A=1::CAN:0xH000C=3::SUB:0xH000D=1::VAL:0x 000E", "VALUE") ","   /* different format */
-      GENERIC_LEADERBOARD_JSON("47", "STA:0xH000A=1::CAN:0xH000C=4::SUB:0xH000D=2::VAL:0x 000E", "SCORE") ","   /* different submit */
-      GENERIC_LEADERBOARD_JSON("48", "STA:0xH000A=2::CAN:0xH000C=5::SUB:0xH000D=1::VAL:0x 000E", "SCORE") ","   /* different start */
-      GENERIC_LEADERBOARD_JSON("51", "STA:0xH000A=3::CAN:0xH000C=6::SUB:0xH000D=1::VAL:M:0xH0009=1", "VALUE") "," /* hit count */
-      GENERIC_LEADERBOARD_JSON("52", "STA:0xH000B=3::CAN:0xH000C=7::SUB:0xH000D=1::VAL:M:0xH0009=1", "VALUE")     /* hit count */
-    "],"
-    "\"RichPresencePatch\":\"Display:\\r\\nPoints:@Number(0xH0003)\\r\\n\","
+static const char* patchdata_subset_unofficial_unsupported = "{\"Success\":true,"
+    "\"GameId\":1234,\"Title\":\"Sample Game\",\"ConsoleId\":17,"
+    "\"ImageIconUrl\":\"http://server/Images/112233.png\","
+    "\"RichPresenceGameId\":1234,\"RichPresencePatch\":\"Display:\\r\\nPoints:@Number(0xH0003)\\r\\n\","
     "\"Sets\":[{"
-      "\"GameAchievementSetID\":2345,\"SetTitle\":\"Bonus\",\"ImageIcon\":\"/Images/112234.png\","
-      "\"ImageIconURL\":\"http://host/Images/112234.png\","
+      "\"AchievementSetId\":1111,\"GameId\":1234,\"Title\":null,\"Type\":\"core\","
+      "\"ImageIconUrl\":\"http://server/Images/112233.png\","
+      "\"Achievements\":["
+        GENERIC_ACHIEVEMENT_JSON("5", "0xH0005=5") ","
+        GENERIC_ACHIEVEMENT_JSON("6", "M:0xH0006=6") ","
+        GENERIC_ACHIEVEMENT_JSON("7", "T:0xH0007=7_0xH0001=1") ","
+        UNOFFICIAL_ACHIEVEMENT_JSON("8", "0xH0008=8") ","
+        GENERIC_ACHIEVEMENT_JSON("9", "0xH0009=9") ","
+        GENERIC_ACHIEVEMENT_JSON("70", "M:0xX0010=100000") ","
+        GENERIC_ACHIEVEMENT_JSON("71", "G:0xX0010=100000")
+      "],"
+      "\"Leaderboards\":["
+        GENERIC_LEADERBOARD_JSON("44", "STA:0xH000B=1::CAN:0xH000C=1::SUB:0xH000D=1::VAL:0x 000E", "SCORE") ","
+        GENERIC_LEADERBOARD_JSON("45", "STA:0xH000A=1::CAN:0xH000C=2::SUB:0xH000D=1::VAL:0xH000E", "SCORE") ","   /* different size */
+        GENERIC_LEADERBOARD_JSON("46", "STA:0xH000A=1::CAN:0xH000C=3::SUB:0xH000D=1::VAL:0x 000E", "VALUE") ","   /* different format */
+        GENERIC_LEADERBOARD_JSON("47", "STA:0xH000A=1::CAN:0xH000C=4::SUB:0xH000D=2::VAL:0x 000E", "SCORE") ","   /* different submit */
+        GENERIC_LEADERBOARD_JSON("48", "STA:0xH000A=2::CAN:0xH000C=5::SUB:0xH000D=1::VAL:0x 000E", "SCORE") ","   /* different start */
+        GENERIC_LEADERBOARD_JSON("51", "STA:0xH000A=3::CAN:0xH000C=6::SUB:0xH000D=1::VAL:M:0xH0009=1", "VALUE") "," /* hit count */
+        GENERIC_LEADERBOARD_JSON("52", "STA:0xH000B=3::CAN:0xH000C=7::SUB:0xH000D=1::VAL:M:0xH0009=1", "VALUE")     /* hit count */
+      "]"
+    "},{"
+      "\"AchievementSetId\":2345,\"GameId\":1235,\"Title\":\"Bonus\",\"Type\":\"bonus\","
+      "\"ImageIconUrl\":\"http://server/Images/112234.png\","
       "\"Achievements\":["
         GENERIC_ACHIEVEMENT_JSON("5501", "0xH0017=7") ","
         UNOFFICIAL_ACHIEVEMENT_JSON("5502", "0xH0018=8") ","
@@ -303,9 +365,8 @@ static const char* patchdata_subset_unofficial_unsupported = "{\"Success\":true,
       "\"Leaderboards\":["
         GENERIC_LEADERBOARD_JSON("81", "STA:0xH0008=1::CAN:0xH000C=1::SUB:0xH000D=1::VAL:0x 000E", "SCORE") ","
         GENERIC_LEADERBOARD_JSON("82", "STA:0xH0008=2::CAN:0xH000C=1::SUB:0xH000D=1::VAL:0x 000E", "SCORE")
-      "]}"
-    "]"
-    "}}";
+      "]"
+    "}]}";
 
 static const char* patchdata_not_found = "{\"Success\":false,\"Error\":\"Unknown game\",\"Code\":\"not_found\",\"Status\":404}";
 
@@ -698,7 +759,7 @@ static rc_client_t* mock_client_logged_in(void)
   client->user.display_name = "DisplayName";
   client->user.token = "ApiToken";
   client->user.score = 12345;
-  client->user.avatar_url = "http://host/UserPic/Username.png";
+  client->user.avatar_url = "http://server/UserPic/Username.png";
   client->state.user = RC_CLIENT_USER_STATE_LOGGED_IN;
 
   return client;
@@ -715,7 +776,7 @@ static void mock_client_load_game(const char* patchdata, const char* unlocks)
 {
   reset_mock_api_handlers();
   event_count = 0;
-  mock_api_response("r=patch&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata);
+  mock_api_response("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata);
   mock_api_response("r=startsession&u=Username&t=ApiToken&g=1234&h=1&m=0123456789ABCDEF&l=" RCHEEVOS_VERSION_STRING, unlocks);
 
   rc_client_begin_load_game(g_client, "0123456789ABCDEF", rc_client_callback_expect_success, g_callback_userdata);
@@ -728,7 +789,7 @@ static void mock_client_load_game_softcore(const char* patchdata, const char* un
 {
   reset_mock_api_handlers();
   event_count = 0;
-  mock_api_response("r=patch&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata);
+  mock_api_response("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata);
   mock_api_response("r=startsession&u=Username&t=ApiToken&g=1234&h=0&m=0123456789ABCDEF&l=" RCHEEVOS_VERSION_STRING, unlocks);
 
   rc_client_begin_load_game(g_client, "0123456789ABCDEF", rc_client_callback_expect_success, g_callback_userdata);
@@ -778,7 +839,7 @@ static void test_login_with_token(void)
   g_client = mock_client_not_logged_in();
   reset_mock_api_handlers();
   mock_api_response("r=login2&u=User&t=ApiToken",
-	  "{\"Success\":true,\"User\":\"User\",\"AvatarUrl\":\"http://host/UserPic/USER.png\",\"Token\":\"ApiToken\",\"Score\":12345,\"Messages\":2}");
+	  "{\"Success\":true,\"User\":\"User\",\"AvatarUrl\":\"http://server/UserPic/USER.png\",\"Token\":\"ApiToken\",\"Score\":12345,\"Messages\":2}");
 
   rc_client_begin_login_with_token(g_client, "User", "ApiToken", rc_client_callback_expect_success, g_callback_userdata);
 
@@ -787,7 +848,7 @@ static void test_login_with_token(void)
   ASSERT_STR_EQUALS(user->username, "User");
   ASSERT_STR_EQUALS(user->display_name, "User");
   ASSERT_STR_EQUALS(user->token, "ApiToken");
-  ASSERT_STR_EQUALS(user->avatar_url, "http://host/UserPic/USER.png");
+  ASSERT_STR_EQUALS(user->avatar_url, "http://server/UserPic/USER.png");
   ASSERT_NUM_EQUALS(user->score, 12345);
   ASSERT_NUM_EQUALS(user->num_unread_messages, 2);
 
@@ -1065,7 +1126,7 @@ static void test_logout(void)
 
   /* attempt to load game should fail */
   reset_mock_api_handlers();
-  mock_api_response("r=patch&u=Username&t=ApiToken&m=0123456789ABCDEF", "{\"Success\":true,\"GameID\":1234}");
+  mock_api_response("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", "{\"Success\":true,\"GameID\":1234}");
 
   rc_client_begin_load_game(g_client, "0123456789ABCDEF", rc_client_callback_expect_login_required, g_callback_userdata);
 
@@ -1132,7 +1193,7 @@ static void test_logout_during_fetch_game(void)
   rc_client_begin_load_game(g_client, "0123456789ABCDEF",
     rc_client_callback_expect_no_longer_active, g_callback_userdata);
 
-  async_api_response("r=patch&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
+  async_api_response("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
 
   rc_client_logout(g_client);
 
@@ -1149,10 +1210,10 @@ static void test_user_get_image_url(void)
 {
   char buffer[256];
   g_client = mock_client_game_loaded(patchdata_2ach_1lbd, no_unlocks);
-  ASSERT_STR_EQUALS(g_client->user.avatar_url, "http://host/UserPic/Username.png");
+  ASSERT_STR_EQUALS(g_client->user.avatar_url, "http://server/UserPic/Username.png");
 
   ASSERT_NUM_EQUALS(rc_client_user_get_image_url(rc_client_get_user_info(g_client), buffer, sizeof(buffer)), RC_OK);
-  ASSERT_STR_EQUALS(buffer, "http://host/UserPic/Username.png");
+  ASSERT_STR_EQUALS(buffer, "http://server/UserPic/Username.png");
 
   rc_client_destroy(g_client);
 }
@@ -1205,7 +1266,7 @@ static void test_get_user_game_summary_encore_mode(void)
   g_client = mock_client_logged_in();
   rc_client_set_unofficial_enabled(g_client, 1);
   reset_mock_api_handlers();
-  mock_api_response("r=patch&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_exhaustive);
+  mock_api_response("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_exhaustive);
   mock_api_response("r=startsession&u=Username&t=ApiToken&g=1234&h=1&m=0123456789ABCDEF&l=" RCHEEVOS_VERSION_STRING, unlock_6_8h_and_9);
 
   rc_client_set_encore_mode_enabled(g_client, 1);
@@ -1320,7 +1381,7 @@ static void test_get_user_game_summary_unknown_game(void)
   g_client = mock_client_logged_in();
 
   reset_mock_api_handlers();
-  mock_api_response("r=patch&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_not_found);
+  mock_api_response("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_not_found);
   rc_client_begin_load_game(g_client, "0123456789ABCDEF", rc_client_callback_expect_unknown_game, g_callback_userdata);
 
   rc_client_get_user_game_summary(g_client, &summary);
@@ -1363,7 +1424,7 @@ static void test_load_game_unknown_hash(void)
   g_client = mock_client_logged_in();
 
   reset_mock_api_handlers();
-  mock_api_response("r=patch&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_not_found);
+  mock_api_response("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_not_found);
 
   ASSERT_NUM_EQUALS(rc_client_get_load_game_state(g_client), RC_CLIENT_LOAD_GAME_STATE_NONE);
   ASSERT_NUM_EQUALS(rc_client_is_game_loaded(g_client), 0);
@@ -1408,7 +1469,7 @@ static void test_load_game_unknown_hash_repeated(void)
   ASSERT_PTR_NOT_NULL(handle);
   ASSERT_PTR_NOT_NULL(g_client->state.load);
 
-  async_api_response("r=patch&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_not_found);
+  async_api_response("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_not_found);
 
   ASSERT_PTR_NULL(g_client->state.load);
   ASSERT_PTR_NOT_NULL(g_client->game);
@@ -1455,7 +1516,7 @@ static void test_load_game_unknown_hash_multiple(void)
   ASSERT_PTR_NOT_NULL(handle);
   ASSERT_PTR_NOT_NULL(g_client->state.load);
 
-  async_api_response("r=patch&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_not_found);
+  async_api_response("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_not_found);
 
   ASSERT_PTR_NULL(g_client->state.load);
   ASSERT_PTR_NOT_NULL(g_client->game);
@@ -1474,7 +1535,7 @@ static void test_load_game_unknown_hash_multiple(void)
   ASSERT_PTR_NOT_NULL(handle);
   ASSERT_PTR_NOT_NULL(g_client->state.load);
 
-  async_api_response("r=patch&u=Username&t=ApiToken&m=FEDCBA9876543210", patchdata_not_found);
+  async_api_response("r=hashdata&u=Username&t=ApiToken&m=FEDCBA9876543210", patchdata_not_found);
 
   ASSERT_PTR_NULL(g_client->state.load);
   ASSERT_PTR_NOT_NULL(g_client->game);
@@ -1495,7 +1556,7 @@ static void test_load_game_not_logged_in(void)
   g_client = mock_client_not_logged_in();
 
   reset_mock_api_handlers();
-  mock_api_response("r=patch&u=Username&t=ApiToken&m=0123456789ABCDEF", "{\"Success\":true,\"GameID\":1234}");
+  mock_api_response("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", "{\"Success\":true,\"GameID\":1234}");
 
   ASSERT_NUM_EQUALS(rc_client_get_load_game_state(g_client), RC_CLIENT_LOAD_GAME_STATE_NONE);
 
@@ -1515,7 +1576,7 @@ static void test_load_game(void)
   g_client = mock_client_logged_in();
 
   reset_mock_api_handlers();
-  mock_api_response("r=patch&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
+  mock_api_response("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
   mock_api_response("r=startsession&u=Username&t=ApiToken&g=1234&h=1&m=0123456789ABCDEF&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
 
   ASSERT_NUM_EQUALS(rc_client_get_load_game_state(g_client), RC_CLIENT_LOAD_GAME_STATE_NONE);
@@ -1536,7 +1597,7 @@ static void test_load_game(void)
     ASSERT_STR_EQUALS(g_client->game->public_.title, "Sample Game");
     ASSERT_STR_EQUALS(g_client->game->public_.hash, "0123456789ABCDEF");
     ASSERT_STR_EQUALS(g_client->game->public_.badge_name, "112233");
-    ASSERT_STR_EQUALS(g_client->game->public_.badge_url, "https://media.retroachievements.org/Images/112233.png");
+    ASSERT_STR_EQUALS(g_client->game->public_.badge_url, "http://server/Images/112233.png");
     ASSERT_NUM_EQUALS(g_client->game->subsets->public_.num_achievements, 2);
     ASSERT_NUM_EQUALS(g_client->game->subsets->public_.num_leaderboards, 1);
 
@@ -1582,15 +1643,19 @@ static void test_load_game(void)
 
 static void test_load_game_async_load_different_game(void)
 {
-  static const char* patchdata_alternate = "{\"Success\":true,\"PatchData\":{"
-    "\"ID\":2345,\"Title\":\"Other Game\",\"ConsoleID\":7,\"ImageIcon\":\"/Images/555555.png\","
-    "\"Achievements\":["
-      GENERIC_ACHIEVEMENT_JSON("1", "0xH0000=5") ","
-      GENERIC_ACHIEVEMENT_JSON("2", "0xHFFFF=5") ","
-      GENERIC_ACHIEVEMENT_JSON("3", "0xH10000=5")
-    "],"
-    "\"Leaderboards\":[]"
-    "}}";
+  static const char* patchdata_alternate = "{\"Success\":true,"
+    "\"GameId\":2345,\"Title\":\"Other Game\",\"ConsoleId\":7,"
+    "\"ImageIconUrl\":\"http://server/Images/555555.png\","
+    "\"RichPresenceGameId\":2345,\"RichPresencePatch\":\"\",\"Sets\":[{"
+      "\"AchievementSetId\":2222,\"GameId\":2345,\"Title\":null,\"Type\":\"core\","
+      "\"ImageIconUrl\":\"http://server/Images/555555.png\","
+      "\"Achievements\":["
+        GENERIC_ACHIEVEMENT_JSON("1", "0xH0000=5") ","
+        GENERIC_ACHIEVEMENT_JSON("2", "0xHFFFF=5") ","
+        GENERIC_ACHIEVEMENT_JSON("3", "0xH10000=5")
+      "],"
+      "\"Leaderboards\":[]"
+    "}]}";
 
   g_client = mock_client_logged_in_async();
   reset_mock_api_handlers();
@@ -1598,16 +1663,16 @@ static void test_load_game_async_load_different_game(void)
   /* start loading first game */
   ASSERT_NUM_EQUALS(rc_client_get_load_game_state(g_client), RC_CLIENT_LOAD_GAME_STATE_NONE);
   rc_client_begin_load_game(g_client, "0123456789ABCDEF", rc_client_callback_expect_no_longer_active, g_callback_userdata);
-  assert_api_pending("r=patch&u=Username&t=ApiToken&m=0123456789ABCDEF");
+  assert_api_pending("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF");
   ASSERT_NUM_EQUALS(rc_client_get_load_game_state(g_client), RC_CLIENT_LOAD_GAME_STATE_IDENTIFYING_GAME);
 
   /* receive data for first game, start session for first game */
-  async_api_response("r=patch&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
+  async_api_response("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
   ASSERT_NUM_EQUALS(rc_client_get_load_game_state(g_client), RC_CLIENT_LOAD_GAME_STATE_STARTING_SESSION);
 
   /* start loading second game*/
   rc_client_begin_load_game(g_client, "ABCDEF0123456789", rc_client_callback_expect_success, g_callback_userdata);
-  assert_api_pending("r=patch&u=Username&t=ApiToken&m=ABCDEF0123456789");
+  assert_api_pending("r=hashdata&u=Username&t=ApiToken&m=ABCDEF0123456789");
   ASSERT_NUM_EQUALS(rc_client_get_load_game_state(g_client), RC_CLIENT_LOAD_GAME_STATE_IDENTIFYING_GAME);
 
   /* session started for first game, should abort */
@@ -1615,7 +1680,7 @@ static void test_load_game_async_load_different_game(void)
   ASSERT_NUM_EQUALS(rc_client_get_load_game_state(g_client), RC_CLIENT_LOAD_GAME_STATE_IDENTIFYING_GAME);
 
   /* receive data for second game, start session for second game */
-  async_api_response("r=patch&u=Username&t=ApiToken&m=ABCDEF0123456789", patchdata_alternate);
+  async_api_response("r=hashdata&u=Username&t=ApiToken&m=ABCDEF0123456789", patchdata_alternate);
   ASSERT_NUM_EQUALS(rc_client_get_load_game_state(g_client), RC_CLIENT_LOAD_GAME_STATE_STARTING_SESSION);
 
   /* session started for second game, should succeed */
@@ -1652,15 +1717,15 @@ static void test_load_game_async_login(void)
   ASSERT_NUM_EQUALS(rc_client_get_load_game_state(g_client), RC_CLIENT_LOAD_GAME_STATE_AWAIT_LOGIN);
 
   /* game load process will stop here waiting for the login to complete */
-  assert_api_not_called("r=patch&u=Username&t=ApiToken&m=0123456789ABCDEF");
+  assert_api_not_called("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF");
 
   /* login completion will trigger process to continue */
   async_api_response("r=login2&u=Username&p=Pa%24%24word",
 	    "{\"Success\":true,\"User\":\"Username\",\"Token\":\"ApiToken\",\"Score\":12345,\"SoftcoreScore\":123,\"Messages\":2,\"Permissions\":1,\"AccountType\":\"Registered\"}");
-  assert_api_pending("r=patch&u=Username&t=ApiToken&m=0123456789ABCDEF");
+  assert_api_pending("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF");
   ASSERT_NUM_EQUALS(rc_client_get_load_game_state(g_client), RC_CLIENT_LOAD_GAME_STATE_IDENTIFYING_GAME);
 
-  async_api_response("r=patch&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
+  async_api_response("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
   ASSERT_NUM_EQUALS(rc_client_get_load_game_state(g_client), RC_CLIENT_LOAD_GAME_STATE_STARTING_SESSION);
 
   async_api_response("r=startsession&u=Username&t=ApiToken&g=1234&h=1&m=0123456789ABCDEF&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
@@ -1695,13 +1760,13 @@ static void test_load_game_async_login_with_incorrect_password(void)
   ASSERT_NUM_EQUALS(rc_client_get_load_game_state(g_client), RC_CLIENT_LOAD_GAME_STATE_AWAIT_LOGIN);
 
   /* game load process will stop here waiting for the login to complete */
-  assert_api_not_called("r=patch&u=Username&t=ApiToken&m=0123456789ABCDEF");
+  assert_api_not_called("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF");
 
   /* login failure will trigger process to continue */
   async_api_error("r=login2&u=Username&p=Pa%24%24word",
       "{\"Success\":false,\"Error\":\"Invalid User/Password combination. Please try again\","
       "\"Status\":401,\"Code\":\"invalid_credentials\"}", 401);
-  assert_api_not_called("r=patch&u=Username&t=ApiToken&m=0123456789ABCDEF");
+  assert_api_not_called("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF");
 
   ASSERT_PTR_NULL(g_client->user.username);
 
@@ -1721,13 +1786,13 @@ static void test_load_game_async_login_logout(void)
   rc_client_begin_load_game(g_client, "0123456789ABCDEF", rc_client_callback_expect_login_aborted, g_callback_userdata);
 
   /* game load process will stop here waiting for the login to complete */
-  assert_api_not_called("r=patch&u=Username&t=ApiToken&m=0123456789ABCDEF");
+  assert_api_not_called("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF");
 
   /* logout will cancel login and allow game load to proceed with failure */
   rc_client_logout(g_client);
   async_api_response("r=login2&u=Username&p=Pa%24%24word",
     "{\"Success\":true,\"User\":\"Username\",\"Token\":\"ApiToken\",\"Score\":12345,\"SoftcoreScore\":123,\"Messages\":2,\"Permissions\":1,\"AccountType\":\"Registered\"}");
-  assert_api_not_called("r=patch&u=Username&t=ApiToken&m=0123456789ABCDEF");
+  assert_api_not_called("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF");
 
   ASSERT_PTR_NULL(g_client->user.username);
 
@@ -1749,13 +1814,13 @@ static void test_load_game_async_login_aborted(void)
   rc_client_begin_load_game(g_client, "0123456789ABCDEF", rc_client_callback_expect_login_aborted, g_callback_userdata);
 
   /* game load process will stop here waiting for the login to complete */
-  assert_api_not_called("r=patch&u=Username&t=ApiToken&m=0123456789ABCDEF");
+  assert_api_not_called("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF");
 
   /* login abort will trigger game load process to continue */
   rc_client_abort_async(g_client, handle);
   async_api_response("r=login2&u=Username&p=Pa%24%24word",
     "{\"Success\":true,\"User\":\"Username\",\"Token\":\"ApiToken\",\"Score\":12345,\"SoftcoreScore\":123,\"Messages\":2,\"Permissions\":1,\"AccountType\":\"Registered\"}");
-  assert_api_not_called("r=patch&u=Username&t=ApiToken&m=0123456789ABCDEF");
+  assert_api_not_called("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF");
 
   ASSERT_PTR_NULL(g_client->user.username);
 
@@ -1779,7 +1844,7 @@ static void test_load_game_patch_failure(void)
   g_client = mock_client_logged_in();
 
   reset_mock_api_handlers();
-  mock_api_error("r=patch&u=Username&t=ApiToken&m=0123456789ABCDEF", response_429, 429);
+  mock_api_error("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", response_429, 429);
   mock_api_response("r=startsession&u=Username&t=ApiToken&g=1234&h=1&m=0123456789ABCDEF&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
 
   rc_client_begin_load_game(g_client, "0123456789ABCDEF", rc_client_callback_expect_too_many_requests, g_callback_userdata);
@@ -1796,7 +1861,7 @@ static void test_load_game_startsession_failure(void)
   g_client = mock_client_logged_in();
 
   reset_mock_api_handlers();
-  mock_api_response("r=patch&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
+  mock_api_response("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
   mock_api_error("r=startsession&u=Username&t=ApiToken&g=1234&h=1&m=0123456789ABCDEF&l=" RCHEEVOS_VERSION_STRING, response_429, 429);
 
   rc_client_begin_load_game(g_client, "0123456789ABCDEF", rc_client_callback_expect_too_many_requests, g_callback_userdata);
@@ -1813,7 +1878,7 @@ static void test_load_game_startsession_timeout(void)
   g_client = mock_client_logged_in();
 
   reset_mock_api_handlers();
-  mock_api_response("r=patch&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
+  mock_api_response("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
   mock_api_error("r=startsession&u=Username&t=ApiToken&g=1234&h=1&m=0123456789ABCDEF&l=" RCHEEVOS_VERSION_STRING, "", 504);
 
   rc_client_begin_load_game(g_client, "0123456789ABCDEF", rc_client_callback_expect_timeout, g_callback_userdata);
@@ -1830,7 +1895,7 @@ static void test_load_game_startsession_custom_timeout(void)
   g_client = mock_client_logged_in();
 
   reset_mock_api_handlers();
-  mock_api_response("r=patch&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
+  mock_api_response("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
   mock_api_error("r=startsession&u=Username&t=ApiToken&g=1234&h=1&m=0123456789ABCDEF&l=" RCHEEVOS_VERSION_STRING,
     "Request has timed out.", RC_API_SERVER_RESPONSE_RETRYABLE_CLIENT_ERROR);
 
@@ -1857,7 +1922,7 @@ static void test_load_game_patch_aborted(void)
 
   rc_client_abort_async(g_client, handle);
 
-  async_api_response("r=patch&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
+  async_api_response("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
   assert_api_not_called("r=startsession&u=Username&t=ApiToken&g=1234&h=1&m=0123456789ABCDEF&l=" RCHEEVOS_VERSION_STRING);
 
   ASSERT_PTR_NULL(g_client->state.load);
@@ -1879,7 +1944,7 @@ static void test_load_game_startsession_aborted(void)
   handle = rc_client_begin_load_game(g_client, "0123456789ABCDEF",
     rc_client_callback_expect_uncalled, g_callback_userdata);
 
-  async_api_response("r=patch&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
+  async_api_response("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
 
   rc_client_abort_async(g_client, handle);
 
@@ -1900,7 +1965,7 @@ static void test_load_game_while_spectating(void)
   rc_client_set_spectator_mode_enabled(g_client, 1);
 
   reset_mock_api_handlers();
-  mock_api_response("r=patch&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
+  mock_api_response("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
   /* spectator mode should not start a session or fetch unlocks */
 
   rc_client_begin_load_game(g_client, "0123456789ABCDEF", rc_client_callback_expect_success, g_callback_userdata);
@@ -1965,27 +2030,28 @@ static void test_load_game_while_spectating(void)
   rc_client_destroy(g_client);
 }
 
-static int rc_client_callback_process_game_data_called = 0;
-static void rc_client_callback_process_game_data(const rc_api_server_response_t* server_response,
-    struct rc_api_fetch_game_data_response_t* game_data_response, rc_client_t* client, void* userdata)
+static int rc_client_callback_process_game_sets_called = 0;
+static void rc_client_callback_process_game_sets(const rc_api_server_response_t* server_response,
+    struct rc_api_fetch_game_sets_response_t* game_sets_response, rc_client_t* client, void* userdata)
 {
   ASSERT_STR_EQUALS(server_response->body, patchdata_2ach_1lbd);
-  ASSERT_NUM_EQUALS(game_data_response->id, 1234);
-  ASSERT_NUM_EQUALS(game_data_response->num_achievements, 2);
-  ASSERT_NUM_EQUALS(game_data_response->num_leaderboards, 1);
-  rc_client_callback_process_game_data_called = 1;
+  ASSERT_NUM_EQUALS(game_sets_response->id, 1234);
+  ASSERT_NUM_EQUALS(game_sets_response->num_sets, 1);
+  ASSERT_NUM_EQUALS(game_sets_response->sets[0].num_achievements, 2);
+  ASSERT_NUM_EQUALS(game_sets_response->sets[0].num_leaderboards, 1);
+  rc_client_callback_process_game_sets_called = 1;
 }
 
-static void test_load_game_process_game_data(void)
+static void test_load_game_process_game_sets(void)
 {
   rc_client_achievement_info_t* achievement;
   rc_client_leaderboard_info_t* leaderboard;
   g_client = mock_client_logged_in();
-  g_client->callbacks.post_process_game_data_response = rc_client_callback_process_game_data;
-  rc_client_callback_process_game_data_called = 0;
+  g_client->callbacks.post_process_game_sets_response = rc_client_callback_process_game_sets;
+  rc_client_callback_process_game_sets_called = 0;
 
   reset_mock_api_handlers();
-  mock_api_response("r=patch&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
+  mock_api_response("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
   mock_api_response("r=startsession&u=Username&t=ApiToken&g=1234&h=1&m=0123456789ABCDEF&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
 
   rc_client_begin_load_game(g_client, "0123456789ABCDEF", rc_client_callback_expect_success, g_callback_userdata);
@@ -2034,7 +2100,7 @@ static void test_load_game_process_game_data(void)
   ASSERT_NUM_NOT_EQUALS(leaderboard->value_djb2, 0);
   ASSERT_PTR_NULL(leaderboard->tracker);
 
-  ASSERT_NUM_NOT_EQUALS(rc_client_callback_process_game_data_called, 0);
+  ASSERT_NUM_NOT_EQUALS(rc_client_callback_process_game_sets_called, 0);
 
   rc_client_destroy(g_client);
 }
@@ -2049,7 +2115,7 @@ static void test_load_game_destroy_while_fetching_game_data(void)
 
   rc_client_destroy(g_client);
 
-  async_api_response("r=patch&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
+  async_api_response("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
 }
 
 static void test_load_unknown_game(void)
@@ -2181,7 +2247,7 @@ static void test_unload_game_while_fetching_game_data(void)
 
   rc_client_unload_game(g_client);
 
-  async_api_response("r=patch&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
+  async_api_response("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
 
   ASSERT_PTR_NULL(g_client->state.load);
   ASSERT_PTR_NULL(g_client->game);
@@ -2197,7 +2263,7 @@ static void test_unload_game_while_starting_session(void)
 
   rc_client_begin_load_game(g_client, "0123456789ABCDEF", rc_client_callback_expect_uncalled, g_callback_userdata);
 
-  async_api_response("r=patch&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
+  async_api_response("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
 
   rc_client_unload_game(g_client);
 
@@ -2242,7 +2308,7 @@ static void test_identify_and_load_game_console_specified(void)
   g_client = mock_client_logged_in();
 
   reset_mock_api_handlers();
-  mock_api_response("r=patch&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", patchdata_2ach_1lbd);
+  mock_api_response("r=hashdata&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", patchdata_2ach_1lbd);
   mock_api_response("r=startsession&u=Username&t=ApiToken&g=1234&h=1&m=6a2305a2b6675a97ff792709be1ca857&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
 
   rc_client_begin_identify_and_load_game(g_client, RC_CONSOLE_GAMEBOY, "foo.zip#foo.gb",
@@ -2274,7 +2340,7 @@ static void test_identify_and_load_game_console_not_specified(void)
   g_client = mock_client_logged_in();
 
   reset_mock_api_handlers();
-  mock_api_response("r=patch&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", patchdata_2ach_1lbd);
+  mock_api_response("r=hashdata&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", patchdata_2ach_1lbd);
   mock_api_response("r=startsession&u=Username&t=ApiToken&g=1234&h=1&m=6a2305a2b6675a97ff792709be1ca857&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
 
   rc_client_begin_identify_and_load_game(g_client, RC_CONSOLE_UNKNOWN, "foo.zip#foo.gb",
@@ -2316,17 +2382,17 @@ static void test_identify_and_load_game_multiconsole_first(void)
     image, image_size, rc_client_callback_expect_success, g_callback_userdata);
 
   /* first hash lookup should be pending. inject a secondary console into the iterator */
-  assert_api_pending("r=patch&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857");
+  assert_api_pending("r=hashdata&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857");
   iterator = rc_client_get_load_state_hash_iterator(g_client);
   ASSERT_NUM_EQUALS(iterator->index, 1);
   ASSERT_NUM_EQUALS(iterator->consoles[iterator->index], 0);
   iterator->consoles[iterator->index] = RC_CONSOLE_MEGA_DRIVE; /* full buffer hash */
   iterator->consoles[iterator->index + 1] = 0;
 
-  async_api_response("r=patch&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", patchdata_2ach_1lbd);
+  async_api_response("r=hashdata&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", patchdata_2ach_1lbd);
   async_api_response("r=startsession&u=Username&t=ApiToken&g=1234&h=1&m=6a2305a2b6675a97ff792709be1ca857&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
 
-  assert_api_not_pending("r=patch&u=Username&t=ApiToken&m=64b131c5c7fec32985d9c99700babb7e");
+  assert_api_not_pending("r=hashdata&u=Username&t=ApiToken&m=64b131c5c7fec32985d9c99700babb7e");
 
   ASSERT_PTR_NULL(g_client->state.load);
   ASSERT_PTR_NOT_NULL(g_client->game);
@@ -2361,17 +2427,17 @@ static void test_identify_and_load_game_multiconsole_second(void)
     image, image_size, rc_client_callback_expect_success, g_callback_userdata);
 
   /* first hash lookup should be pending. inject a secondary console into the iterator */
-  assert_api_pending("r=patch&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857");
+  assert_api_pending("r=hashdata&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857");
   iterator = rc_client_get_load_state_hash_iterator(g_client);
   ASSERT_NUM_EQUALS(iterator->index, 1);
   ASSERT_NUM_EQUALS(iterator->consoles[iterator->index], 0);
   iterator->consoles[iterator->index] = RC_CONSOLE_MEGA_DRIVE; /* full buffer hash */
   iterator->consoles[iterator->index + 1] = 0;
 
-  async_api_response("r=patch&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", patchdata_not_found);
+  async_api_response("r=hashdata&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", patchdata_not_found);
 
-  assert_api_pending("r=patch&u=Username&t=ApiToken&m=64b131c5c7fec32985d9c99700babb7e");
-  async_api_response("r=patch&u=Username&t=ApiToken&m=64b131c5c7fec32985d9c99700babb7e" ,patchdata_2ach_1lbd);
+  assert_api_pending("r=hashdata&u=Username&t=ApiToken&m=64b131c5c7fec32985d9c99700babb7e");
+  async_api_response("r=hashdata&u=Username&t=ApiToken&m=64b131c5c7fec32985d9c99700babb7e" ,patchdata_2ach_1lbd);
   async_api_response("r=startsession&u=Username&t=ApiToken&g=1234&h=1&m=64b131c5c7fec32985d9c99700babb7e&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
 
   ASSERT_PTR_NULL(g_client->state.load);
@@ -2402,7 +2468,7 @@ static void test_identify_and_load_game_unknown_hash(void)
   g_client = mock_client_logged_in();
 
   reset_mock_api_handlers();
-  mock_api_response("r=patch&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", patchdata_not_found);
+  mock_api_response("r=hashdata&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", patchdata_not_found);
 
   rc_client_begin_identify_and_load_game(g_client, RC_CONSOLE_UNKNOWN, "foo.zip#foo.gb",
       image, image_size, rc_client_callback_expect_unknown_game, g_callback_userdata);
@@ -2441,7 +2507,7 @@ static void test_identify_and_load_game_unknown_hash_repeated(void)
   ASSERT_PTR_NOT_NULL(handle);
   ASSERT_PTR_NOT_NULL(g_client->state.load);
 
-  async_api_response("r=patch&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", patchdata_not_found);
+  async_api_response("r=hashdata&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", patchdata_not_found);
 
   ASSERT_PTR_NULL(g_client->state.load);
   ASSERT_PTR_NOT_NULL(g_client->game);
@@ -2491,7 +2557,7 @@ static void test_identify_and_load_game_unknown_hash_multiple(void)
   ASSERT_PTR_NOT_NULL(handle);
   ASSERT_PTR_NOT_NULL(g_client->state.load);
 
-  async_api_response("r=patch&u=Username&t=ApiToken&m=88be638f4d78b4072109e55f13e8a0ac", patchdata_not_found);
+  async_api_response("r=hashdata&u=Username&t=ApiToken&m=88be638f4d78b4072109e55f13e8a0ac", patchdata_not_found);
 
   ASSERT_PTR_NULL(g_client->state.load);
   ASSERT_PTR_NOT_NULL(g_client->game);
@@ -2511,7 +2577,7 @@ static void test_identify_and_load_game_unknown_hash_multiple(void)
   ASSERT_PTR_NOT_NULL(handle);
   ASSERT_PTR_NOT_NULL(g_client->state.load);
 
-  async_api_response("r=patch&u=Username&t=ApiToken&m=8e39c6077108cafd6193d1c649b5d695", patchdata_not_found);
+  async_api_response("r=hashdata&u=Username&t=ApiToken&m=8e39c6077108cafd6193d1c649b5d695", patchdata_not_found);
 
   ASSERT_PTR_NULL(g_client->state.load);
   ASSERT_PTR_NOT_NULL(g_client->game);
@@ -2545,17 +2611,17 @@ static void test_identify_and_load_game_unknown_hash_multiconsole(void)
     image, image_size, rc_client_callback_expect_unknown_game, g_callback_userdata);
 
   /* first hash lookup should be pending. inject a secondary console into the iterator */
-  assert_api_pending("r=patch&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857");
+  assert_api_pending("r=hashdata&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857");
   iterator = rc_client_get_load_state_hash_iterator(g_client);
   ASSERT_NUM_EQUALS(iterator->index, 1);
   ASSERT_NUM_EQUALS(iterator->consoles[iterator->index], 0);
   iterator->consoles[iterator->index] = RC_CONSOLE_MEGA_DRIVE; /* full buffer hash */
   iterator->consoles[iterator->index + 1] = 0;
 
-  async_api_response("r=patch&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", patchdata_not_found);
+  async_api_response("r=hashdata&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", patchdata_not_found);
 
-  assert_api_pending("r=patch&u=Username&t=ApiToken&m=64b131c5c7fec32985d9c99700babb7e");
-  async_api_response("r=patch&u=Username&t=ApiToken&m=64b131c5c7fec32985d9c99700babb7e", patchdata_not_found);
+  assert_api_pending("r=hashdata&u=Username&t=ApiToken&m=64b131c5c7fec32985d9c99700babb7e");
+  async_api_response("r=hashdata&u=Username&t=ApiToken&m=64b131c5c7fec32985d9c99700babb7e", patchdata_not_found);
 
   ASSERT_PTR_NULL(g_client->state.load);
   ASSERT_PTR_NOT_NULL(g_client->game);
@@ -2592,12 +2658,12 @@ static void test_identify_and_load_game_unknown_hash_console_specified(void)
     image, image_size, rc_client_callback_expect_unknown_game, g_callback_userdata);
 
   /* first hash lookup should be pending. iterator should not have been initialized */
-  assert_api_pending("r=patch&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857");
+  assert_api_pending("r=hashdata&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857");
   iterator = rc_client_get_load_state_hash_iterator(g_client);
   ASSERT_NUM_EQUALS(iterator->index, 0);
   ASSERT_NUM_EQUALS(iterator->consoles[iterator->index], 0);
 
-  async_api_response("r=patch&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", patchdata_not_found);
+  async_api_response("r=hashdata&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", patchdata_not_found);
 
   ASSERT_PTR_NULL(g_client->state.load);
   ASSERT_PTR_NOT_NULL(g_client->game);
@@ -2638,8 +2704,8 @@ static void test_identify_and_load_game_unknown_hash_client_provided(void)
   g_client->callbacks.identify_unknown_hash = rc_client_identify_unknown_hash;
 
   reset_mock_api_handlers();
-  mock_api_response("r=patch&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", patchdata_not_found);
-  mock_api_response("r=patch&u=Username&t=ApiToken&g=1234", patchdata_2ach_1lbd);
+  mock_api_response("r=hashdata&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", patchdata_not_found);
+  mock_api_response("r=hashdata&u=Username&t=ApiToken&g=1234", patchdata_2ach_1lbd);
   mock_api_response("r=startsession&u=Username&t=ApiToken&g=1234&h=1&m=6a2305a2b6675a97ff792709be1ca857&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
 
   rc_client_begin_identify_and_load_game(g_client, RC_CONSOLE_GAMEBOY, "foo.zip#foo.gb",
@@ -2672,7 +2738,7 @@ static void test_identify_and_load_game_multihash(void)
   g_client = mock_client_logged_in();
 
   reset_mock_api_handlers();
-  mock_api_response("r=patch&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", patchdata_2ach_1lbd);
+  mock_api_response("r=hashdata&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", patchdata_2ach_1lbd);
   mock_api_response("r=startsession&u=Username&t=ApiToken&g=1234&h=1&m=6a2305a2b6675a97ff792709be1ca857&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
 
   rc_client_begin_identify_and_load_game(g_client, RC_CONSOLE_UNKNOWN, "abc.dsk",
@@ -2704,7 +2770,7 @@ static void test_identify_and_load_game_multihash_unknown_game(void)
   g_client = mock_client_logged_in();
 
   reset_mock_api_handlers();
-  mock_api_response("r=patch&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", patchdata_not_found);
+  mock_api_response("r=hashdata&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", patchdata_not_found);
 
   rc_client_begin_identify_and_load_game(g_client, RC_CONSOLE_UNKNOWN, "abc.dsk",
       image, image_size, rc_client_callback_expect_unknown_game, g_callback_userdata);
@@ -2722,7 +2788,7 @@ static void test_identify_and_load_game_multihash_unknown_game(void)
   }
 
   /* same hash generated for all dsk consoles - only one server call should be made */
-  assert_api_call_count("r=patch&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", 1);
+  assert_api_call_count("r=hashdata&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", 1);
 
   rc_client_destroy(g_client);
   free(image);
@@ -2745,11 +2811,11 @@ static void test_identify_and_load_game_multihash_differ(void)
   memset(&image[256], 0, 32);
 
   /* first lookup fails */
-  async_api_response("r=patch&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", patchdata_not_found);
+  async_api_response("r=hashdata&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", patchdata_not_found);
   ASSERT_PTR_NOT_NULL(g_client->state.load);
 
   /* second lookup should succeed */
-  async_api_response("r=patch&u=Username&t=ApiToken&m=4989b063a40dcfa28291ff8d675050e3", patchdata_2ach_1lbd);
+  async_api_response("r=hashdata&u=Username&t=ApiToken&m=4989b063a40dcfa28291ff8d675050e3", patchdata_2ach_1lbd);
   async_api_response("r=startsession&u=Username&t=ApiToken&g=1234&h=1&m=4989b063a40dcfa28291ff8d675050e3&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
  
   ASSERT_PTR_NULL(g_client->state.load);
@@ -3047,7 +3113,7 @@ static void test_change_media_while_loading(void)
 
   /* media request won't occur until patch data is received */
   assert_api_not_called("r=gameid&m=6a2305a2b6675a97ff792709be1ca857");
-  async_api_response("r=patch&u=Username&t=ApiToken&m=4989b063a40dcfa28291ff8d675050e3", patchdata_2ach_1lbd);
+  async_api_response("r=hashdata&u=Username&t=ApiToken&m=4989b063a40dcfa28291ff8d675050e3", patchdata_2ach_1lbd);
   assert_api_not_called("r=gameid&m=6a2305a2b6675a97ff792709be1ca857");
 
   /* finish loading game */
@@ -3089,7 +3155,7 @@ static void test_change_media_while_loading_later(void)
       rc_client_callback_expect_success, g_callback_userdata);
 
   /* get past fetching the patch data so there's a valid console for the change media call */
-  async_api_response("r=patch&u=Username&t=ApiToken&m=4989b063a40dcfa28291ff8d675050e3", patchdata_2ach_1lbd);
+  async_api_response("r=hashdata&u=Username&t=ApiToken&m=4989b063a40dcfa28291ff8d675050e3", patchdata_2ach_1lbd);
 
   /* change_media should immediately attempt to resolve the new hash */
   rc_client_begin_change_media(g_client, "foo.zip#foo.gb", image, image_size,
@@ -3158,7 +3224,7 @@ static void test_change_media_async_aborted(void)
     rc_client_callback_expect_success, g_callback_userdata);
 
   ASSERT_STR_EQUALS(g_client->game->public_.hash, "6a2305a2b6675a97ff792709be1ca857");
-  assert_api_not_called("r=patch&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857");
+  assert_api_not_called("r=hashdata&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857");
 
   rc_client_destroy(g_client);
   free(image);
@@ -3355,7 +3421,7 @@ static void test_change_media_from_hash_while_loading(void)
 
   /* media request won't occur until patch data is received */
   assert_api_not_called("r=gameid&m=6a2305a2b6675a97ff792709be1ca857");
-  async_api_response("r=patch&u=Username&t=ApiToken&m=4989b063a40dcfa28291ff8d675050e3", patchdata_2ach_1lbd);
+  async_api_response("r=hashdata&u=Username&t=ApiToken&m=4989b063a40dcfa28291ff8d675050e3", patchdata_2ach_1lbd);
   assert_api_not_called("r=gameid&m=6a2305a2b6675a97ff792709be1ca857");
 
   /* finish loading game */
@@ -3386,7 +3452,7 @@ static void test_change_media_from_hash_while_loading_later(void)
     rc_client_callback_expect_success, g_callback_userdata);
 
   /* get past fetching the patch data so there's a valid console for the change media call */
-  async_api_response("r=patch&u=Username&t=ApiToken&m=4989b063a40dcfa28291ff8d675050e3", patchdata_2ach_1lbd);
+  async_api_response("r=hashdata&u=Username&t=ApiToken&m=4989b063a40dcfa28291ff8d675050e3", patchdata_2ach_1lbd);
 
   /* change_media should immediately attempt to resolve the new hash */
   rc_client_begin_change_media_from_hash(g_client, "6a2305a2b6675a97ff792709be1ca857",
@@ -3473,7 +3539,7 @@ static void test_game_get_image_url(void)
   g_client = mock_client_game_loaded(patchdata_2ach_1lbd, no_unlocks);
 
   ASSERT_NUM_EQUALS(rc_client_game_get_image_url(rc_client_get_game_info(g_client), buffer, sizeof(buffer)), RC_OK);
-  ASSERT_STR_EQUALS(buffer, "https://media.retroachievements.org/Images/112233.png");
+  ASSERT_STR_EQUALS(buffer, "http://server/Images/112233.png");
 
   rc_client_destroy(g_client);
 }
@@ -3568,7 +3634,7 @@ static void test_load_subset(void)
   g_client = mock_client_logged_in();
 
   reset_mock_api_handlers();
-  mock_api_response("r=patch&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_subset);
+  mock_api_response("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_subset);
   mock_api_response("r=startsession&u=Username&t=ApiToken&g=1234&h=1&m=0123456789ABCDEF&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
 
   rc_client_begin_load_game(g_client, "0123456789ABCDEF", rc_client_callback_expect_success, g_callback_userdata);
@@ -3596,7 +3662,7 @@ static void test_load_subset(void)
     ASSERT_NUM_EQUALS(subset->id, 2345);
     ASSERT_STR_EQUALS(subset->title, "Bonus");
     ASSERT_STR_EQUALS(subset->badge_name, "112234");
-    ASSERT_STR_EQUALS(subset->badge_url, "http://host/Images/112234.png");
+    ASSERT_STR_EQUALS(subset->badge_url, "http://server/Images/112234.png");
     ASSERT_NUM_EQUALS(subset->num_achievements, 3);
     ASSERT_NUM_EQUALS(subset->num_leaderboards, 2);
 
@@ -4472,7 +4538,7 @@ static void test_achievement_list_subset_with_unofficial_and_unsupported(void)
   if (list) {
     ASSERT_NUM_EQUALS(list->num_buckets, 3);
     ASSERT_NUM_EQUALS(list->buckets[0].bucket_type, RC_CLIENT_ACHIEVEMENT_BUCKET_LOCKED);
-    ASSERT_NUM_EQUALS(list->buckets[0].subset_id, 1234);
+    ASSERT_NUM_EQUALS(list->buckets[0].subset_id, 1111);
     ASSERT_STR_EQUALS(list->buckets[0].label, "Sample Game - Locked");
     ASSERT_NUM_EQUALS(list->buckets[0].num_achievements, 6);
     ASSERT_NUM_EQUALS(list->buckets[0].achievements[0]->id, 5);
@@ -4502,7 +4568,7 @@ static void test_achievement_list_subset_with_unofficial_and_unsupported(void)
   if (list) {
     ASSERT_NUM_EQUALS(list->num_buckets, 2);
     ASSERT_NUM_EQUALS(list->buckets[0].bucket_type, RC_CLIENT_ACHIEVEMENT_BUCKET_UNOFFICIAL);
-    ASSERT_NUM_EQUALS(list->buckets[0].subset_id, 1234);
+    ASSERT_NUM_EQUALS(list->buckets[0].subset_id, 1111);
     ASSERT_STR_EQUALS(list->buckets[0].label, "Sample Game - Unofficial");
     ASSERT_NUM_EQUALS(list->buckets[0].num_achievements, 1);
     ASSERT_NUM_EQUALS(list->buckets[0].achievements[0]->id, 8);
@@ -4521,7 +4587,7 @@ static void test_achievement_list_subset_with_unofficial_and_unsupported(void)
   if (list) {
     ASSERT_NUM_EQUALS(list->num_buckets, 5);
     ASSERT_NUM_EQUALS(list->buckets[0].bucket_type, RC_CLIENT_ACHIEVEMENT_BUCKET_LOCKED);
-    ASSERT_NUM_EQUALS(list->buckets[0].subset_id, 1234);
+    ASSERT_NUM_EQUALS(list->buckets[0].subset_id, 1111);
     ASSERT_STR_EQUALS(list->buckets[0].label, "Sample Game - Locked");
     ASSERT_NUM_EQUALS(list->buckets[0].num_achievements, 6);
     ASSERT_NUM_EQUALS(list->buckets[0].achievements[0]->id, 5);
@@ -4532,7 +4598,7 @@ static void test_achievement_list_subset_with_unofficial_and_unsupported(void)
     ASSERT_NUM_EQUALS(list->buckets[0].achievements[5]->id, 71);
 
     ASSERT_NUM_EQUALS(list->buckets[1].bucket_type, RC_CLIENT_ACHIEVEMENT_BUCKET_UNOFFICIAL);
-    ASSERT_NUM_EQUALS(list->buckets[1].subset_id, 1234);
+    ASSERT_NUM_EQUALS(list->buckets[1].subset_id, 1111);
     ASSERT_STR_EQUALS(list->buckets[1].label, "Sample Game - Unofficial");
     ASSERT_NUM_EQUALS(list->buckets[1].num_achievements, 1);
     ASSERT_NUM_EQUALS(list->buckets[1].achievements[0]->id, 8);
@@ -4587,7 +4653,7 @@ static void test_achievement_list_subset_buckets(void)
     ASSERT_NUM_EQUALS(list->num_buckets, 4);
 
     ASSERT_NUM_EQUALS(list->buckets[0].bucket_type, RC_CLIENT_ACHIEVEMENT_BUCKET_LOCKED);
-    ASSERT_NUM_EQUALS(list->buckets[0].subset_id, 1234);
+    ASSERT_NUM_EQUALS(list->buckets[0].subset_id, 1111);
     ASSERT_STR_EQUALS(list->buckets[0].label, "Sample Game - Locked");
     ASSERT_NUM_EQUALS(list->buckets[0].num_achievements, 6);
     iter = list->buckets[0].achievements;
@@ -4611,7 +4677,7 @@ static void test_achievement_list_subset_buckets(void)
     ASSERT_FLOAT_EQUALS(achievement->measured_percent, 0.0);
 
     ASSERT_NUM_EQUALS(list->buckets[1].bucket_type, RC_CLIENT_ACHIEVEMENT_BUCKET_UNLOCKED);
-    ASSERT_NUM_EQUALS(list->buckets[1].subset_id, 1234);
+    ASSERT_NUM_EQUALS(list->buckets[1].subset_id, 1111);
     ASSERT_STR_EQUALS(list->buckets[1].label, "Sample Game - Unlocked");
     ASSERT_NUM_EQUALS(list->buckets[1].num_achievements, 1);
     ASSERT_NUM_EQUALS(list->buckets[1].achievements[0]->id, 8);
@@ -4662,7 +4728,7 @@ static void test_achievement_list_subset_buckets(void)
     ASSERT_NUM_EQUALS(list->buckets[1].achievements[1]->id, 5);
 
     ASSERT_NUM_EQUALS(list->buckets[2].bucket_type, RC_CLIENT_ACHIEVEMENT_BUCKET_LOCKED);
-    ASSERT_NUM_EQUALS(list->buckets[2].subset_id, 1234);
+    ASSERT_NUM_EQUALS(list->buckets[2].subset_id, 1111);
     ASSERT_STR_EQUALS(list->buckets[2].label, "Sample Game - Locked");
     ASSERT_NUM_EQUALS(list->buckets[2].num_achievements, 4);
     iter = list->buckets[2].achievements;
@@ -4682,7 +4748,7 @@ static void test_achievement_list_subset_buckets(void)
     ASSERT_FLOAT_EQUALS(achievement->measured_percent, 25.6);
 
     ASSERT_NUM_EQUALS(list->buckets[3].bucket_type, RC_CLIENT_ACHIEVEMENT_BUCKET_UNLOCKED);
-    ASSERT_NUM_EQUALS(list->buckets[3].subset_id, 1234);
+    ASSERT_NUM_EQUALS(list->buckets[3].subset_id, 1111);
     ASSERT_STR_EQUALS(list->buckets[3].label, "Sample Game - Unlocked");
     ASSERT_NUM_EQUALS(list->buckets[3].num_achievements, 1);
     ASSERT_NUM_EQUALS(list->buckets[3].achievements[0]->id, 8);
@@ -4724,7 +4790,7 @@ static void test_achievement_list_subset_buckets(void)
     ASSERT_FLOAT_EQUALS(list->buckets[0].achievements[0] ->measured_percent, 83.333333);
 
     ASSERT_NUM_EQUALS(list->buckets[1].bucket_type, RC_CLIENT_ACHIEVEMENT_BUCKET_LOCKED);
-    ASSERT_NUM_EQUALS(list->buckets[1].subset_id, 1234);
+    ASSERT_NUM_EQUALS(list->buckets[1].subset_id, 1111);
     ASSERT_STR_EQUALS(list->buckets[1].label, "Sample Game - Locked");
     ASSERT_NUM_EQUALS(list->buckets[1].num_achievements, 4);
     iter = list->buckets[1].achievements;
@@ -4742,7 +4808,7 @@ static void test_achievement_list_subset_buckets(void)
     ASSERT_FLOAT_EQUALS(achievement->measured_percent, 25.6);
 
     ASSERT_NUM_EQUALS(list->buckets[2].bucket_type, RC_CLIENT_ACHIEVEMENT_BUCKET_UNLOCKED);
-    ASSERT_NUM_EQUALS(list->buckets[2].subset_id, 1234);
+    ASSERT_NUM_EQUALS(list->buckets[2].subset_id, 1111);
     ASSERT_STR_EQUALS(list->buckets[2].label, "Sample Game - Unlocked");
     ASSERT_NUM_EQUALS(list->buckets[2].num_achievements, 2);
     ASSERT_NUM_EQUALS(list->buckets[2].achievements[0]->id, 5);
@@ -5111,7 +5177,7 @@ static void test_leaderboard_list_subset(void)
   if (list) {
     ASSERT_NUM_EQUALS(list->num_buckets, 2);
     ASSERT_NUM_EQUALS(list->buckets[0].bucket_type, RC_CLIENT_LEADERBOARD_BUCKET_INACTIVE);
-    ASSERT_NUM_EQUALS(list->buckets[0].subset_id, 1234);
+    ASSERT_NUM_EQUALS(list->buckets[0].subset_id, 1111);
     ASSERT_STR_EQUALS(list->buckets[0].label, "Sample Game - Inactive");
     ASSERT_NUM_EQUALS(list->buckets[0].num_leaderboards, 7);
 
@@ -5169,7 +5235,7 @@ static void test_leaderboard_list_subset(void)
     ASSERT_NUM_EQUALS(leaderboard->id, 82);
 
     ASSERT_NUM_EQUALS(list->buckets[1].bucket_type, RC_CLIENT_LEADERBOARD_BUCKET_INACTIVE);
-    ASSERT_NUM_EQUALS(list->buckets[1].subset_id, 1234);
+    ASSERT_NUM_EQUALS(list->buckets[1].subset_id, 1111);
     ASSERT_STR_EQUALS(list->buckets[1].label, "Sample Game - Inactive");
     ASSERT_NUM_EQUALS(list->buckets[1].num_leaderboards, 4);
 
@@ -6697,15 +6763,19 @@ static void test_do_frame_achievement_challenge_indicator(void)
 
 static void test_do_frame_achievement_challenge_indicator_primed_while_reset(void)
 {
-  static const char* patchdata = "{\"Success\":true,\"PatchData\":{"
-    "\"ID\":1234,\"Title\":\"Sample Game\",\"ConsoleID\":17,\"ImageIcon\":\"/Images/112233.png\","
-    "\"Achievements\":["
-     "{\"ID\":7,\"Title\":\"Ach1\",\"Description\":\"Desc1\",\"Flags\":3,\"Points\":5,"
-      "\"MemAddr\":\"0xH0001=3_T:0xH0002=4_R:0xH0003=3\",\"Author\":\"User1\",\"BadgeName\":\"00234\","
-      "\"Created\":1367266583,\"Modified\":1376929305}"
-    "],"
-    "\"Leaderboards\":[]"
-    "}}";
+  static const char* patchdata = "{\"Success\":true,"
+    "\"GameId\":1234,\"Title\":\"Sample Game\",\"ConsoleId\":17,"
+    "\"ImageIconUrl\":\"http://server/Images/112233.png\","
+    "\"RichPresenceGameId\":1234,\"RichPresencePatch\":\"\",\"Sets\":[{"
+      "\"AchievementSetId\":1111,\"GameId\":1234,\"Title\":null,\"Type\":\"core\","
+      "\"ImageIconUrl\":\"http://server/Images/112233.png\","
+      "\"Achievements\":["
+       "{\"ID\":7,\"Title\":\"Ach1\",\"Description\":\"Desc1\",\"Flags\":3,\"Points\":5,"
+        "\"MemAddr\":\"0xH0001=3_T:0xH0002=4_R:0xH0003=3\",\"Author\":\"User1\",\"BadgeName\":\"00234\","
+        "\"Created\":1367266583,\"Modified\":1376929305}"
+      "],"
+      "\"Leaderboards\":[]"
+    "}]}";
 
   rc_client_event_t* event;
   rc_client_achievement_info_t* achievement;
@@ -6766,15 +6836,19 @@ static void test_do_frame_achievement_challenge_indicator_primed_while_reset(voi
 
 static void test_do_frame_achievement_challenge_indicator_primed_while_reset_next(void)
 {
-  static const char* patchdata = "{\"Success\":true,\"PatchData\":{"
-    "\"ID\":1234,\"Title\":\"Sample Game\",\"ConsoleID\":17,\"ImageIcon\":\"/Images/112233.png\","
-    "\"Achievements\":["
-    "{\"ID\":7,\"Title\":\"Ach1\",\"Description\":\"Desc1\",\"Flags\":3,\"Points\":5,"
-    "\"MemAddr\":\"0xH0001=3_T:0xH0002=4_Z:0xH0003=3_P:0xH0006=1.10.\",\"Author\":\"User1\",\"BadgeName\":\"00234\","
-    "\"Created\":1367266583,\"Modified\":1376929305}"
-    "],"
-    "\"Leaderboards\":[]"
-    "}}";
+  static const char* patchdata = "{\"Success\":true,"
+    "\"GameId\":1234,\"Title\":\"Sample Game\",\"ConsoleId\":17,"
+    "\"ImageIconUrl\":\"http://server/Images/112233.png\","
+    "\"RichPresenceGameId\":1234,\"RichPresencePatch\":\"\",\"Sets\":[{"
+      "\"AchievementSetId\":1111,\"GameId\":1234,\"Title\":null,\"Type\":\"core\","
+      "\"ImageIconUrl\":\"http://server/Images/112233.png\","
+      "\"Achievements\":["
+       "{\"ID\":7,\"Title\":\"Ach1\",\"Description\":\"Desc1\",\"Flags\":3,\"Points\":5,"
+        "\"MemAddr\":\"0xH0001=3_T:0xH0002=4_Z:0xH0003=3_P:0xH0006=1.10.\",\"Author\":\"User1\",\"BadgeName\":\"00234\","
+        "\"Created\":1367266583,\"Modified\":1376929305}"
+      "],"
+      "\"Leaderboards\":[]"
+    "}]}";
 
   rc_client_event_t* event;
   rc_client_achievement_info_t* achievement;
@@ -9064,7 +9138,7 @@ static void test_deserialize_progress_unknown_game(void)
   g_client = mock_client_logged_in();
 
   reset_mock_api_handlers();
-  mock_api_response("r=patch&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_not_found);
+  mock_api_response("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_not_found);
   rc_client_begin_load_game(g_client, "0123456789ABCDEF", rc_client_callback_expect_unknown_game, g_callback_userdata);
 
   ASSERT_NUM_EQUALS(rc_client_progress_size(g_client), 0);
@@ -9565,7 +9639,7 @@ void test_client(void) {
   TEST(test_load_game_patch_aborted);
   TEST(test_load_game_startsession_aborted);
   TEST(test_load_game_while_spectating);
-  TEST(test_load_game_process_game_data);
+  TEST(test_load_game_process_game_sets);
   TEST(test_load_game_destroy_while_fetching_game_data);
   TEST(test_load_unknown_game);
   TEST(test_load_unknown_game_multihash);

--- a/test/test_rc_client.c
+++ b/test/test_rc_client.c
@@ -776,7 +776,7 @@ static void mock_client_load_game(const char* patchdata, const char* unlocks)
 {
   reset_mock_api_handlers();
   event_count = 0;
-  mock_api_response("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata);
+  mock_api_response("r=achievementsets&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata);
   mock_api_response("r=startsession&u=Username&t=ApiToken&g=1234&h=1&m=0123456789ABCDEF&l=" RCHEEVOS_VERSION_STRING, unlocks);
 
   rc_client_begin_load_game(g_client, "0123456789ABCDEF", rc_client_callback_expect_success, g_callback_userdata);
@@ -789,7 +789,7 @@ static void mock_client_load_game_softcore(const char* patchdata, const char* un
 {
   reset_mock_api_handlers();
   event_count = 0;
-  mock_api_response("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata);
+  mock_api_response("r=achievementsets&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata);
   mock_api_response("r=startsession&u=Username&t=ApiToken&g=1234&h=0&m=0123456789ABCDEF&l=" RCHEEVOS_VERSION_STRING, unlocks);
 
   rc_client_begin_load_game(g_client, "0123456789ABCDEF", rc_client_callback_expect_success, g_callback_userdata);
@@ -1126,7 +1126,7 @@ static void test_logout(void)
 
   /* attempt to load game should fail */
   reset_mock_api_handlers();
-  mock_api_response("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", "{\"Success\":true,\"GameID\":1234}");
+  mock_api_response("r=achievementsets&u=Username&t=ApiToken&m=0123456789ABCDEF", "{\"Success\":true,\"GameID\":1234}");
 
   rc_client_begin_load_game(g_client, "0123456789ABCDEF", rc_client_callback_expect_login_required, g_callback_userdata);
 
@@ -1193,7 +1193,7 @@ static void test_logout_during_fetch_game(void)
   rc_client_begin_load_game(g_client, "0123456789ABCDEF",
     rc_client_callback_expect_no_longer_active, g_callback_userdata);
 
-  async_api_response("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
+  async_api_response("r=achievementsets&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
 
   rc_client_logout(g_client);
 
@@ -1266,7 +1266,7 @@ static void test_get_user_game_summary_encore_mode(void)
   g_client = mock_client_logged_in();
   rc_client_set_unofficial_enabled(g_client, 1);
   reset_mock_api_handlers();
-  mock_api_response("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_exhaustive);
+  mock_api_response("r=achievementsets&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_exhaustive);
   mock_api_response("r=startsession&u=Username&t=ApiToken&g=1234&h=1&m=0123456789ABCDEF&l=" RCHEEVOS_VERSION_STRING, unlock_6_8h_and_9);
 
   rc_client_set_encore_mode_enabled(g_client, 1);
@@ -1381,7 +1381,7 @@ static void test_get_user_game_summary_unknown_game(void)
   g_client = mock_client_logged_in();
 
   reset_mock_api_handlers();
-  mock_api_response("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_not_found);
+  mock_api_response("r=achievementsets&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_not_found);
   rc_client_begin_load_game(g_client, "0123456789ABCDEF", rc_client_callback_expect_unknown_game, g_callback_userdata);
 
   rc_client_get_user_game_summary(g_client, &summary);
@@ -1424,7 +1424,7 @@ static void test_load_game_unknown_hash(void)
   g_client = mock_client_logged_in();
 
   reset_mock_api_handlers();
-  mock_api_response("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_not_found);
+  mock_api_response("r=achievementsets&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_not_found);
 
   ASSERT_NUM_EQUALS(rc_client_get_load_game_state(g_client), RC_CLIENT_LOAD_GAME_STATE_NONE);
   ASSERT_NUM_EQUALS(rc_client_is_game_loaded(g_client), 0);
@@ -1469,7 +1469,7 @@ static void test_load_game_unknown_hash_repeated(void)
   ASSERT_PTR_NOT_NULL(handle);
   ASSERT_PTR_NOT_NULL(g_client->state.load);
 
-  async_api_response("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_not_found);
+  async_api_response("r=achievementsets&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_not_found);
 
   ASSERT_PTR_NULL(g_client->state.load);
   ASSERT_PTR_NOT_NULL(g_client->game);
@@ -1516,7 +1516,7 @@ static void test_load_game_unknown_hash_multiple(void)
   ASSERT_PTR_NOT_NULL(handle);
   ASSERT_PTR_NOT_NULL(g_client->state.load);
 
-  async_api_response("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_not_found);
+  async_api_response("r=achievementsets&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_not_found);
 
   ASSERT_PTR_NULL(g_client->state.load);
   ASSERT_PTR_NOT_NULL(g_client->game);
@@ -1535,7 +1535,7 @@ static void test_load_game_unknown_hash_multiple(void)
   ASSERT_PTR_NOT_NULL(handle);
   ASSERT_PTR_NOT_NULL(g_client->state.load);
 
-  async_api_response("r=hashdata&u=Username&t=ApiToken&m=FEDCBA9876543210", patchdata_not_found);
+  async_api_response("r=achievementsets&u=Username&t=ApiToken&m=FEDCBA9876543210", patchdata_not_found);
 
   ASSERT_PTR_NULL(g_client->state.load);
   ASSERT_PTR_NOT_NULL(g_client->game);
@@ -1556,7 +1556,7 @@ static void test_load_game_not_logged_in(void)
   g_client = mock_client_not_logged_in();
 
   reset_mock_api_handlers();
-  mock_api_response("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", "{\"Success\":true,\"GameID\":1234}");
+  mock_api_response("r=achievementsets&u=Username&t=ApiToken&m=0123456789ABCDEF", "{\"Success\":true,\"GameID\":1234}");
 
   ASSERT_NUM_EQUALS(rc_client_get_load_game_state(g_client), RC_CLIENT_LOAD_GAME_STATE_NONE);
 
@@ -1576,7 +1576,7 @@ static void test_load_game(void)
   g_client = mock_client_logged_in();
 
   reset_mock_api_handlers();
-  mock_api_response("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
+  mock_api_response("r=achievementsets&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
   mock_api_response("r=startsession&u=Username&t=ApiToken&g=1234&h=1&m=0123456789ABCDEF&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
 
   ASSERT_NUM_EQUALS(rc_client_get_load_game_state(g_client), RC_CLIENT_LOAD_GAME_STATE_NONE);
@@ -1663,16 +1663,16 @@ static void test_load_game_async_load_different_game(void)
   /* start loading first game */
   ASSERT_NUM_EQUALS(rc_client_get_load_game_state(g_client), RC_CLIENT_LOAD_GAME_STATE_NONE);
   rc_client_begin_load_game(g_client, "0123456789ABCDEF", rc_client_callback_expect_no_longer_active, g_callback_userdata);
-  assert_api_pending("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF");
+  assert_api_pending("r=achievementsets&u=Username&t=ApiToken&m=0123456789ABCDEF");
   ASSERT_NUM_EQUALS(rc_client_get_load_game_state(g_client), RC_CLIENT_LOAD_GAME_STATE_IDENTIFYING_GAME);
 
   /* receive data for first game, start session for first game */
-  async_api_response("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
+  async_api_response("r=achievementsets&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
   ASSERT_NUM_EQUALS(rc_client_get_load_game_state(g_client), RC_CLIENT_LOAD_GAME_STATE_STARTING_SESSION);
 
   /* start loading second game*/
   rc_client_begin_load_game(g_client, "ABCDEF0123456789", rc_client_callback_expect_success, g_callback_userdata);
-  assert_api_pending("r=hashdata&u=Username&t=ApiToken&m=ABCDEF0123456789");
+  assert_api_pending("r=achievementsets&u=Username&t=ApiToken&m=ABCDEF0123456789");
   ASSERT_NUM_EQUALS(rc_client_get_load_game_state(g_client), RC_CLIENT_LOAD_GAME_STATE_IDENTIFYING_GAME);
 
   /* session started for first game, should abort */
@@ -1680,7 +1680,7 @@ static void test_load_game_async_load_different_game(void)
   ASSERT_NUM_EQUALS(rc_client_get_load_game_state(g_client), RC_CLIENT_LOAD_GAME_STATE_IDENTIFYING_GAME);
 
   /* receive data for second game, start session for second game */
-  async_api_response("r=hashdata&u=Username&t=ApiToken&m=ABCDEF0123456789", patchdata_alternate);
+  async_api_response("r=achievementsets&u=Username&t=ApiToken&m=ABCDEF0123456789", patchdata_alternate);
   ASSERT_NUM_EQUALS(rc_client_get_load_game_state(g_client), RC_CLIENT_LOAD_GAME_STATE_STARTING_SESSION);
 
   /* session started for second game, should succeed */
@@ -1717,15 +1717,15 @@ static void test_load_game_async_login(void)
   ASSERT_NUM_EQUALS(rc_client_get_load_game_state(g_client), RC_CLIENT_LOAD_GAME_STATE_AWAIT_LOGIN);
 
   /* game load process will stop here waiting for the login to complete */
-  assert_api_not_called("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF");
+  assert_api_not_called("r=achievementsets&u=Username&t=ApiToken&m=0123456789ABCDEF");
 
   /* login completion will trigger process to continue */
   async_api_response("r=login2&u=Username&p=Pa%24%24word",
 	    "{\"Success\":true,\"User\":\"Username\",\"Token\":\"ApiToken\",\"Score\":12345,\"SoftcoreScore\":123,\"Messages\":2,\"Permissions\":1,\"AccountType\":\"Registered\"}");
-  assert_api_pending("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF");
+  assert_api_pending("r=achievementsets&u=Username&t=ApiToken&m=0123456789ABCDEF");
   ASSERT_NUM_EQUALS(rc_client_get_load_game_state(g_client), RC_CLIENT_LOAD_GAME_STATE_IDENTIFYING_GAME);
 
-  async_api_response("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
+  async_api_response("r=achievementsets&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
   ASSERT_NUM_EQUALS(rc_client_get_load_game_state(g_client), RC_CLIENT_LOAD_GAME_STATE_STARTING_SESSION);
 
   async_api_response("r=startsession&u=Username&t=ApiToken&g=1234&h=1&m=0123456789ABCDEF&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
@@ -1760,13 +1760,13 @@ static void test_load_game_async_login_with_incorrect_password(void)
   ASSERT_NUM_EQUALS(rc_client_get_load_game_state(g_client), RC_CLIENT_LOAD_GAME_STATE_AWAIT_LOGIN);
 
   /* game load process will stop here waiting for the login to complete */
-  assert_api_not_called("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF");
+  assert_api_not_called("r=achievementsets&u=Username&t=ApiToken&m=0123456789ABCDEF");
 
   /* login failure will trigger process to continue */
   async_api_error("r=login2&u=Username&p=Pa%24%24word",
       "{\"Success\":false,\"Error\":\"Invalid User/Password combination. Please try again\","
       "\"Status\":401,\"Code\":\"invalid_credentials\"}", 401);
-  assert_api_not_called("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF");
+  assert_api_not_called("r=achievementsets&u=Username&t=ApiToken&m=0123456789ABCDEF");
 
   ASSERT_PTR_NULL(g_client->user.username);
 
@@ -1786,13 +1786,13 @@ static void test_load_game_async_login_logout(void)
   rc_client_begin_load_game(g_client, "0123456789ABCDEF", rc_client_callback_expect_login_aborted, g_callback_userdata);
 
   /* game load process will stop here waiting for the login to complete */
-  assert_api_not_called("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF");
+  assert_api_not_called("r=achievementsets&u=Username&t=ApiToken&m=0123456789ABCDEF");
 
   /* logout will cancel login and allow game load to proceed with failure */
   rc_client_logout(g_client);
   async_api_response("r=login2&u=Username&p=Pa%24%24word",
     "{\"Success\":true,\"User\":\"Username\",\"Token\":\"ApiToken\",\"Score\":12345,\"SoftcoreScore\":123,\"Messages\":2,\"Permissions\":1,\"AccountType\":\"Registered\"}");
-  assert_api_not_called("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF");
+  assert_api_not_called("r=achievementsets&u=Username&t=ApiToken&m=0123456789ABCDEF");
 
   ASSERT_PTR_NULL(g_client->user.username);
 
@@ -1814,13 +1814,13 @@ static void test_load_game_async_login_aborted(void)
   rc_client_begin_load_game(g_client, "0123456789ABCDEF", rc_client_callback_expect_login_aborted, g_callback_userdata);
 
   /* game load process will stop here waiting for the login to complete */
-  assert_api_not_called("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF");
+  assert_api_not_called("r=achievementsets&u=Username&t=ApiToken&m=0123456789ABCDEF");
 
   /* login abort will trigger game load process to continue */
   rc_client_abort_async(g_client, handle);
   async_api_response("r=login2&u=Username&p=Pa%24%24word",
     "{\"Success\":true,\"User\":\"Username\",\"Token\":\"ApiToken\",\"Score\":12345,\"SoftcoreScore\":123,\"Messages\":2,\"Permissions\":1,\"AccountType\":\"Registered\"}");
-  assert_api_not_called("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF");
+  assert_api_not_called("r=achievementsets&u=Username&t=ApiToken&m=0123456789ABCDEF");
 
   ASSERT_PTR_NULL(g_client->user.username);
 
@@ -1844,7 +1844,7 @@ static void test_load_game_patch_failure(void)
   g_client = mock_client_logged_in();
 
   reset_mock_api_handlers();
-  mock_api_error("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", response_429, 429);
+  mock_api_error("r=achievementsets&u=Username&t=ApiToken&m=0123456789ABCDEF", response_429, 429);
   mock_api_response("r=startsession&u=Username&t=ApiToken&g=1234&h=1&m=0123456789ABCDEF&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
 
   rc_client_begin_load_game(g_client, "0123456789ABCDEF", rc_client_callback_expect_too_many_requests, g_callback_userdata);
@@ -1861,7 +1861,7 @@ static void test_load_game_startsession_failure(void)
   g_client = mock_client_logged_in();
 
   reset_mock_api_handlers();
-  mock_api_response("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
+  mock_api_response("r=achievementsets&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
   mock_api_error("r=startsession&u=Username&t=ApiToken&g=1234&h=1&m=0123456789ABCDEF&l=" RCHEEVOS_VERSION_STRING, response_429, 429);
 
   rc_client_begin_load_game(g_client, "0123456789ABCDEF", rc_client_callback_expect_too_many_requests, g_callback_userdata);
@@ -1878,7 +1878,7 @@ static void test_load_game_startsession_timeout(void)
   g_client = mock_client_logged_in();
 
   reset_mock_api_handlers();
-  mock_api_response("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
+  mock_api_response("r=achievementsets&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
   mock_api_error("r=startsession&u=Username&t=ApiToken&g=1234&h=1&m=0123456789ABCDEF&l=" RCHEEVOS_VERSION_STRING, "", 504);
 
   rc_client_begin_load_game(g_client, "0123456789ABCDEF", rc_client_callback_expect_timeout, g_callback_userdata);
@@ -1895,7 +1895,7 @@ static void test_load_game_startsession_custom_timeout(void)
   g_client = mock_client_logged_in();
 
   reset_mock_api_handlers();
-  mock_api_response("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
+  mock_api_response("r=achievementsets&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
   mock_api_error("r=startsession&u=Username&t=ApiToken&g=1234&h=1&m=0123456789ABCDEF&l=" RCHEEVOS_VERSION_STRING,
     "Request has timed out.", RC_API_SERVER_RESPONSE_RETRYABLE_CLIENT_ERROR);
 
@@ -1922,7 +1922,7 @@ static void test_load_game_patch_aborted(void)
 
   rc_client_abort_async(g_client, handle);
 
-  async_api_response("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
+  async_api_response("r=achievementsets&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
   assert_api_not_called("r=startsession&u=Username&t=ApiToken&g=1234&h=1&m=0123456789ABCDEF&l=" RCHEEVOS_VERSION_STRING);
 
   ASSERT_PTR_NULL(g_client->state.load);
@@ -1944,7 +1944,7 @@ static void test_load_game_startsession_aborted(void)
   handle = rc_client_begin_load_game(g_client, "0123456789ABCDEF",
     rc_client_callback_expect_uncalled, g_callback_userdata);
 
-  async_api_response("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
+  async_api_response("r=achievementsets&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
 
   rc_client_abort_async(g_client, handle);
 
@@ -1965,7 +1965,7 @@ static void test_load_game_while_spectating(void)
   rc_client_set_spectator_mode_enabled(g_client, 1);
 
   reset_mock_api_handlers();
-  mock_api_response("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
+  mock_api_response("r=achievementsets&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
   /* spectator mode should not start a session or fetch unlocks */
 
   rc_client_begin_load_game(g_client, "0123456789ABCDEF", rc_client_callback_expect_success, g_callback_userdata);
@@ -2051,7 +2051,7 @@ static void test_load_game_process_game_sets(void)
   rc_client_callback_process_game_sets_called = 0;
 
   reset_mock_api_handlers();
-  mock_api_response("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
+  mock_api_response("r=achievementsets&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
   mock_api_response("r=startsession&u=Username&t=ApiToken&g=1234&h=1&m=0123456789ABCDEF&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
 
   rc_client_begin_load_game(g_client, "0123456789ABCDEF", rc_client_callback_expect_success, g_callback_userdata);
@@ -2115,7 +2115,7 @@ static void test_load_game_destroy_while_fetching_game_data(void)
 
   rc_client_destroy(g_client);
 
-  async_api_response("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
+  async_api_response("r=achievementsets&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
 }
 
 static void test_load_unknown_game(void)
@@ -2247,7 +2247,7 @@ static void test_unload_game_while_fetching_game_data(void)
 
   rc_client_unload_game(g_client);
 
-  async_api_response("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
+  async_api_response("r=achievementsets&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
 
   ASSERT_PTR_NULL(g_client->state.load);
   ASSERT_PTR_NULL(g_client->game);
@@ -2263,7 +2263,7 @@ static void test_unload_game_while_starting_session(void)
 
   rc_client_begin_load_game(g_client, "0123456789ABCDEF", rc_client_callback_expect_uncalled, g_callback_userdata);
 
-  async_api_response("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
+  async_api_response("r=achievementsets&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
 
   rc_client_unload_game(g_client);
 
@@ -2308,7 +2308,7 @@ static void test_identify_and_load_game_console_specified(void)
   g_client = mock_client_logged_in();
 
   reset_mock_api_handlers();
-  mock_api_response("r=hashdata&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", patchdata_2ach_1lbd);
+  mock_api_response("r=achievementsets&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", patchdata_2ach_1lbd);
   mock_api_response("r=startsession&u=Username&t=ApiToken&g=1234&h=1&m=6a2305a2b6675a97ff792709be1ca857&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
 
   rc_client_begin_identify_and_load_game(g_client, RC_CONSOLE_GAMEBOY, "foo.zip#foo.gb",
@@ -2340,7 +2340,7 @@ static void test_identify_and_load_game_console_not_specified(void)
   g_client = mock_client_logged_in();
 
   reset_mock_api_handlers();
-  mock_api_response("r=hashdata&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", patchdata_2ach_1lbd);
+  mock_api_response("r=achievementsets&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", patchdata_2ach_1lbd);
   mock_api_response("r=startsession&u=Username&t=ApiToken&g=1234&h=1&m=6a2305a2b6675a97ff792709be1ca857&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
 
   rc_client_begin_identify_and_load_game(g_client, RC_CONSOLE_UNKNOWN, "foo.zip#foo.gb",
@@ -2382,17 +2382,17 @@ static void test_identify_and_load_game_multiconsole_first(void)
     image, image_size, rc_client_callback_expect_success, g_callback_userdata);
 
   /* first hash lookup should be pending. inject a secondary console into the iterator */
-  assert_api_pending("r=hashdata&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857");
+  assert_api_pending("r=achievementsets&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857");
   iterator = rc_client_get_load_state_hash_iterator(g_client);
   ASSERT_NUM_EQUALS(iterator->index, 1);
   ASSERT_NUM_EQUALS(iterator->consoles[iterator->index], 0);
   iterator->consoles[iterator->index] = RC_CONSOLE_MEGA_DRIVE; /* full buffer hash */
   iterator->consoles[iterator->index + 1] = 0;
 
-  async_api_response("r=hashdata&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", patchdata_2ach_1lbd);
+  async_api_response("r=achievementsets&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", patchdata_2ach_1lbd);
   async_api_response("r=startsession&u=Username&t=ApiToken&g=1234&h=1&m=6a2305a2b6675a97ff792709be1ca857&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
 
-  assert_api_not_pending("r=hashdata&u=Username&t=ApiToken&m=64b131c5c7fec32985d9c99700babb7e");
+  assert_api_not_pending("r=achievementsets&u=Username&t=ApiToken&m=64b131c5c7fec32985d9c99700babb7e");
 
   ASSERT_PTR_NULL(g_client->state.load);
   ASSERT_PTR_NOT_NULL(g_client->game);
@@ -2427,17 +2427,17 @@ static void test_identify_and_load_game_multiconsole_second(void)
     image, image_size, rc_client_callback_expect_success, g_callback_userdata);
 
   /* first hash lookup should be pending. inject a secondary console into the iterator */
-  assert_api_pending("r=hashdata&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857");
+  assert_api_pending("r=achievementsets&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857");
   iterator = rc_client_get_load_state_hash_iterator(g_client);
   ASSERT_NUM_EQUALS(iterator->index, 1);
   ASSERT_NUM_EQUALS(iterator->consoles[iterator->index], 0);
   iterator->consoles[iterator->index] = RC_CONSOLE_MEGA_DRIVE; /* full buffer hash */
   iterator->consoles[iterator->index + 1] = 0;
 
-  async_api_response("r=hashdata&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", patchdata_not_found);
+  async_api_response("r=achievementsets&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", patchdata_not_found);
 
-  assert_api_pending("r=hashdata&u=Username&t=ApiToken&m=64b131c5c7fec32985d9c99700babb7e");
-  async_api_response("r=hashdata&u=Username&t=ApiToken&m=64b131c5c7fec32985d9c99700babb7e" ,patchdata_2ach_1lbd);
+  assert_api_pending("r=achievementsets&u=Username&t=ApiToken&m=64b131c5c7fec32985d9c99700babb7e");
+  async_api_response("r=achievementsets&u=Username&t=ApiToken&m=64b131c5c7fec32985d9c99700babb7e" ,patchdata_2ach_1lbd);
   async_api_response("r=startsession&u=Username&t=ApiToken&g=1234&h=1&m=64b131c5c7fec32985d9c99700babb7e&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
 
   ASSERT_PTR_NULL(g_client->state.load);
@@ -2468,7 +2468,7 @@ static void test_identify_and_load_game_unknown_hash(void)
   g_client = mock_client_logged_in();
 
   reset_mock_api_handlers();
-  mock_api_response("r=hashdata&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", patchdata_not_found);
+  mock_api_response("r=achievementsets&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", patchdata_not_found);
 
   rc_client_begin_identify_and_load_game(g_client, RC_CONSOLE_UNKNOWN, "foo.zip#foo.gb",
       image, image_size, rc_client_callback_expect_unknown_game, g_callback_userdata);
@@ -2507,7 +2507,7 @@ static void test_identify_and_load_game_unknown_hash_repeated(void)
   ASSERT_PTR_NOT_NULL(handle);
   ASSERT_PTR_NOT_NULL(g_client->state.load);
 
-  async_api_response("r=hashdata&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", patchdata_not_found);
+  async_api_response("r=achievementsets&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", patchdata_not_found);
 
   ASSERT_PTR_NULL(g_client->state.load);
   ASSERT_PTR_NOT_NULL(g_client->game);
@@ -2557,7 +2557,7 @@ static void test_identify_and_load_game_unknown_hash_multiple(void)
   ASSERT_PTR_NOT_NULL(handle);
   ASSERT_PTR_NOT_NULL(g_client->state.load);
 
-  async_api_response("r=hashdata&u=Username&t=ApiToken&m=88be638f4d78b4072109e55f13e8a0ac", patchdata_not_found);
+  async_api_response("r=achievementsets&u=Username&t=ApiToken&m=88be638f4d78b4072109e55f13e8a0ac", patchdata_not_found);
 
   ASSERT_PTR_NULL(g_client->state.load);
   ASSERT_PTR_NOT_NULL(g_client->game);
@@ -2577,7 +2577,7 @@ static void test_identify_and_load_game_unknown_hash_multiple(void)
   ASSERT_PTR_NOT_NULL(handle);
   ASSERT_PTR_NOT_NULL(g_client->state.load);
 
-  async_api_response("r=hashdata&u=Username&t=ApiToken&m=8e39c6077108cafd6193d1c649b5d695", patchdata_not_found);
+  async_api_response("r=achievementsets&u=Username&t=ApiToken&m=8e39c6077108cafd6193d1c649b5d695", patchdata_not_found);
 
   ASSERT_PTR_NULL(g_client->state.load);
   ASSERT_PTR_NOT_NULL(g_client->game);
@@ -2611,17 +2611,17 @@ static void test_identify_and_load_game_unknown_hash_multiconsole(void)
     image, image_size, rc_client_callback_expect_unknown_game, g_callback_userdata);
 
   /* first hash lookup should be pending. inject a secondary console into the iterator */
-  assert_api_pending("r=hashdata&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857");
+  assert_api_pending("r=achievementsets&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857");
   iterator = rc_client_get_load_state_hash_iterator(g_client);
   ASSERT_NUM_EQUALS(iterator->index, 1);
   ASSERT_NUM_EQUALS(iterator->consoles[iterator->index], 0);
   iterator->consoles[iterator->index] = RC_CONSOLE_MEGA_DRIVE; /* full buffer hash */
   iterator->consoles[iterator->index + 1] = 0;
 
-  async_api_response("r=hashdata&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", patchdata_not_found);
+  async_api_response("r=achievementsets&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", patchdata_not_found);
 
-  assert_api_pending("r=hashdata&u=Username&t=ApiToken&m=64b131c5c7fec32985d9c99700babb7e");
-  async_api_response("r=hashdata&u=Username&t=ApiToken&m=64b131c5c7fec32985d9c99700babb7e", patchdata_not_found);
+  assert_api_pending("r=achievementsets&u=Username&t=ApiToken&m=64b131c5c7fec32985d9c99700babb7e");
+  async_api_response("r=achievementsets&u=Username&t=ApiToken&m=64b131c5c7fec32985d9c99700babb7e", patchdata_not_found);
 
   ASSERT_PTR_NULL(g_client->state.load);
   ASSERT_PTR_NOT_NULL(g_client->game);
@@ -2658,12 +2658,12 @@ static void test_identify_and_load_game_unknown_hash_console_specified(void)
     image, image_size, rc_client_callback_expect_unknown_game, g_callback_userdata);
 
   /* first hash lookup should be pending. iterator should not have been initialized */
-  assert_api_pending("r=hashdata&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857");
+  assert_api_pending("r=achievementsets&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857");
   iterator = rc_client_get_load_state_hash_iterator(g_client);
   ASSERT_NUM_EQUALS(iterator->index, 0);
   ASSERT_NUM_EQUALS(iterator->consoles[iterator->index], 0);
 
-  async_api_response("r=hashdata&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", patchdata_not_found);
+  async_api_response("r=achievementsets&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", patchdata_not_found);
 
   ASSERT_PTR_NULL(g_client->state.load);
   ASSERT_PTR_NOT_NULL(g_client->game);
@@ -2704,8 +2704,8 @@ static void test_identify_and_load_game_unknown_hash_client_provided(void)
   g_client->callbacks.identify_unknown_hash = rc_client_identify_unknown_hash;
 
   reset_mock_api_handlers();
-  mock_api_response("r=hashdata&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", patchdata_not_found);
-  mock_api_response("r=hashdata&u=Username&t=ApiToken&g=1234", patchdata_2ach_1lbd);
+  mock_api_response("r=achievementsets&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", patchdata_not_found);
+  mock_api_response("r=achievementsets&u=Username&t=ApiToken&g=1234", patchdata_2ach_1lbd);
   mock_api_response("r=startsession&u=Username&t=ApiToken&g=1234&h=1&m=6a2305a2b6675a97ff792709be1ca857&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
 
   rc_client_begin_identify_and_load_game(g_client, RC_CONSOLE_GAMEBOY, "foo.zip#foo.gb",
@@ -2738,7 +2738,7 @@ static void test_identify_and_load_game_multihash(void)
   g_client = mock_client_logged_in();
 
   reset_mock_api_handlers();
-  mock_api_response("r=hashdata&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", patchdata_2ach_1lbd);
+  mock_api_response("r=achievementsets&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", patchdata_2ach_1lbd);
   mock_api_response("r=startsession&u=Username&t=ApiToken&g=1234&h=1&m=6a2305a2b6675a97ff792709be1ca857&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
 
   rc_client_begin_identify_and_load_game(g_client, RC_CONSOLE_UNKNOWN, "abc.dsk",
@@ -2770,7 +2770,7 @@ static void test_identify_and_load_game_multihash_unknown_game(void)
   g_client = mock_client_logged_in();
 
   reset_mock_api_handlers();
-  mock_api_response("r=hashdata&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", patchdata_not_found);
+  mock_api_response("r=achievementsets&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", patchdata_not_found);
 
   rc_client_begin_identify_and_load_game(g_client, RC_CONSOLE_UNKNOWN, "abc.dsk",
       image, image_size, rc_client_callback_expect_unknown_game, g_callback_userdata);
@@ -2788,7 +2788,7 @@ static void test_identify_and_load_game_multihash_unknown_game(void)
   }
 
   /* same hash generated for all dsk consoles - only one server call should be made */
-  assert_api_call_count("r=hashdata&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", 1);
+  assert_api_call_count("r=achievementsets&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", 1);
 
   rc_client_destroy(g_client);
   free(image);
@@ -2811,11 +2811,11 @@ static void test_identify_and_load_game_multihash_differ(void)
   memset(&image[256], 0, 32);
 
   /* first lookup fails */
-  async_api_response("r=hashdata&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", patchdata_not_found);
+  async_api_response("r=achievementsets&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857", patchdata_not_found);
   ASSERT_PTR_NOT_NULL(g_client->state.load);
 
   /* second lookup should succeed */
-  async_api_response("r=hashdata&u=Username&t=ApiToken&m=4989b063a40dcfa28291ff8d675050e3", patchdata_2ach_1lbd);
+  async_api_response("r=achievementsets&u=Username&t=ApiToken&m=4989b063a40dcfa28291ff8d675050e3", patchdata_2ach_1lbd);
   async_api_response("r=startsession&u=Username&t=ApiToken&g=1234&h=1&m=4989b063a40dcfa28291ff8d675050e3&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
  
   ASSERT_PTR_NULL(g_client->state.load);
@@ -3113,7 +3113,7 @@ static void test_change_media_while_loading(void)
 
   /* media request won't occur until patch data is received */
   assert_api_not_called("r=gameid&m=6a2305a2b6675a97ff792709be1ca857");
-  async_api_response("r=hashdata&u=Username&t=ApiToken&m=4989b063a40dcfa28291ff8d675050e3", patchdata_2ach_1lbd);
+  async_api_response("r=achievementsets&u=Username&t=ApiToken&m=4989b063a40dcfa28291ff8d675050e3", patchdata_2ach_1lbd);
   assert_api_not_called("r=gameid&m=6a2305a2b6675a97ff792709be1ca857");
 
   /* finish loading game */
@@ -3155,7 +3155,7 @@ static void test_change_media_while_loading_later(void)
       rc_client_callback_expect_success, g_callback_userdata);
 
   /* get past fetching the patch data so there's a valid console for the change media call */
-  async_api_response("r=hashdata&u=Username&t=ApiToken&m=4989b063a40dcfa28291ff8d675050e3", patchdata_2ach_1lbd);
+  async_api_response("r=achievementsets&u=Username&t=ApiToken&m=4989b063a40dcfa28291ff8d675050e3", patchdata_2ach_1lbd);
 
   /* change_media should immediately attempt to resolve the new hash */
   rc_client_begin_change_media(g_client, "foo.zip#foo.gb", image, image_size,
@@ -3224,7 +3224,7 @@ static void test_change_media_async_aborted(void)
     rc_client_callback_expect_success, g_callback_userdata);
 
   ASSERT_STR_EQUALS(g_client->game->public_.hash, "6a2305a2b6675a97ff792709be1ca857");
-  assert_api_not_called("r=hashdata&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857");
+  assert_api_not_called("r=achievementsets&u=Username&t=ApiToken&m=6a2305a2b6675a97ff792709be1ca857");
 
   rc_client_destroy(g_client);
   free(image);
@@ -3421,7 +3421,7 @@ static void test_change_media_from_hash_while_loading(void)
 
   /* media request won't occur until patch data is received */
   assert_api_not_called("r=gameid&m=6a2305a2b6675a97ff792709be1ca857");
-  async_api_response("r=hashdata&u=Username&t=ApiToken&m=4989b063a40dcfa28291ff8d675050e3", patchdata_2ach_1lbd);
+  async_api_response("r=achievementsets&u=Username&t=ApiToken&m=4989b063a40dcfa28291ff8d675050e3", patchdata_2ach_1lbd);
   assert_api_not_called("r=gameid&m=6a2305a2b6675a97ff792709be1ca857");
 
   /* finish loading game */
@@ -3452,7 +3452,7 @@ static void test_change_media_from_hash_while_loading_later(void)
     rc_client_callback_expect_success, g_callback_userdata);
 
   /* get past fetching the patch data so there's a valid console for the change media call */
-  async_api_response("r=hashdata&u=Username&t=ApiToken&m=4989b063a40dcfa28291ff8d675050e3", patchdata_2ach_1lbd);
+  async_api_response("r=achievementsets&u=Username&t=ApiToken&m=4989b063a40dcfa28291ff8d675050e3", patchdata_2ach_1lbd);
 
   /* change_media should immediately attempt to resolve the new hash */
   rc_client_begin_change_media_from_hash(g_client, "6a2305a2b6675a97ff792709be1ca857",
@@ -3634,7 +3634,7 @@ static void test_load_subset(void)
   g_client = mock_client_logged_in();
 
   reset_mock_api_handlers();
-  mock_api_response("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_subset);
+  mock_api_response("r=achievementsets&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_subset);
   mock_api_response("r=startsession&u=Username&t=ApiToken&g=1234&h=1&m=0123456789ABCDEF&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
 
   rc_client_begin_load_game(g_client, "0123456789ABCDEF", rc_client_callback_expect_success, g_callback_userdata);
@@ -9138,7 +9138,7 @@ static void test_deserialize_progress_unknown_game(void)
   g_client = mock_client_logged_in();
 
   reset_mock_api_handlers();
-  mock_api_response("r=hashdata&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_not_found);
+  mock_api_response("r=achievementsets&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_not_found);
   rc_client_begin_load_game(g_client, "0123456789ABCDEF", rc_client_callback_expect_unknown_game, g_callback_userdata);
 
   ASSERT_NUM_EQUALS(rc_client_progress_size(g_client), 0);


### PR DESCRIPTION
Subset information is no longer returned by the `patch` API. A new API has been provided (see https://github.com/RetroAchievements/RAWeb/pull/3513). This simplifies exposing the subset data to the client without modifying the old non-subset API. There were some odd cases where loading a subset hash would try to return the core set a the top level, preventing older clients from being able to access the subset achievements.

`rc_client` has been updated to use the new API, so the transition should be transparent to existing integrations.

