### PR TITLE
Fixed Wii hash in hash_disc.c

### DIFF
--- a/src/rhash/hash_disc.c
+++ b/src/rhash/hash_disc.c
@@ -1219,7 +1219,7 @@ static int rc_hash_wii_disc(md5_state_t* md5, const rc_hash_iterator_t* iterator
       }
     }
     else { /* Decrypted */
-      if (rc_hash_nintendo_disc_partition(md5, iterator, file_handle, part_offset, 2) == 0) {
+      if (rc_hash_nintendo_disc_partition(md5, iterator, file_handle, (uint32_t)part_offset, 2) == 0) {
         return rc_hash_iterator_error(iterator, "Failed to hash Wii partition");
       }
     }

--- a/src/rhash/hash_disc.c
+++ b/src/rhash/hash_disc.c
@@ -1219,16 +1219,13 @@ static int rc_hash_wii_disc(md5_state_t* md5, const rc_hash_iterator_t* iterator
       }
     }
     else { /* Decrypted */
-      success = rc_hash_nintendo_disc_partition(md5, iterator, file_handle, (uint32_t)part_offset, 2);
+      if (rc_hash_nintendo_disc_partition(md5, iterator, file_handle, part_offset, 2) == 0) {
+        return rc_hash_iterator_error(iterator, "Failed to hash Wii partition");
+      }
     }
   }
   free(partition_table);
   free(buffer);
-  rc_file_close(iterator, file_handle);
-
-  if (!success)
-    return rc_hash_iterator_error(iterator, "Failed to hash Wii partition");
-
   return 1;
 }
 


### PR DESCRIPTION
Current behavior causes a crash when loading a Wii disc because rc_hash_wii_disc closes the filereader file and then returns to rc_hash_wii which also attempts to close the file.