### PR TITLE
fix invalid pointer reference when iterator gets cloned

### DIFF
--- a/include/rc_hash.h
+++ b/include/rc_hash.h
@@ -154,6 +154,7 @@ typedef struct rc_hash_iterator {
   uint8_t consoles[12];
   int index;
   const char* path;
+  void* userdata;
 
   rc_hash_callbacks_t callbacks;
 } rc_hash_iterator_t;

--- a/src/rc_client.c
+++ b/src/rc_client.c
@@ -2796,16 +2796,14 @@ rc_hash_iterator_t* rc_client_get_load_state_hash_iterator(rc_client_t* client)
 
 static void rc_client_log_hash_message_verbose(const char* message, const rc_hash_iterator_t* iterator)
 {
-  rc_client_load_state_t unused;
-  rc_client_load_state_t* load_state = (rc_client_load_state_t*)(((uint8_t*)iterator) - RC_OFFSETOF(unused, hash_iterator));
+  const rc_client_load_state_t* load_state = (const rc_client_load_state_t*)iterator->userdata;
   if (load_state->client->state.log_level >= RC_CLIENT_LOG_LEVEL_INFO)
     rc_client_log_message(load_state->client, message);
 }
 
 static void rc_client_log_hash_message_error(const char* message, const rc_hash_iterator_t* iterator)
 {
-  rc_client_load_state_t unused;
-  rc_client_load_state_t* load_state = (rc_client_load_state_t*)(((uint8_t*)iterator) - RC_OFFSETOF(unused, hash_iterator));
+  const rc_client_load_state_t* load_state = (const rc_client_load_state_t*)iterator->userdata;
   if (load_state->client->state.log_level >= RC_CLIENT_LOG_LEVEL_ERROR)
     rc_client_log_message(load_state->client, message);
 }
@@ -2875,6 +2873,7 @@ rc_client_async_handle_t* rc_client_begin_identify_and_load_game(rc_client_t* cl
   /* initialize the iterator */
   rc_hash_initialize_iterator(&load_state->hash_iterator, file_path, data, data_size);
   rc_hash_merge_callbacks(&load_state->hash_iterator, &client->callbacks.hash);
+  load_state->hash_iterator.userdata = load_state;
 
   if (!load_state->hash_iterator.callbacks.verbose_message)
     load_state->hash_iterator.callbacks.verbose_message = rc_client_log_hash_message_verbose;

--- a/src/rhash/hash.c
+++ b/src/rhash/hash.c
@@ -480,6 +480,7 @@ static int rc_hash_file_from_buffer(char hash[33], uint32_t console_id, const rc
   rc_hash_iterator_t buffered_file_iterator;
   memset(&buffered_file_iterator, 0, sizeof(buffered_file_iterator));
   memcpy(&buffered_file_iterator.callbacks, &iterator->callbacks, sizeof(iterator->callbacks));
+  buffered_file_iterator.userdata = iterator->userdata;
 
   buffered_file_iterator.callbacks.filereader.open = rc_file_open_buffered_file;
   buffered_file_iterator.callbacks.filereader.close = rc_file_close_buffered_file;
@@ -650,6 +651,7 @@ int rc_hash_buffered_file(char hash[33], uint32_t console_id, const rc_hash_iter
     rc_hash_iterator_t buffer_iterator;
     memset(&buffer_iterator, 0, sizeof(buffer_iterator));
     memcpy(&buffer_iterator.callbacks, &iterator->callbacks, sizeof(iterator->callbacks));
+    buffer_iterator.userdata = iterator->userdata;
     buffer_iterator.path = iterator->path;
     buffer_iterator.buffer = buffer;
     buffer_iterator.buffer_size = (size_t)size;
@@ -773,6 +775,7 @@ static int rc_hash_generate_from_playlist(char hash[33], uint32_t console_id, co
 
   memset(&first_file_iterator, 0, sizeof(first_file_iterator));
   memcpy(&first_file_iterator.callbacks, &iterator->callbacks, sizeof(iterator->callbacks));
+  first_file_iterator.userdata = iterator->userdata;
   first_file_iterator.path = disc_path; /* rc_hash_destory_iterator will free */
 
   result = rc_hash_from_file(hash, console_id, &first_file_iterator);


### PR DESCRIPTION
The attempt to locate the `rc_client_load_state_t` as an offset of the iterator doesn't work when the iterator is cloned. Solution: add a userdata field to the iterator to pass the `rc_client_load_state_t` along.

https://discord.com/channels/184109094070779904/434713532341288961/1399875820171956294