### PR TITLE
update real addresses for N64 memory

### DIFF
--- a/src/rcheevos/consoleinfo.c
+++ b/src/rcheevos/consoleinfo.c
@@ -724,10 +724,11 @@ static const rc_memory_regions_t rc_memory_regions_nes = { _rc_memory_regions_ne
 
 /* ===== Nintendo 64 ===== */
 /* https://raw.githubusercontent.com/mikeryan/n64dev/master/docs/n64ops/n64ops%23h.txt */
+/* https://n64brew.dev/wiki/Memory_map#Virtual_Memory_Map */
 static const rc_memory_region_t _rc_memory_regions_n64[] = {
-    { 0x000000U, 0x1FFFFFU, 0x00000000U, RC_MEMORY_TYPE_SYSTEM_RAM, "System RAM" }, /* RDRAM 1 */
-    { 0x200000U, 0x3FFFFFU, 0x00200000U, RC_MEMORY_TYPE_SYSTEM_RAM, "System RAM" }, /* RDRAM 2 */
-    { 0x400000U, 0x7FFFFFU, 0x80000000U, RC_MEMORY_TYPE_SYSTEM_RAM, "System RAM" }  /* expansion pak - cannot find any details for real address */
+    { 0x000000U, 0x1FFFFFU, 0x80000000U, RC_MEMORY_TYPE_SYSTEM_RAM, "System RAM" }, /* RDRAM 1 */
+    { 0x200000U, 0x3FFFFFU, 0x80200000U, RC_MEMORY_TYPE_SYSTEM_RAM, "System RAM" }, /* RDRAM 2 */
+    { 0x400000U, 0x7FFFFFU, 0x80400000U, RC_MEMORY_TYPE_SYSTEM_RAM, "System RAM" }  /* expansion pak */
 };
 static const rc_memory_regions_t rc_memory_regions_n64 = { _rc_memory_regions_n64, 3 };
 


### PR DESCRIPTION
See https://discord.com/channels/310192285306454017/645777658319208448/1376071955035455569

And https://n64brew.dev/wiki/Memory_map#Virtual_Memory_Map

The RDRAM is typically accessed from $80000000 (cached) or $A0000000 (uncached), with the 4MB of system RAM being in the first 0x400000 bytes, and the expansion pack in the next 0x400000 bytes.

Currently, neither the mupen64plus-next nor the parallel-n64 core expose a memory map, so we just grab the `RETRO_SYSTEM_RAM` and chunk it up into RDRAM and expansion pak chunks. The mupen64plus-next core is being updated to expose a memory map and they're going to expose the memory at $80000000 (which seems appropriate). As such, we need to update our mapping to look for stuff exposed at $80000000.

**This is a breaking change**, but I feel it is the correct change. Once clients uptake this PR, they'll be able to use the updated core. They can still use the outdated core as we don't care about the address unless a memory map is exposed. The breakage comes in using the updated core on older clients.

In the best case scenario, the select and disconnect bits allow $80000000 to be mapped to $00000000 and achievements not using expansion pak memory will work just fine. However, as we're looking for expansion pak memory at $80000000, which will now be in the memory map (exposing the RDRAM), the client will see the RDRAM instead of the expansion pak memory and it go on its merry way. As it still sees memory, it won't report any achievements dependent on the expansion pak memory as unsupported, but the data the achievements relies on won't be there, so they won't trigger. This will likely manifest itself as weirdly broken Rich Presence as well, so that could be a good indicator that the user has an updated core but out of date client.

In the worse case scenario, the select and disconnect bits won't be specified and the core won't expose any RDRAM at $00000000, but will expose the RDRAM as the expansion pak memory (as described above). In that case, any achievement dependent on the non-expansion pak memory will be marked as Unsupported, and other achievements just won't function. I think this is worse than the first case as it completely breaks all achievement sets, instead of just those that use the expansion pak memory. The plus side to this implementation is that the majority of achievements should report as Unsupported, so the user will know going into the set that there will be issues.