### PR TITLE
attempt to squash VS compiler warnings

### DIFF
--- a/src/rc_client.c
+++ b/src/rc_client.c
@@ -3806,9 +3806,9 @@ rc_client_achievement_list_t* rc_client_create_achievement_list(rc_client_t* cli
         bucket_ptr->bucket_type = bucket_type;
 
         if (bucket_type == RC_CLIENT_ACHIEVEMENT_BUCKET_RECENTLY_UNLOCKED)
-          qsort(bucket_ptr->achievements, bucket_ptr->num_achievements, sizeof(rc_client_achievement_t*), rc_client_compare_achievement_unlock_times);
+          qsort((void*)bucket_ptr->achievements, bucket_ptr->num_achievements, sizeof(rc_client_achievement_t*), rc_client_compare_achievement_unlock_times);
         else if (bucket_type == RC_CLIENT_ACHIEVEMENT_BUCKET_ALMOST_THERE)
-          qsort(bucket_ptr->achievements, bucket_ptr->num_achievements, sizeof(rc_client_achievement_t*), rc_client_compare_achievement_progress);
+          qsort((void*)bucket_ptr->achievements, bucket_ptr->num_achievements, sizeof(rc_client_achievement_t*), rc_client_compare_achievement_progress);
 
         ++bucket_ptr;
       }

--- a/src/rcheevos/runtime_progress.c
+++ b/src/rcheevos/runtime_progress.c
@@ -560,8 +560,17 @@ static int rc_runtime_progress_read_variables(rc_runtime_progress_t* progress)
     }
   }
 
+  /* VS raises a C6385 warning here because it thinks count can exceed the size of the local_pending_variables array.
+   * When count is larger, pending_variables points to allocated memory, so the warning is wrong. */
+#if defined (_MSC_VER)
+ #pragma warning(push)
+ #pragma warning(disable:6385)
+#endif
   while (count > 0)
     rc_reset_value(pending_variables[--count].variable);
+#if defined (_MSC_VER)
+ #pragma warning(pop)
+#endif
 
   if (pending_variables != local_pending_variables)
     free(pending_variables);


### PR DESCRIPTION
Fixes "different const qualifiers" when using qsort and suppresses "reading invalid data from" warning