### PR TITLE
don't generate warning about transformed index offset

### DIFF
--- a/src/rcheevos/rc_validate.c
+++ b/src/rcheevos/rc_validate.c
@@ -351,11 +351,11 @@ static int rc_validate_condset_internal(const rc_condset_t* condset, char result
           snprintf(result, result_size, "Condition %d: Using pointer from previous frame", index);
           return 0;
         }
-        if (rc_operand_is_float(&cond->operand1) || rc_operand_is_float(&cond->operand2)) {
+        if (rc_operand_is_float(operand1) || rc_operand_is_float(&cond->operand2)) {
           snprintf(result, result_size, "Condition %d: Using non-integer value in AddAddress calcuation", index);
           return 0;
         }
-        if (rc_operand_type_is_transform(cond->operand1.type)) {
+        if (rc_operand_type_is_transform(operand1->type) && cond->oper != RC_OPERATOR_MULT) {
           snprintf(result, result_size, "Condition %d: Using transformed value in AddAddress calcuation", index);
           return 0;
         }

--- a/test/rcheevos/test_rc_validate.c
+++ b/test/rcheevos/test_rc_validate.c
@@ -286,9 +286,9 @@ void test_nonsized_pointers() {
   TEST_PARAMS2(test_validate_trigger, "I:0xH1234*f1.5_0xH0000=1", "Condition 1: Using non-integer value in AddAddress calcuation");
   TEST_PARAMS2(test_validate_trigger, "I:b0xH1234_0xH0000=1", "Condition 1: Using transformed value in AddAddress calcuation");
   TEST_PARAMS2(test_validate_trigger, "I:~0xH1234_0xH0000=1", "Condition 1: Using transformed value in AddAddress calcuation");
-  TEST_PARAMS2(test_validate_trigger, "I:~0xH1234*1_0xH0000=1", ""); // don't report scaled values - assume indexed array
-  TEST_PARAMS2(test_validate_trigger, "I:~0xM1234*4096_0xH0000=1", ""); // don't report scaled values - assume indexed array
-  TEST_PARAMS2(test_validate_trigger, "I:b0x 1234*8_0xH0000=1", ""); // don't report scaled values - assume indexed array
+  TEST_PARAMS2(test_validate_trigger, "I:~0xH1234*1_0xH0000=1", ""); /* don't report scaled values - assume indexed array */
+  TEST_PARAMS2(test_validate_trigger, "I:~0xM1234*4096_0xH0000=1", ""); /* don't report scaled values - assume indexed array */
+  TEST_PARAMS2(test_validate_trigger, "I:b0x 1234*8_0xH0000=1", ""); /* don't report scaled values - assume indexed array */
 }
 
 void test_float_comparisons() {

--- a/test/rcheevos/test_rc_validate.c
+++ b/test/rcheevos/test_rc_validate.c
@@ -286,6 +286,9 @@ void test_nonsized_pointers() {
   TEST_PARAMS2(test_validate_trigger, "I:0xH1234*f1.5_0xH0000=1", "Condition 1: Using non-integer value in AddAddress calcuation");
   TEST_PARAMS2(test_validate_trigger, "I:b0xH1234_0xH0000=1", "Condition 1: Using transformed value in AddAddress calcuation");
   TEST_PARAMS2(test_validate_trigger, "I:~0xH1234_0xH0000=1", "Condition 1: Using transformed value in AddAddress calcuation");
+  TEST_PARAMS2(test_validate_trigger, "I:~0xH1234*1_0xH0000=1", ""); // don't report scaled values - assume indexed array
+  TEST_PARAMS2(test_validate_trigger, "I:~0xM1234*4096_0xH0000=1", ""); // don't report scaled values - assume indexed array
+  TEST_PARAMS2(test_validate_trigger, "I:b0x 1234*8_0xH0000=1", ""); // don't report scaled values - assume indexed array
 }
 
 void test_float_comparisons() {


### PR DESCRIPTION
Prevents warning message when using Invert or BCD to calculate an array offset for use with AddAddress