### PR TITLE
rename rc_client change_media functions for consistency with load_game functions

### DIFF
--- a/include/rc_client.h
+++ b/include/rc_client.h
@@ -322,15 +322,17 @@ RC_EXPORT int RC_CCONV rc_client_game_get_image_url(const rc_client_game_t* game
 /**
  * Changes the active disc in a multi-disc game.
  */
-RC_EXPORT rc_client_async_handle_t* RC_CCONV rc_client_begin_change_media(rc_client_t* client, const char* file_path,
+RC_EXPORT rc_client_async_handle_t* RC_CCONV rc_client_begin_identify_and_change_media(rc_client_t* client, const char* file_path,
     const uint8_t* data, size_t data_size, rc_client_callback_t callback, void* callback_userdata);
 #endif
 
 /**
  * Changes the active disc in a multi-disc game.
  */
-RC_EXPORT rc_client_async_handle_t* RC_CCONV rc_client_begin_change_media_from_hash(rc_client_t* client, const char* hash,
+RC_EXPORT rc_client_async_handle_t* RC_CCONV rc_client_begin_change_media(rc_client_t* client, const char* hash,
     rc_client_callback_t callback, void* callback_userdata);
+/* this function was renamed in rcheevos 12.0 */
+#define rc_client_begin_change_media_from_hash rc_client_begin_change_media
 
 /*****************************************************************************\
 | Subsets                                                                     |

--- a/src/rc_client.c
+++ b/src/rc_client.c
@@ -1672,11 +1672,11 @@ static void rc_client_activate_game(rc_client_load_state_t* load_state, rc_api_s
          * client->state.load->game. since we've detached the load_state, this has to occur after
          * we've made the game active. */
         if (pending_media->hash) {
-          rc_client_begin_change_media_from_hash(client, pending_media->hash,
+          rc_client_begin_change_media(client, pending_media->hash,
             pending_media->callback, pending_media->callback_userdata);
         } else {
 #ifdef RC_CLIENT_SUPPORTS_HASH
-          rc_client_begin_change_media(client, pending_media->file_path,
+          rc_client_begin_identify_and_change_media(client, pending_media->file_path,
             pending_media->data, pending_media->data_size,
             pending_media->callback, pending_media->callback_userdata);
 #endif
@@ -3161,7 +3161,7 @@ static rc_client_game_info_t* rc_client_check_pending_media(rc_client_t* client,
 
 #ifdef RC_CLIENT_SUPPORTS_HASH
 
-rc_client_async_handle_t* rc_client_begin_change_media(rc_client_t* client, const char* file_path,
+rc_client_async_handle_t* rc_client_begin_identify_and_change_media(rc_client_t* client, const char* file_path,
     const uint8_t* data, size_t data_size, rc_client_callback_t callback, void* callback_userdata)
 {
   rc_client_pending_media_t media;
@@ -3181,9 +3181,9 @@ rc_client_async_handle_t* rc_client_begin_change_media(rc_client_t* client, cons
   }
 
 #ifdef RC_CLIENT_SUPPORTS_EXTERNAL
-  if (client->state.external_client && !client->state.external_client->begin_change_media_from_hash) {
-    if (client->state.external_client->begin_change_media)
-      return client->state.external_client->begin_change_media(client, file_path, data, data_size, callback, callback_userdata);
+  if (client->state.external_client && !client->state.external_client->begin_change_media) {
+    if (client->state.external_client->begin_identify_and_change_media)
+      return client->state.external_client->begin_identify_and_change_media(client, file_path, data, data_size, callback, callback_userdata);
   }
 #endif
 
@@ -3246,8 +3246,8 @@ rc_client_async_handle_t* rc_client_begin_change_media(rc_client_t* client, cons
 
     if (!result) {
 #ifdef RC_CLIENT_SUPPORTS_EXTERNAL
-      if (client->state.external_client && client->state.external_client->begin_change_media_from_hash)
-        return client->state.external_client->begin_change_media_from_hash(client, game_hash->hash, callback, callback_userdata);
+      if (client->state.external_client && client->state.external_client->begin_change_media)
+        return client->state.external_client->begin_change_media(client, game_hash->hash, callback, callback_userdata);
 #endif
 
       rc_client_change_media_internal(client, game_hash, callback, callback_userdata);
@@ -3259,8 +3259,8 @@ rc_client_async_handle_t* rc_client_begin_change_media(rc_client_t* client, cons
   if (client->state.external_client) {
     if (client->state.external_client->add_game_hash)
       client->state.external_client->add_game_hash(game_hash->hash, game_hash->game_id);
-    if (client->state.external_client->begin_change_media_from_hash)
-      return client->state.external_client->begin_change_media_from_hash(client, game_hash->hash, callback, callback_userdata);
+    if (client->state.external_client->begin_change_media)
+      return client->state.external_client->begin_change_media(client, game_hash->hash, callback, callback_userdata);
   }
 #endif
 
@@ -3269,7 +3269,7 @@ rc_client_async_handle_t* rc_client_begin_change_media(rc_client_t* client, cons
 
 #endif /* RC_CLIENT_SUPPORTS_HASH */
 
-rc_client_async_handle_t* rc_client_begin_change_media_from_hash(rc_client_t* client, const char* hash,
+rc_client_async_handle_t* rc_client_begin_change_media(rc_client_t* client, const char* hash,
     rc_client_callback_t callback, void* callback_userdata)
 {
   rc_client_pending_media_t media;
@@ -3287,8 +3287,8 @@ rc_client_async_handle_t* rc_client_begin_change_media_from_hash(rc_client_t* cl
   }
 
 #ifdef RC_CLIENT_SUPPORTS_EXTERNAL
-  if (client->state.external_client && client->state.external_client->begin_change_media_from_hash) {
-    return client->state.external_client->begin_change_media_from_hash(client, hash, callback, callback_userdata);
+  if (client->state.external_client && client->state.external_client->begin_change_media) {
+    return client->state.external_client->begin_change_media(client, hash, callback, callback_userdata);
   }
 #endif
 

--- a/src/rc_client_external.h
+++ b/src/rc_client_external.h
@@ -99,8 +99,8 @@ typedef struct rc_client_external_t
   rc_client_external_get_subset_info_func_t get_subset_info;
   rc_client_external_action_func_t unload_game;
   rc_client_external_get_user_game_summary_func_t get_user_game_summary;
-  rc_client_external_begin_change_media_func_t begin_change_media;
-  rc_client_external_begin_load_game_func_t begin_change_media_from_hash;
+  rc_client_external_begin_change_media_func_t begin_identify_and_change_media;
+  rc_client_external_begin_load_game_func_t begin_change_media;
 
   rc_client_external_create_achievement_list_func_t create_achievement_list;
   rc_client_external_get_int_func_t has_achievements;

--- a/test/test_rc_client.c
+++ b/test/test_rc_client.c
@@ -2791,7 +2791,7 @@ static void test_change_media_required_fields(void)
 
   g_client = mock_client_game_loaded(patchdata_2ach_1lbd, no_unlocks);
 
-  rc_client_begin_change_media(g_client, NULL, NULL, 0,
+  rc_client_begin_identify_and_change_media(g_client, NULL, NULL, 0,
       rc_client_callback_expect_data_or_file_path_required, g_callback_userdata);
 
   ASSERT_PTR_NULL(g_client->state.load);
@@ -2819,7 +2819,7 @@ static void test_change_media_no_game_loaded(void)
 
   g_client = mock_client_logged_in();
 
-  rc_client_begin_change_media(g_client, "foo.zip#foo.gb", image, image_size,
+  rc_client_begin_identify_and_change_media(g_client, "foo.zip#foo.gb", image, image_size,
       rc_client_callback_expect_no_game_loaded, g_callback_userdata);
 
   ASSERT_PTR_NULL(g_client->state.load);
@@ -2839,7 +2839,7 @@ static void test_change_media_same_game(void)
   mock_api_response("r=gameid&m=6a2305a2b6675a97ff792709be1ca857", "{\"Success\":true,\"GameID\":1234}");
 
   /* changing known discs within a game set is expected to succeed */
-  rc_client_begin_change_media(g_client, "foo.zip#foo.gb", image, image_size,
+  rc_client_begin_identify_and_change_media(g_client, "foo.zip#foo.gb", image, image_size,
       rc_client_callback_expect_success, g_callback_userdata);
 
   ASSERT_PTR_NULL(g_client->state.load);
@@ -2886,7 +2886,7 @@ static void test_change_media_known_game(void)
   mock_api_response("r=gameid&m=6a2305a2b6675a97ff792709be1ca857", "{\"Success\":true,\"GameID\":5555}");
 
   /* changing to a known disc from another game is allowed */
-  rc_client_begin_change_media(g_client, "foo.zip#foo.gb", image, image_size,
+  rc_client_begin_identify_and_change_media(g_client, "foo.zip#foo.gb", image, image_size,
       rc_client_callback_expect_success, g_callback_userdata);
 
   ASSERT_PTR_NULL(g_client->state.load);
@@ -2923,7 +2923,7 @@ static void test_change_media_unknown_game(void)
   mock_api_response("r=gameid&m=6a2305a2b6675a97ff792709be1ca857", "{\"Success\":true,\"GameID\":0}");
 
   /* changing to an unknown disc is not allowed - could be a hacked version of one of the game's discs */
-  rc_client_begin_change_media(g_client, "foo.zip#foo.gb", image, image_size,
+  rc_client_begin_identify_and_change_media(g_client, "foo.zip#foo.gb", image, image_size,
       rc_client_callback_expect_hardcore_disabled_undentified_media, g_callback_userdata);
 
   ASSERT_PTR_NULL(g_client->state.load);
@@ -2962,7 +2962,7 @@ static void test_change_media_unhashable(void)
   g_client->game->public_.console_id = RC_CONSOLE_NINTENDO_64;
 
   /* changing to a disc not supported by the system is allowed */
-  rc_client_begin_change_media(g_client, "foo.zip#foo.gb", image, image_size,
+  rc_client_begin_identify_and_change_media(g_client, "foo.zip#foo.gb", image, image_size,
       rc_client_callback_expect_success, g_callback_userdata);
 
   ASSERT_PTR_NULL(g_client->state.load);
@@ -2999,13 +2999,13 @@ static void test_change_media_back_and_forth(void)
   mock_api_response("r=gameid&m=6a2305a2b6675a97ff792709be1ca857", "{\"Success\":true,\"GameID\":1234}");
   mock_api_response("r=gameid&m=4989b063a40dcfa28291ff8d675050e3", "{\"Success\":true,\"GameID\":1234}");
 
-  rc_client_begin_change_media(g_client, "foo.zip#foo.gb", image, image_size,
+  rc_client_begin_identify_and_change_media(g_client, "foo.zip#foo.gb", image, image_size,
       rc_client_callback_expect_success, g_callback_userdata);
-  rc_client_begin_change_media(g_client, "foo.zip#foo2.nes", image2, image_size,
+  rc_client_begin_identify_and_change_media(g_client, "foo.zip#foo2.nes", image2, image_size,
       rc_client_callback_expect_success, g_callback_userdata);
-  rc_client_begin_change_media(g_client, "foo.zip#foo.gb", image, image_size,
+  rc_client_begin_identify_and_change_media(g_client, "foo.zip#foo.gb", image, image_size,
       rc_client_callback_expect_success, g_callback_userdata);
-  rc_client_begin_change_media(g_client, "foo.zip#foo2.nes", image2, image_size,
+  rc_client_begin_identify_and_change_media(g_client, "foo.zip#foo2.nes", image2, image_size,
       rc_client_callback_expect_success, g_callback_userdata);
 
   assert_api_call_count("r=gameid&m=6a2305a2b6675a97ff792709be1ca857", 1);
@@ -3042,7 +3042,7 @@ static void test_change_media_while_loading(void)
 
   rc_client_begin_load_game(g_client, "4989b063a40dcfa28291ff8d675050e3",
       rc_client_callback_expect_success, g_callback_userdata);
-  rc_client_begin_change_media(g_client, "foo.zip#foo.gb", image, image_size,
+  rc_client_begin_identify_and_change_media(g_client, "foo.zip#foo.gb", image, image_size,
       rc_client_callback_expect_success, g_callback_userdata);
 
   /* media request won't occur until patch data is received */
@@ -3092,7 +3092,7 @@ static void test_change_media_while_loading_later(void)
   async_api_response("r=patch&u=Username&t=ApiToken&m=4989b063a40dcfa28291ff8d675050e3", patchdata_2ach_1lbd);
 
   /* change_media should immediately attempt to resolve the new hash */
-  rc_client_begin_change_media(g_client, "foo.zip#foo.gb", image, image_size,
+  rc_client_begin_identify_and_change_media(g_client, "foo.zip#foo.gb", image, image_size,
       rc_client_callback_expect_success, g_callback_userdata);
   assert_api_pending("r=gameid&m=6a2305a2b6675a97ff792709be1ca857");
 
@@ -3130,7 +3130,7 @@ static void test_change_media_async_aborted(void)
   reset_mock_api_handlers();
 
   /* changing known discs within a game set is expected to succeed */
-  handle = rc_client_begin_change_media(g_client, "foo.zip#foo.gb", image, image_size,
+  handle = rc_client_begin_identify_and_change_media(g_client, "foo.zip#foo.gb", image, image_size,
     rc_client_callback_expect_uncalled, g_callback_userdata);
 
   rc_client_abort_async(g_client, handle);
@@ -3154,7 +3154,7 @@ static void test_change_media_async_aborted(void)
   /* hash should still have been captured and lookup should succeed without having to call server again */
   reset_mock_api_handlers();
 
-  rc_client_begin_change_media(g_client, "foo.zip#foo.gb", image, image_size,
+  rc_client_begin_identify_and_change_media(g_client, "foo.zip#foo.gb", image, image_size,
     rc_client_callback_expect_success, g_callback_userdata);
 
   ASSERT_STR_EQUALS(g_client->game->public_.hash, "6a2305a2b6675a97ff792709be1ca857");
@@ -3173,7 +3173,7 @@ static void test_change_media_client_error(void)
   g_client = mock_client_game_loaded(patchdata_2ach_1lbd, no_unlocks);
   mock_api_error("r=gameid&m=6a2305a2b6675a97ff792709be1ca857", "Internet not available.", RC_API_SERVER_RESPONSE_CLIENT_ERROR);
 
-  handle = rc_client_begin_change_media(g_client, "foo.zip#foo.gb", image, image_size,
+  handle = rc_client_begin_identify_and_change_media(g_client, "foo.zip#foo.gb", image, image_size,
       rc_client_callback_expect_no_internet, g_callback_userdata);
 
   ASSERT_PTR_NULL(g_client->state.load);
@@ -3203,7 +3203,7 @@ static void test_change_media_from_hash_required_fields(void)
 {
   g_client = mock_client_game_loaded(patchdata_2ach_1lbd, no_unlocks);
 
-  rc_client_begin_change_media_from_hash(g_client, NULL,
+  rc_client_begin_change_media(g_client, NULL,
     rc_client_callback_expect_hash_required, g_callback_userdata);
 
   ASSERT_PTR_NULL(g_client->state.load);
@@ -3221,7 +3221,7 @@ static void test_change_media_from_hash_no_game_loaded(void)
 {
   g_client = mock_client_logged_in();
 
-  rc_client_begin_change_media_from_hash(g_client, "6a2305a2b6675a97ff792709be1ca857",
+  rc_client_begin_change_media(g_client, "6a2305a2b6675a97ff792709be1ca857",
     rc_client_callback_expect_no_game_loaded, g_callback_userdata);
 
   ASSERT_PTR_NULL(g_client->state.load);
@@ -3237,7 +3237,7 @@ static void test_change_media_from_hash_same_game(void)
   mock_api_response("r=gameid&m=6a2305a2b6675a97ff792709be1ca857", "{\"Success\":true,\"GameID\":1234}");
 
   /* changing known discs within a game set is expected to succeed */
-  rc_client_begin_change_media_from_hash(g_client, "6a2305a2b6675a97ff792709be1ca857",
+  rc_client_begin_change_media(g_client, "6a2305a2b6675a97ff792709be1ca857",
     rc_client_callback_expect_success, g_callback_userdata);
 
   ASSERT_PTR_NULL(g_client->state.load);
@@ -3266,7 +3266,7 @@ static void test_change_media_from_hash_known_game(void)
   mock_api_response("r=gameid&m=6a2305a2b6675a97ff792709be1ca857", "{\"Success\":true,\"GameID\":5555}");
 
   /* changing to a known disc from another game is allowed */
-  rc_client_begin_change_media_from_hash(g_client, "6a2305a2b6675a97ff792709be1ca857",
+  rc_client_begin_change_media(g_client, "6a2305a2b6675a97ff792709be1ca857",
     rc_client_callback_expect_success, g_callback_userdata);
 
   ASSERT_PTR_NULL(g_client->state.load);
@@ -3292,7 +3292,7 @@ static void test_change_media_from_hash_unknown_game(void)
   mock_api_response("r=gameid&m=6a2305a2b6675a97ff792709be1ca857", "{\"Success\":true,\"GameID\":0}");
 
   /* changing to an unknown disc is not allowed - could be a hacked version of one of the game's discs */
-  rc_client_begin_change_media_from_hash(g_client, "6a2305a2b6675a97ff792709be1ca857",
+  rc_client_begin_change_media(g_client, "6a2305a2b6675a97ff792709be1ca857",
     rc_client_callback_expect_hardcore_disabled_undentified_media, g_callback_userdata);
 
   ASSERT_PTR_NULL(g_client->state.load);
@@ -3319,13 +3319,13 @@ static void test_change_media_from_hash_back_and_forth(void)
   mock_api_response("r=gameid&m=6a2305a2b6675a97ff792709be1ca857", "{\"Success\":true,\"GameID\":1234}");
   mock_api_response("r=gameid&m=4989b063a40dcfa28291ff8d675050e3", "{\"Success\":true,\"GameID\":1234}");
 
-  rc_client_begin_change_media_from_hash(g_client, "6a2305a2b6675a97ff792709be1ca857",
+  rc_client_begin_change_media(g_client, "6a2305a2b6675a97ff792709be1ca857",
     rc_client_callback_expect_success, g_callback_userdata);
-  rc_client_begin_change_media_from_hash(g_client, "4989b063a40dcfa28291ff8d675050e3",
+  rc_client_begin_change_media(g_client, "4989b063a40dcfa28291ff8d675050e3",
     rc_client_callback_expect_success, g_callback_userdata);
-  rc_client_begin_change_media_from_hash(g_client, "6a2305a2b6675a97ff792709be1ca857",
+  rc_client_begin_change_media(g_client, "6a2305a2b6675a97ff792709be1ca857",
     rc_client_callback_expect_success, g_callback_userdata);
-  rc_client_begin_change_media_from_hash(g_client, "4989b063a40dcfa28291ff8d675050e3",
+  rc_client_begin_change_media(g_client, "4989b063a40dcfa28291ff8d675050e3",
     rc_client_callback_expect_success, g_callback_userdata);
 
   assert_api_call_count("r=gameid&m=6a2305a2b6675a97ff792709be1ca857", 1);
@@ -3350,7 +3350,7 @@ static void test_change_media_from_hash_while_loading(void)
 
   rc_client_begin_load_game(g_client, "4989b063a40dcfa28291ff8d675050e3",
     rc_client_callback_expect_success, g_callback_userdata);
-  rc_client_begin_change_media_from_hash(g_client, "6a2305a2b6675a97ff792709be1ca857",
+  rc_client_begin_change_media(g_client, "6a2305a2b6675a97ff792709be1ca857",
     rc_client_callback_expect_success, g_callback_userdata);
 
   /* media request won't occur until patch data is received */
@@ -3389,7 +3389,7 @@ static void test_change_media_from_hash_while_loading_later(void)
   async_api_response("r=patch&u=Username&t=ApiToken&m=4989b063a40dcfa28291ff8d675050e3", patchdata_2ach_1lbd);
 
   /* change_media should immediately attempt to resolve the new hash */
-  rc_client_begin_change_media_from_hash(g_client, "6a2305a2b6675a97ff792709be1ca857",
+  rc_client_begin_change_media(g_client, "6a2305a2b6675a97ff792709be1ca857",
     rc_client_callback_expect_success, g_callback_userdata);
   assert_api_pending("r=gameid&m=6a2305a2b6675a97ff792709be1ca857");
 
@@ -3417,7 +3417,7 @@ static void test_change_media_from_hash_async_aborted(void)
   reset_mock_api_handlers();
 
   /* changing known discs within a game set is expected to succeed */
-  handle = rc_client_begin_change_media_from_hash(g_client, "6a2305a2b6675a97ff792709be1ca857",
+  handle = rc_client_begin_change_media(g_client, "6a2305a2b6675a97ff792709be1ca857",
     rc_client_callback_expect_uncalled, g_callback_userdata);
 
   rc_client_abort_async(g_client, handle);
@@ -3434,7 +3434,7 @@ static void test_change_media_from_hash_async_aborted(void)
   /* hash should still have been captured and lookup should succeed without having to call server again */
   reset_mock_api_handlers();
 
-  rc_client_begin_change_media_from_hash(g_client, "6a2305a2b6675a97ff792709be1ca857",
+  rc_client_begin_change_media(g_client, "6a2305a2b6675a97ff792709be1ca857",
     rc_client_callback_expect_success, g_callback_userdata);
 
   ASSERT_STR_EQUALS(g_client->game->public_.hash, "6a2305a2b6675a97ff792709be1ca857");
@@ -3450,7 +3450,7 @@ static void test_change_media_from_hash_client_error(void)
   g_client = mock_client_game_loaded(patchdata_2ach_1lbd, no_unlocks);
   mock_api_error("r=gameid&m=6a2305a2b6675a97ff792709be1ca857", "Internet not available.", RC_API_SERVER_RESPONSE_CLIENT_ERROR);
 
-  handle = rc_client_begin_change_media_from_hash(g_client, "6a2305a2b6675a97ff792709be1ca857",
+  handle = rc_client_begin_change_media(g_client, "6a2305a2b6675a97ff792709be1ca857",
     rc_client_callback_expect_no_internet, g_callback_userdata);
 
   ASSERT_PTR_NULL(g_client->state.load);

--- a/test/test_rc_client_external.c
+++ b/test/test_rc_client_external.c
@@ -969,7 +969,7 @@ static void assert_change_media(rc_client_t* client, const char* file_path, cons
   ASSERT_NUM_EQUALS(data_size, 32768);
 }
 
-static rc_client_async_handle_t* rc_client_external_begin_change_media(rc_client_t* client, const char* file_path,
+static rc_client_async_handle_t* rc_client_external_begin_identify_and_change_media(rc_client_t* client, const char* file_path,
   const uint8_t* data, size_t data_size, rc_client_callback_t callback, void* callback_userdata)
 {
   assert_change_media(client, file_path, data, data_size);
@@ -986,9 +986,9 @@ static void test_change_media(void)
   uint8_t* image = generate_generic_file(image_size);
 
   g_client = mock_client_with_external();
-  g_client->state.external_client->begin_change_media = rc_client_external_begin_change_media;
+  g_client->state.external_client->begin_identify_and_change_media = rc_client_external_begin_identify_and_change_media;
 
-  rc_client_begin_change_media(g_client, "foo.zip#foo.gb", image, image_size, rc_client_callback_expect_success, g_callback_userdata);
+  rc_client_begin_identify_and_change_media(g_client, "foo.zip#foo.gb", image, image_size, rc_client_callback_expect_success, g_callback_userdata);
 
   ASSERT_STR_EQUALS(g_external_event, "change_media");
 
@@ -1004,7 +1004,7 @@ static void assert_change_media_from_hash(rc_client_t* client, const char* hash)
   ASSERT_STR_EQUALS(hash, "6a2305a2b6675a97ff792709be1ca857");
 }
 
-static rc_client_async_handle_t* rc_client_external_begin_change_media_from_hash(rc_client_t* client, const char* hash,
+static rc_client_async_handle_t* rc_client_external_begin_change_media(rc_client_t* client, const char* hash,
     rc_client_callback_t callback, void* callback_userdata)
 {
   assert_change_media_from_hash(client, hash);
@@ -1018,9 +1018,9 @@ static rc_client_async_handle_t* rc_client_external_begin_change_media_from_hash
 static void test_change_media_from_hash(void)
 {
   g_client = mock_client_with_external();
-  g_client->state.external_client->begin_change_media_from_hash = rc_client_external_begin_change_media_from_hash;
+  g_client->state.external_client->begin_change_media = rc_client_external_begin_change_media;
 
-  rc_client_begin_change_media_from_hash(g_client, "6a2305a2b6675a97ff792709be1ca857", rc_client_callback_expect_success, g_callback_userdata);
+  rc_client_begin_change_media(g_client, "6a2305a2b6675a97ff792709be1ca857", rc_client_callback_expect_success, g_callback_userdata);
 
   ASSERT_STR_EQUALS(g_external_event, "change_media_from_hash");
 


### PR DESCRIPTION
`rc_client_begin_change_media` -> `rc_client_begin_identify_and_change_media` to be consistent with `rc_client_begin_identify_and_load_game`

`rc_client_begin_change_media_from_hash` -> `rc_client_begin_change_media` to be consistent with `rc_client_begin_load_game`

These names are backwards because `rc_client_begin_change_media` was added first by itself. When a second method was required to support loading an external hash, an alternate name had to be added. Since the upcoming release has already been assigned a new major release number, I'm taking this opportunity to make a breaking change to the API to standardize these names.

Because the signatures differ, this will create compiler errors and I'll make sure the solution is documented in the release notes. Hopefully, the impact is minimal.