### PR TITLE
add rc_client_set_hash_callbacks

### DIFF
--- a/include/rc_client.h
+++ b/include/rc_client.h
@@ -264,6 +264,12 @@ RC_EXPORT rc_client_async_handle_t* RC_CCONV rc_client_begin_identify_and_load_g
     uint32_t console_id, const char* file_path,
     const uint8_t* data, size_t data_size,
     rc_client_callback_t callback, void* callback_userdata);
+
+struct rc_hash_callbacks;
+/**
+ * Provide callback functions for interacting with the file system and processing disc-based files when generating hashes.
+ */
+RC_EXPORT void rc_client_set_hash_callbacks(rc_client_t* client, const struct rc_hash_callbacks* callbacks);
 #endif
 
 /**
@@ -278,9 +284,9 @@ RC_EXPORT rc_client_async_handle_t* RC_CCONV rc_client_begin_load_game(rc_client
 RC_EXPORT int RC_CCONV rc_client_get_load_game_state(const rc_client_t* client);
 enum {
   RC_CLIENT_LOAD_GAME_STATE_NONE,
-  RC_CLIENT_LOAD_GAME_STATE_IDENTIFYING_GAME,
   RC_CLIENT_LOAD_GAME_STATE_AWAIT_LOGIN,
-  RC_CLIENT_LOAD_GAME_STATE_FETCHING_GAME_DATA,
+  RC_CLIENT_LOAD_GAME_STATE_IDENTIFYING_GAME,
+  RC_CLIENT_LOAD_GAME_STATE_FETCHING_GAME_DATA, /* [deprecated] - game data is now returned by identify call */
   RC_CLIENT_LOAD_GAME_STATE_STARTING_SESSION,
   RC_CLIENT_LOAD_GAME_STATE_DONE,
   RC_CLIENT_LOAD_GAME_STATE_ABORTED

--- a/include/rc_hash.h
+++ b/include/rc_hash.h
@@ -9,17 +9,19 @@
 
 RC_BEGIN_C_DECLS
 
+  struct rc_hash_iterator;
+
   /* ===================================================== */
 
-  /* specifies a function to call when an error occurs to display the error message */
-  typedef void (RC_CCONV *rc_hash_message_callback)(const char*);
+  typedef void (RC_CCONV *rc_hash_message_callback_deprecated)(const char*);
 
+  /* specifies a function to call when an error occurs to display the error message */
   /* [deprecated] set callbacks in rc_hash_iterator_t */
-  RC_EXPORT void RC_CCONV rc_hash_init_error_message_callback(rc_hash_message_callback callback);
+  RC_EXPORT void RC_CCONV rc_hash_init_error_message_callback(rc_hash_message_callback_deprecated callback);
 
   /* specifies a function to call for verbose logging */
   /* [deprecated] set callbacks in rc_hash_iterator_t */
-  RC_EXPORT void rc_hash_init_verbose_message_callback(rc_hash_message_callback callback);
+  RC_EXPORT void rc_hash_init_verbose_message_callback(rc_hash_message_callback_deprecated callback);
 
   /* ===================================================== */
 
@@ -54,6 +56,8 @@ RC_BEGIN_C_DECLS
 
   /* ===================================================== */
 
+#ifndef RC_HASH_NO_DISC
+
   #define RC_HASH_CDTRACK_FIRST_DATA ((uint32_t)-1) /* the first data track (skip audio tracks) */
   #define RC_HASH_CDTRACK_LAST ((uint32_t)-2) /* the last data/audio track */
   #define RC_HASH_CDTRACK_LARGEST ((uint32_t)-3) /* the largest data/audio track */
@@ -63,7 +67,7 @@ RC_BEGIN_C_DECLS
    * returns a handle to be passed to the other functions, or NULL if the track could not be opened.
    */
   typedef void* (RC_CCONV *rc_hash_cdreader_open_track_handler)(const char* path, uint32_t track);
-  typedef void* (RC_CCONV* rc_hash_cdreader_open_track_filereader_handler)(const char* path, uint32_t track, const rc_hash_filereader_t* filereader);
+  typedef void* (RC_CCONV* rc_hash_cdreader_open_track_iterator_handler)(const char* path, uint32_t track, const struct rc_hash_iterator* iterator);
 
   /* attempts to read the specified number of bytes from the file starting at the specified absolute sector.
    * returns the number of bytes actually read.
@@ -82,7 +86,7 @@ RC_BEGIN_C_DECLS
     rc_hash_cdreader_read_sector_handler             read_sector;
     rc_hash_cdreader_close_track_handler             close_track;
     rc_hash_cdreader_first_track_sector_handler      first_track_sector;
-    rc_hash_cdreader_open_track_filereader_handler   open_track_filereader;
+    rc_hash_cdreader_open_track_iterator_handler     open_track_iterator;
   } rc_hash_cdreader_t;
 
   RC_EXPORT void RC_CCONV rc_hash_get_default_cdreader(struct rc_hash_cdreader* cdreader);
@@ -90,6 +94,8 @@ RC_BEGIN_C_DECLS
   RC_EXPORT void RC_CCONV rc_hash_init_default_cdreader(void);
   /* [deprecated] set callbacks in rc_hash_iterator_t */
   RC_EXPORT void RC_CCONV rc_hash_init_custom_cdreader(struct rc_hash_cdreader* reader);
+
+#endif /* RC_HASH_NO_DISC */
 
 #ifndef RC_HASH_NO_ENCRYPTED
 
@@ -117,16 +123,20 @@ RC_BEGIN_C_DECLS
   /* [deprecated] set callbacks in rc_hash_iterator_t */
   RC_EXPORT void RC_CCONV rc_hash_init_3ds_get_ncch_normal_keys_func(rc_hash_3ds_get_ncch_normal_keys_func func);
 
-#endif
+#endif /* RC_HASH_NO_ENCRYPTED */
 
 /* ===================================================== */
 
+typedef void (RC_CCONV* rc_hash_message_callback_func)(const char*, const struct rc_hash_iterator* iterator);
+
 typedef struct rc_hash_callbacks {
-  rc_hash_message_callback verbose_message;
-  rc_hash_message_callback error_message;
+  rc_hash_message_callback_func verbose_message;
+  rc_hash_message_callback_func error_message;
 
   rc_hash_filereader_t filereader;
+#ifndef RC_HASH_NO_DISC
   rc_hash_cdreader_t cdreader;
+#endif
 
 #ifndef RC_HASH_NO_ENCRYPTED
   struct rc_hash_encryption_callbacks {

--- a/src/rc_client.c
+++ b/src/rc_client.c
@@ -228,14 +228,6 @@ void rc_client_destroy(rc_client_t* client)
 
 /* ===== Logging ===== */
 
-static rc_client_t* g_hash_client = NULL;
-
-#ifdef RC_CLIENT_SUPPORTS_HASH
-static void rc_client_log_hash_message(const char* message) {
-  rc_client_log_message(g_hash_client, message);
-}
-#endif
-
 void rc_client_log_message(const rc_client_t* client, const char* message)
 {
   if (client->callbacks.log_call)
@@ -1829,8 +1821,12 @@ static void rc_client_start_session_callback(const rc_api_server_response_t* ser
       rc_api_process_start_session_response(load_state->start_session_response, server_response->body);
     }
 
-    if (outstanding_requests == 0)
-      rc_client_queue_activate_game(load_state);
+    if (outstanding_requests == 0) {
+      if (load_state->client->state.allow_background_memory_reads)
+        rc_client_activate_game(load_state, load_state->start_session_response);
+      else
+        rc_client_queue_activate_game(load_state);
+    }
   }
 
   rc_api_destroy_start_session_response(&start_session_response);
@@ -2463,9 +2459,6 @@ static void rc_client_process_resolved_hash(rc_client_load_state_t* load_state)
     load_state->game->public_.hash = load_state->hash->hash;
   }
 
-  /* done with the hashing code, release the global pointer */
-  g_hash_client = NULL;
-
 #ifdef RC_CLIENT_SUPPORTS_EXTERNAL
   if (client->state.external_client) {
     if (client->state.external_client->add_game_hash)
@@ -2795,6 +2788,32 @@ rc_hash_iterator_t* rc_client_get_load_state_hash_iterator(rc_client_t* client)
   return NULL;
 }
 
+static void rc_client_log_hash_message_verbose(const char* message, const rc_hash_iterator_t* iterator)
+{
+  rc_client_load_state_t unused;
+  rc_client_load_state_t* load_state = (rc_client_load_state_t*)(((uint8_t*)iterator) - RC_OFFSETOF(unused, hash_iterator));
+  if (load_state->client->state.log_level >= RC_CLIENT_LOG_LEVEL_INFO)
+    rc_client_log_message(load_state->client, message);
+}
+
+static void rc_client_log_hash_message_error(const char* message, const rc_hash_iterator_t* iterator)
+{
+  rc_client_load_state_t unused;
+  rc_client_load_state_t* load_state = (rc_client_load_state_t*)(((uint8_t*)iterator) - RC_OFFSETOF(unused, hash_iterator));
+  if (load_state->client->state.log_level >= RC_CLIENT_LOG_LEVEL_ERROR)
+    rc_client_log_message(load_state->client, message);
+}
+
+void rc_client_set_hash_callbacks(rc_client_t* client, const struct rc_hash_callbacks* callbacks)
+{
+  memcpy(&client->callbacks.hash, callbacks, sizeof(*callbacks));
+
+  if (!callbacks->verbose_message)
+    client->callbacks.hash.verbose_message = rc_client_log_hash_message_verbose;
+  if (!callbacks->error_message)
+    client->callbacks.hash.error_message = rc_client_log_hash_message_error;
+}
+
 rc_client_async_handle_t* rc_client_begin_identify_and_load_game(rc_client_t* client,
     uint32_t console_id, const char* file_path,
     const uint8_t* data, size_t data_size,
@@ -2835,12 +2854,6 @@ rc_client_async_handle_t* rc_client_begin_identify_and_load_game(rc_client_t* cl
     return NULL;
   }
 
-  if (client->state.log_level >= RC_CLIENT_LOG_LEVEL_INFO) {
-    g_hash_client = client;
-    rc_hash_init_error_message_callback(rc_client_log_hash_message);
-    rc_hash_init_verbose_message_callback(rc_client_log_hash_message);
-  }
-
   if (!file_path)
     file_path = "?";
 
@@ -2853,9 +2866,17 @@ rc_client_async_handle_t* rc_client_begin_identify_and_load_game(rc_client_t* cl
   load_state->callback = callback;
   load_state->callback_userdata = callback_userdata;
 
-  if (console_id == RC_CONSOLE_UNKNOWN) {
-    rc_hash_initialize_iterator(&load_state->hash_iterator, file_path, data, data_size);
+  /* initialize the iterator */
+  rc_hash_initialize_iterator(&load_state->hash_iterator, file_path, data, data_size);
+  rc_hash_merge_callbacks(&load_state->hash_iterator, &client->callbacks.hash);
 
+  if (!load_state->hash_iterator.callbacks.verbose_message)
+    load_state->hash_iterator.callbacks.verbose_message = rc_client_log_hash_message_verbose;
+  if (!load_state->hash_iterator.callbacks.error_message)
+    load_state->hash_iterator.callbacks.error_message = rc_client_log_hash_message_error;
+
+  /* calculate the hash */
+  if (console_id == RC_CONSOLE_UNKNOWN) {
     if (!rc_hash_iterate(hash, &load_state->hash_iterator)) {
       rc_client_load_error(load_state, RC_INVALID_STATE, "hash generation failed");
       return NULL;
@@ -2867,17 +2888,12 @@ rc_client_async_handle_t* rc_client_begin_identify_and_load_game(rc_client_t* cl
     /* ASSERT: hash_iterator->index and hash_iterator->consoles[0] will be 0 from calloc */
     load_state->hash_console_id = console_id;
 
-    if (data != NULL) {
-      if (!rc_hash_generate_from_buffer(hash, console_id, data, data_size)) {
-        rc_client_load_error(load_state, RC_INVALID_STATE, "hash generation failed");
-        return NULL;
-      }
-    }
-    else {
-      if (!rc_hash_generate_from_file(hash, console_id, file_path)) {
-        rc_client_load_error(load_state, RC_INVALID_STATE, "hash generation failed");
-        return NULL;
-      }
+    /* prevent initializing the iterator so it won't try other consoles in rc_client_process_resolved_hash */
+    load_state->hash_iterator.index = 0;
+
+    if (!rc_hash_generate(hash, console_id, &load_state->hash_iterator)) {
+      rc_client_load_error(load_state, RC_INVALID_STATE, "hash generation failed");
+      return NULL;
     }
   }
 
@@ -3245,18 +3261,10 @@ rc_client_async_handle_t* rc_client_begin_identify_and_change_media(rc_client_t*
     char hash[33];
     int result;
 
-    if (client->state.log_level >= RC_CLIENT_LOG_LEVEL_INFO) {
-      g_hash_client = client;
-      rc_hash_init_error_message_callback(rc_client_log_hash_message);
-      rc_hash_init_verbose_message_callback(rc_client_log_hash_message);
-    }
-
     if (data != NULL)
       result = rc_hash_generate_from_buffer(hash, game->public_.console_id, data, data_size);
     else
       result = rc_hash_generate_from_file(hash, game->public_.console_id, file_path);
-
-    g_hash_client = NULL;
 
     if (!result) {
       /* when changing discs, if the disc is not supported by the system, allow it. this is

--- a/src/rc_client_internal.h
+++ b/src/rc_client_internal.h
@@ -9,6 +9,9 @@
 #ifdef RC_CLIENT_SUPPORTS_EXTERNAL
  #include "rc_client_external.h"
 #endif
+#ifdef RC_CLIENT_SUPPORTS_HASH
+ #include "rhash/rc_hash_internal.h"
+#endif
 
 #include "rc_compat.h"
 #include "rc_runtime.h"
@@ -40,6 +43,10 @@ typedef struct rc_client_callbacks_t {
   rc_client_can_submit_achievement_unlock_t can_submit_achievement_unlock;
   rc_client_can_submit_leaderboard_entry_t can_submit_leaderboard_entry;
   rc_client_rich_presence_override_t rich_presence_override;
+
+#ifdef RC_CLIENT_SUPPORTS_HASH
+  rc_hash_callbacks_t hash;
+#endif
 
   void* client_data;
 } rc_client_callbacks_t;

--- a/src/rc_client_types.natvis
+++ b/src/rc_client_types.natvis
@@ -289,7 +289,6 @@
         <DisplayString Condition="value==RC_CLIENT_LOAD_GAME_STATE_NONE">{RC_CLIENT_LOAD_GAME_STATE_NONE}</DisplayString>
         <DisplayString Condition="value==RC_CLIENT_LOAD_GAME_STATE_IDENTIFYING_GAME">{RC_CLIENT_LOAD_GAME_STATE_IDENTIFYING_GAME}</DisplayString>
         <DisplayString Condition="value==RC_CLIENT_LOAD_GAME_STATE_AWAIT_LOGIN">{RC_CLIENT_LOAD_GAME_STATE_AWAIT_LOGIN}</DisplayString>
-        <DisplayString Condition="value==RC_CLIENT_LOAD_GAME_STATE_FETCHING_GAME_DATA">{RC_CLIENT_LOAD_GAME_STATE_FETCHING_GAME_DATA}</DisplayString>
         <DisplayString Condition="value==RC_CLIENT_LOAD_GAME_STATE_STARTING_SESSION">{RC_CLIENT_LOAD_GAME_STATE_STARTING_SESSION}</DisplayString>
         <DisplayString Condition="value==RC_CLIENT_LOAD_GAME_STATE_DONE">{RC_CLIENT_LOAD_GAME_STATE_DONE}</DisplayString>
         <DisplayString Condition="value==RC_CLIENT_LOAD_GAME_STATE_ABORTED">{RC_CLIENT_LOAD_GAME_STATE_ABORTED}</DisplayString>

--- a/src/rc_libretro.c
+++ b/src/rc_libretro.c
@@ -751,7 +751,10 @@ void rc_libretro_hash_set_init(struct rc_libretro_hash_set_t* hash_set,
 
   file_handle = file_reader->open(m3u_path);
   if (!file_handle) {
-    rc_hash_error(NULL, "Could not open playlist");
+    rc_hash_iterator_t iterator;
+    memset(&iterator, 0, sizeof(iterator));
+    memcpy(&iterator.callbacks, &hash_set->callbacks, sizeof(hash_set->callbacks));
+    rc_hash_iterator_error(&iterator, "Could not open playlist");
     return;
   }
 

--- a/src/rhash/hash_disc.c
+++ b/src/rhash/hash_disc.c
@@ -32,8 +32,8 @@ void rc_hash_init_custom_cdreader(struct rc_hash_cdreader* reader)
 
 static void* rc_cd_open_track(const rc_hash_iterator_t* iterator, uint32_t track)
 {
-  if (iterator->callbacks.cdreader.open_track_filereader)
-    return iterator->callbacks.cdreader.open_track_filereader(iterator->path, track, &iterator->callbacks.filereader);
+  if (iterator->callbacks.cdreader.open_track_iterator)
+    return iterator->callbacks.cdreader.open_track_iterator(iterator->path, track, iterator);
 
   if (iterator->callbacks.cdreader.open_track)
     return iterator->callbacks.cdreader.open_track(iterator->path, track);
@@ -365,14 +365,12 @@ int rc_hash_dreamcast(char hash[33], const rc_hash_iterator_t* iterator)
   md5_append(&md5, (md5_byte_t*)buffer, 256);
 
   if (iterator->callbacks.verbose_message) {
-    char message[256];
     uint8_t* ptr = &buffer[0xFF];
     while (ptr > &buffer[0x80] && ptr[-1] == ' ')
       --ptr;
     *ptr = '\0';
 
-    snprintf(message, sizeof(message), "Found Dreamcast CD: %.128s (%.16s)", (const char*)&buffer[0x80], (const char*)&buffer[0x40]);
-    iterator->callbacks.verbose_message(message);
+    rc_hash_iterator_verbose_formatted(iterator, "Found Dreamcast CD: %.128s (%.16s)", (const char*)&buffer[0x80], (const char*)&buffer[0x40]);
   }
 
   /* the boot filename is 96 bytes into the meta information (https://mc.pp.se/dc/ip0000.bin.html) */

--- a/src/rhash/rc_hash_internal.h
+++ b/src/rhash/rc_hash_internal.h
@@ -8,12 +8,6 @@ RC_BEGIN_C_DECLS
 
 /* hash.c */
 
-void rc_hash_verbose(const rc_hash_callbacks_t* callbacks, const char* message);
-void rc_hash_verbose_formatted(const rc_hash_callbacks_t* callbacks, const char* format, ...);
-
-int rc_hash_error(const rc_hash_callbacks_t*, const char* message);
-int rc_hash_error_formatted(const rc_hash_callbacks_t* callbacks, const char* format, ...);
-
 void* rc_file_open(const rc_hash_iterator_t* iterator, const char* path);
 void rc_file_seek(const rc_hash_iterator_t* iterator, void* file_handle, int64_t offset, int origin);
 int64_t rc_file_tell(const rc_hash_iterator_t* iterator, void* file_handle);
@@ -31,6 +25,7 @@ int rc_hash_iterator_error_formatted(const rc_hash_iterator_t* iterator, const c
 /* arbitrary limit to prevent allocating and hashing large files */
 #define MAX_BUFFER_SIZE 64 * 1024 * 1024
 
+void rc_hash_merge_callbacks(rc_hash_iterator_t* iterator, const rc_hash_callbacks_t* callbacks);
 int rc_hash_finalize(const rc_hash_iterator_t* iterator, md5_state_t* md5, char hash[33]);
 
 int rc_hash_buffer(char hash[33], const uint8_t* buffer, size_t buffer_size, const rc_hash_iterator_t* iterator);

--- a/test/rhash/mock_filereader.c
+++ b/test/rhash/mock_filereader.c
@@ -94,7 +94,7 @@ static void reset_mock_files()
   mock_cd_tracks = 0;
 }
 
-void get_mock_filereader(rc_hash_filereader_t* reader)
+void get_mock_filereader(struct rc_hash_filereader* reader)
 {
   reader->open = _mock_file_open;
   reader->seek = _mock_file_seek;

--- a/test/rhash/test_hash_disc.c
+++ b/test/rhash/test_hash_disc.c
@@ -58,8 +58,6 @@ static void test_hash_3do_bin()
 
   mock_file_size(0, 45678901); /* must be > 32MB for iterator to consider CD formats for bin */
   rc_hash_initialize_iterator(&iterator, "game.bin", NULL, 0);
-  mock_file_size(0, image_size); /* change it back before doing the hashing */
-
   result_iterator = rc_hash_iterate(hash_iterator, &iterator);
   rc_hash_destroy_iterator(&iterator);
 


### PR DESCRIPTION
Another step towards deprecating globals.

Allows attaching a `filereader` and/or a `cdreader` to an `rc_client_t` for use when identifying games.