### PR TITLE
add rc_client_set_allow_background_memory_reads

### DIFF
--- a/include/rc_client.h
+++ b/include/rc_client.h
@@ -735,6 +735,11 @@ RC_EXPORT void RC_CCONV rc_client_set_event_handler(rc_client_t* client, rc_clie
 RC_EXPORT void RC_CCONV rc_client_set_read_memory_function(rc_client_t* client, rc_client_read_memory_func_t handler);
 
 /**
+ * Specifies whether rc_client is allowed to read memory outside of rc_client_do_frame/rc_client_idle.
+ */
+RC_EXPORT void RC_CCONV rc_client_set_allow_background_memory_reads(rc_client_t* client, int allowed);
+
+/**
  * Determines if there are any active achievements/leaderboards/rich presence that need processing.
  */
 RC_EXPORT int RC_CCONV rc_client_is_processing_required(rc_client_t* client);

--- a/src/rc_client.c
+++ b/src/rc_client.c
@@ -172,6 +172,7 @@ rc_client_t* rc_client_create(rc_client_read_memory_func_t read_memory_function,
 
   client->state.hardcore = 1;
   client->state.required_unpaused_frames = RC_MINIMUM_UNPAUSED_FRAMES;
+  client->state.allow_background_memory_reads = 1;
 
   client->callbacks.read_memory = read_memory_function;
   client->callbacks.server_call = server_call_function;
@@ -1623,6 +1624,11 @@ static void rc_client_free_pending_media(rc_client_pending_media_t* pending_medi
   free(pending_media);
 }
 
+/* NOTE: address validation uses the read_memory callback to make sure the client
+ *       will return data for the requested address. As such, this function must
+ *       respect the `client->state.allow_background_memory_reads setting. Use
+ *       rc_client_queue_activate_game to dispatch this function to the do_frame loop/
+ */
 static void rc_client_activate_game(rc_client_load_state_t* load_state, rc_api_start_session_response_t *start_session_response)
 {
   rc_client_t* client = load_state->client;
@@ -1693,11 +1699,6 @@ static void rc_client_activate_game(rc_client_load_state_t* load_state, rc_api_s
     /* if the game is still being loaded, make sure all the required memory addresses are accessible
      * so we can mark achievements as unsupported before loading them into the runtime. */
     if (load_state->progress != RC_CLIENT_LOAD_GAME_STATE_ABORTED) {
-      /* TODO: it is desirable to not do memory reads from a background thread. Some emulators (like Dolphin) don't
-       *       allow it. Dolphin's solution is to use a dummy read function that says all addresses are valid and
-       *       switches to the actual read function after the callback is called. latter invalid reads will
-       *       mark achievements as unsupported. */
-
       /* ASSERT: client->game must be set before calling this function so the read_memory callback can query the console_id */
       rc_client_validate_addresses(load_state->game, client);
 
@@ -1758,6 +1759,28 @@ static void rc_client_activate_game(rc_client_load_state_t* load_state, rc_api_s
   rc_client_free_load_state(load_state);
 }
 
+static void rc_client_dispatch_activate_game(struct rc_client_scheduled_callback_data_t* callback_data, rc_client_t* client, rc_clock_t now)
+{
+  rc_client_load_state_t* load_state = (rc_client_load_state_t*)callback_data->data;
+  free(callback_data);
+
+  rc_client_activate_game(load_state, load_state->start_session_response);
+}
+
+static void rc_client_queue_activate_game(rc_client_load_state_t* load_state)
+{
+  rc_client_scheduled_callback_data_t* scheduled_callback_data = calloc(1, sizeof(rc_client_scheduled_callback_data_t));
+  if (!scheduled_callback_data) {
+    rc_client_load_error(load_state, RC_OUT_OF_MEMORY, rc_error_str(RC_OUT_OF_MEMORY));
+    return;
+  }
+
+  scheduled_callback_data->callback = rc_client_dispatch_activate_game;
+  scheduled_callback_data->data = load_state;
+
+  rc_client_schedule_callback(load_state->client, scheduled_callback_data);
+}
+
 static void rc_client_start_session_callback(const rc_api_server_response_t* server_response, void* callback_data)
 {
   rc_client_load_state_t* load_state = (rc_client_load_state_t*)callback_data;
@@ -1788,7 +1811,7 @@ static void rc_client_start_session_callback(const rc_api_server_response_t* ser
   else if (outstanding_requests < 0) {
     /* previous load state was aborted, load_state was free'd */
   }
-  else if (outstanding_requests == 0) {
+  else if (outstanding_requests == 0 && load_state->client->state.allow_background_memory_reads) {
     rc_client_activate_game(load_state, &start_session_response);
   }
   else {
@@ -1802,6 +1825,9 @@ static void rc_client_start_session_callback(const rc_api_server_response_t* ser
       /* safer to parse the response again than to try to copy it */
       rc_api_process_start_session_response(load_state->start_session_response, server_response->body);
     }
+
+    if (outstanding_requests == 0)
+      rc_client_queue_activate_game(load_state);
   }
 
   rc_api_destroy_start_session_response(&start_session_response);
@@ -2214,9 +2240,11 @@ static void rc_client_fetch_game_data_callback(const rc_api_server_response_t* s
     if (outstanding_requests < 0) {
       /* previous load state was aborted, load_state was free'd */
     }
-    else {
-      if (outstanding_requests == 0)
+    else if (outstanding_requests == 0) {
+      if (load_state->client->state.allow_background_memory_reads)
         rc_client_activate_game(load_state, load_state->start_session_response);
+      else
+        rc_client_queue_activate_game(load_state);
     }
   }
 
@@ -2487,6 +2515,8 @@ static void rc_client_begin_fetch_game_data(rc_client_load_state_t* load_state)
   result = client->state.user;
   if (result == RC_CLIENT_USER_STATE_LOGIN_REQUESTED)
     load_state->progress = RC_CLIENT_LOAD_GAME_STATE_AWAIT_LOGIN;
+  else
+    load_state->progress = RC_CLIENT_LOAD_GAME_STATE_FETCHING_GAME_DATA;
   rc_mutex_unlock(&client->state.mutex);
 
   switch (result) {
@@ -5148,6 +5178,19 @@ void rc_client_set_read_memory_function(rc_client_t* client, rc_client_read_memo
 #endif
 
   client->callbacks.read_memory = handler;
+}
+
+void rc_client_set_allow_background_memory_reads(rc_client_t* client, int allowed)
+{
+  if (!client)
+    return;
+
+#ifdef RC_CLIENT_SUPPORTS_EXTERNAL
+  if (client->state.external_client && client->state.external_client->set_allow_background_memory_reads)
+    client->state.external_client->set_allow_background_memory_reads(allowed);
+#endif
+
+  client->state.allow_background_memory_reads = allowed;
 }
 
 static void rc_client_invalidate_processing_memref(rc_client_t* client)

--- a/src/rc_client.c
+++ b/src/rc_client.c
@@ -1764,6 +1764,9 @@ static void rc_client_dispatch_activate_game(struct rc_client_scheduled_callback
   rc_client_load_state_t* load_state = (rc_client_load_state_t*)callback_data->data;
   free(callback_data);
 
+  (void)client;
+  (void)now;
+
   rc_client_activate_game(load_state, load_state->start_session_response);
 }
 

--- a/src/rc_client_external.h
+++ b/src/rc_client_external.h
@@ -136,9 +136,12 @@ typedef struct rc_client_external_t
   rc_client_external_get_achievement_info_func_t get_achievement_info_v3;
   rc_client_external_create_achievement_list_func_t create_achievement_list_v3;
 
+  /* VERSION 4 */
+  rc_client_external_set_int_func_t set_allow_background_memory_reads;
+
 } rc_client_external_t;
 
-#define RC_CLIENT_EXTERNAL_VERSION 3
+#define RC_CLIENT_EXTERNAL_VERSION 4
 
 void rc_client_add_game_hash(rc_client_t* client, const char* hash, uint32_t game_id);
 void rc_client_load_unknown_game(rc_client_t* client, const char* hash);

--- a/src/rc_client_internal.h
+++ b/src/rc_client_internal.h
@@ -320,6 +320,7 @@ typedef struct rc_client_state_t {
   uint8_t user;
   uint8_t disconnect;
   uint8_t allow_leaderboards_in_softcore;
+  uint8_t allow_background_memory_reads;
 
   struct rc_client_load_state_t* load;
   struct rc_client_async_handle_t* async_handles[4];

--- a/test/test_rc_client.c
+++ b/test/test_rc_client.c
@@ -2106,6 +2106,39 @@ static void test_load_unknown_game_multihash(void)
   rc_client_destroy(g_client);
 }
 
+static void test_load_game_dispatched_read_memory(void)
+{
+  g_client = mock_client_logged_in();
+  rc_client_set_allow_background_memory_reads(g_client, 0);
+
+  reset_mock_api_handlers();
+  mock_api_response("r=patch&u=Username&t=ApiToken&m=0123456789ABCDEF", patchdata_2ach_1lbd);
+  mock_api_response("r=startsession&u=Username&t=ApiToken&g=1234&h=1&m=0123456789ABCDEF&l=" RCHEEVOS_VERSION_STRING, "{\"Success\":true}");
+
+  rc_client_begin_load_game(g_client, "0123456789ABCDEF", rc_client_callback_expect_success, g_callback_userdata);
+  ASSERT_NUM_EQUALS(rc_client_get_load_game_state(g_client), RC_CLIENT_LOAD_GAME_STATE_STARTING_SESSION);
+  ASSERT_PTR_NOT_NULL(g_client->state.load);
+  ASSERT_PTR_NULL(g_client->game);
+
+  rc_client_idle(g_client);
+
+  ASSERT_PTR_NULL(g_client->state.load);
+  ASSERT_PTR_NOT_NULL(g_client->game);
+  if (g_client->game) {
+    ASSERT_PTR_EQUALS(rc_client_get_game_info(g_client), &g_client->game->public_);
+
+    ASSERT_NUM_EQUALS(g_client->game->public_.id, 1234);
+    ASSERT_NUM_EQUALS(g_client->game->public_.console_id, 17);
+    ASSERT_STR_EQUALS(g_client->game->public_.title, "Sample Game");
+    ASSERT_STR_EQUALS(g_client->game->public_.hash, "0123456789ABCDEF");
+    ASSERT_STR_EQUALS(g_client->game->public_.badge_name, "112233");
+    ASSERT_NUM_EQUALS(g_client->game->subsets->public_.num_achievements, 2);
+    ASSERT_NUM_EQUALS(g_client->game->subsets->public_.num_leaderboards, 1);
+  }
+
+  rc_client_destroy(g_client);
+}
+
 /* ----- unload game ----- */
 
 static void test_unload_game(void)
@@ -9569,6 +9602,7 @@ void test_client(void) {
   TEST(test_load_game_destroy_while_fetching_game_data);
   TEST(test_load_unknown_game);
   TEST(test_load_unknown_game_multihash);
+  TEST(test_load_game_dispatched_read_memory);
 
   /* unload game */
   TEST(test_unload_game);

--- a/test/test_rc_client_external.c
+++ b/test/test_rc_client_external.c
@@ -338,6 +338,20 @@ static void test_add_game_hash(void)
   rc_client_destroy(g_client);
 }
 
+static void test_set_allow_background_memory_reads(void)
+{
+  g_client = mock_client_with_external();
+  g_client->state.external_client->set_allow_background_memory_reads = rc_client_external_set_int;
+
+  rc_client_set_allow_background_memory_reads(g_client, 0);
+  ASSERT_NUM_EQUALS(g_external_int, 0);
+
+  rc_client_set_allow_background_memory_reads(g_client, 1);
+  ASSERT_NUM_EQUALS(g_external_int, 1);
+
+  rc_client_destroy(g_client);
+}
+
 /* ----- login ----- */
 
 static void test_v1_user_field_offsets(void)
@@ -1805,6 +1819,7 @@ void test_client_external(void) {
   TEST(test_get_time_millisecs);
   TEST(test_set_host);
   TEST(test_get_user_agent_clause);
+  TEST(test_set_allow_background_memory_reads);
 
   /* login */
   TEST(test_v1_user_field_offsets);


### PR DESCRIPTION
Allows a client to specify that memory reads should only occur within the context of `rc_client_do_frame` or `rc_client_idle`. The trade-off is that the work requiring the memory reads could be delayed by as much as however infrequently `rc_client_idle` is called.

To be expanded to much of RAIntegration after this is merged. This provides the single setting to enable the functionality (by disabling background reads), and addresses the single known situation where rc_client is doing memory reads from a background thread (validating memory addresses before finishing the load game sequence). The flag will automatically be passed to RAIntegration via the `rc_client_external` interface and we can do similar dispatching there for responding to UI events.

For more context, see also https://discord.com/channels/310192285306454017/1149693430306447380/1374558874606243962. A recent Dolphin change supports reading memory outside of the `do_frame` loop by pausing emulation while doing the read. When clicking the "Apply Filter" button, this can cause tens of thousands of pause/unpause calls and the process appears to be very unresponsive. Since emulation is already paused for the call to `rc_client_do_frame` so it can do multiple reads without repeatedly pausing emulation, we want to offload the actual filtering logic into the `do_frame` loop so it can benefit from the "already paused" state while reading memory.