### PR TITLE
fix validation of SubSource chain

### DIFF
--- a/src/rcheevos/rc_validate.c
+++ b/src/rcheevos/rc_validate.c
@@ -174,8 +174,8 @@ static uint32_t rc_scale_value(uint32_t value, uint8_t oper, const rc_operand_t*
 
     case RC_OPERATOR_SUB:
     {
-      const uint32_t op_max = (operand->type == RC_OPERAND_CONST) ? operand->value.num : rc_max_value(operand);
-      if (value > op_max)
+      const uint32_t op_max = (operand->type == RC_OPERAND_CONST) ? operand->value.num : 0;
+      if (value >= op_max)
         return value - op_max;
 
       return 0xFFFFFFFF;

--- a/test/rcheevos/test_rc_validate.c
+++ b/test/rcheevos/test_rc_validate.c
@@ -207,6 +207,9 @@ static void test_range_comparisons() {
   TEST_PARAMS2(test_validate_trigger, "B:0xH1234_0xH1235<510", "");
   TEST_PARAMS2(test_validate_trigger, "B:0xH1234_0xH1235<=510", "");
 
+  /* A - da + 255 > 255 */
+  TEST_PARAMS2(test_validate_trigger, "A:255_B:d0xH1234_0xH1234>255", "");
+
   TEST_PARAMS2(test_validate_trigger, "I:0xG1234&536870911_R:0xG0000=4294967294", "");
 }
 

--- a/test/rcheevos/test_richpresence.c
+++ b/test/rcheevos/test_richpresence.c
@@ -1121,6 +1121,13 @@ static void test_macro_non_numeric_parameter() {
   ASSERT_NUM_EQUALS(lines, 5);
 }
 
+static void test_macro_mathematic_chain() {
+  int lines;
+  int result = rc_richpresence_size_lines("Format:Points\nFormatType=VALUE\n\nDisplay:\n@Points(0xH1234 + 5) Points", &lines);
+  ASSERT_NUM_EQUALS(result, RC_INVALID_OPERATOR);
+  ASSERT_NUM_EQUALS(lines, 5);
+}
+
 static void test_builtin_macro(const char* macro, const char* expected) {
   uint8_t ram[] = { 0x39, 0x30 };
   memory_t memory;
@@ -1436,6 +1443,7 @@ void test_richpresence(void) {
   TEST(test_macro_without_parameter);
   TEST(test_macro_without_parameter_conditional_display);
   TEST(test_macro_non_numeric_parameter);
+  TEST(test_macro_mathematic_chain);
 
   /* builtin macros */
   TEST_PARAMS2(test_builtin_macro, "Number", "12,345");


### PR DESCRIPTION
Prevents "Comparison is never true" warning for:

```
          Value         255
SubSource Delta Byte 0x1234
          Mem   Byte 0x1234 > 255
```
While this could be better achieved with a single "Byte > Delta Byte", it represents a long chain of additions and their deltas:

<img width="679" height="354" alt="image" src="https://github.com/user-attachments/assets/dfd097ec-32eb-4cba-80ef-9c1e3e874887" />
