### PR TITLE
allow explicit definition of Unformatted format for transition

### DIFF
--- a/src/rcheevos/rc_runtime_types.natvis
+++ b/src/rcheevos/rc_runtime_types.natvis
@@ -379,6 +379,8 @@
         <DisplayString Condition="value==RC_FORMAT_TENS">{RC_FORMAT_TENS}</DisplayString>
         <DisplayString Condition="value==RC_FORMAT_HUNDREDS">{RC_FORMAT_HUNDREDS}</DisplayString>
         <DisplayString Condition="value==RC_FORMAT_THOUSANDS">{RC_FORMAT_THOUSANDS}</DisplayString>
+        <DisplayString Condition="value==RC_FORMAT_UNSIGNED_VALUE">{RC_FORMAT_UNSIGNED_VALUE}</DisplayString>
+        <DisplayString Condition="value==RC_FORMAT_UNFORMATTED">{RC_FORMAT_UNFORMATTED}</DisplayString>
         <DisplayString Condition="value==101">RC_FORMAT_STRING (101)</DisplayString>
         <DisplayString Condition="value==102">RC_FORMAT_LOOKUP (102)</DisplayString>
         <DisplayString Condition="value==103">RC_FORMAT_UNKNOWN_MACRO (103)</DisplayString>

--- a/src/rcheevos/richpresence.c
+++ b/src/rcheevos/richpresence.c
@@ -537,6 +537,13 @@ void rc_parse_richpresence_internal(rc_richpresence_t* self, const char* script,
 
     } else if (strncmp(line, "Format:", 7) == 0) {
       line += 7;
+      if (endline - line == 11 && memcmp(line, "Unformatted", 11) == 0) {
+        /* for backwards compatibility with the comma rollout, we allow old scripts
+         * to define an Unformatted type mapped to VALUE, and new versions will ignore
+         * the definition and use the built-in macro. skip the next line (FormatType=) */
+        line = rc_parse_line(nextline, &endline, parse);
+        continue;
+      }
 
       lookup = RC_ALLOC_SCRATCH(rc_richpresence_lookup_t, parse);
       lookup->name = rc_alloc_str(parse, line, (int)(endline - line));

--- a/test/rcheevos/test_richpresence.c
+++ b/test/rcheevos/test_richpresence.c
@@ -1179,6 +1179,19 @@ static void test_builtin_macro_override() {
   assert_richpresence_output(richpresence, &memory, "3h25:45");
 }
 
+static void test_unformatted_legacy() {
+  uint8_t ram[] = { 0x39, 0x30 };
+  memory_t memory;
+  rc_richpresence_t* richpresence;
+  char buffer[512];
+
+  memory.ram = ram;
+  memory.size = sizeof(ram);
+
+  assert_parse_richpresence(&richpresence, buffer, "Format:Unformatted\nFormatType=VALUE\n\nDisplay:\n@Unformatted(0x 0)");
+  assert_richpresence_output(richpresence, &memory, "12345");
+}
+
 static void test_asciichar() {
   uint8_t ram[] = { 'K', 'e', 'n', '\0', 'V', 'e', 'g', 'a', 1 };
   memory_t memory;
@@ -1446,6 +1459,7 @@ void test_richpresence(void) {
   TEST_PARAMS2(test_builtin_macro, "Unformatted", "12345");
   TEST(test_builtin_macro_unsigned_large);
   TEST(test_builtin_macro_override);
+  TEST(test_unformatted_legacy);
 
   /* asciichar */
   TEST(test_asciichar);


### PR DESCRIPTION
#413 changed the behavior of the default `VALUE` format to include commas. There are a few cases in existing scripts where this is undesirable - particularly when showing years: 
* https://discord.com/channels/310192285306454017/533411674162593812/1376881009286582393
* https://discord.com/channels/310192285306454017/310195377993416714/1377926632525795369

To provide a backwards-compatibility layer, this PR allows `Unformatted` to be defined as a classic `VALUE` format (thus preventing an Unknown Macro error), while allowing newer clients that understand `Unformatted` to use the built-in macro.

To leverage this behavior, just define `Unformatted` as a `VALUE` format and then use it in the display strings, just like you would with any other macro.
```
Format:Unformatted
FormatType=VALUE

Display:
The year is @Unformatted(0xX1234).
```

Then, when the client updates to a version of rcheevos that has this PR, it will ignore the explicit definition and use the `UNFORMATTED` format type.