### PR TITLE
fix measured_if evaluation in rich presence macro

### DIFF
--- a/src/rcheevos/richpresence.c
+++ b/src/rcheevos/richpresence.c
@@ -48,8 +48,9 @@ static void rc_alloc_helper_variable_memref_value(rc_richpresence_display_part_t
 
   condset = value->conditions;
   if (condset && !condset->next) {
-    /* single value - if it's only "measured" and "indirect" conditions, we can simplify to a memref */
-    if (condset->num_measured_conditions &&
+    /* single value - if it's a single Measured clause (including any AddSource/AddAddress helpers), we can
+     * simplify to a memref. If there are supporting clauses like MeasuredIf or ResetIf, we can't */
+    if (condset->num_measured_conditions == 1 &&
         !condset->num_pause_conditions && !condset->num_reset_conditions &&
         !condset->num_other_conditions && !condset->num_hittarget_conditions) {
       rc_condition_t* condition = condset->conditions;

--- a/test/rcheevos/test_richpresence.c
+++ b/test/rcheevos/test_richpresence.c
@@ -540,6 +540,28 @@ static void test_macro_value_invalid() {
   ASSERT_NUM_EQUALS(rc_richpresence_size("Format:Points\nFormatType=VALUE\n\nDisplay:\n@Points(0x0x0001) Points"), RC_INVALID_MEMORY_OPERAND);
 }
 
+static void test_macro_value_measured_if() {
+  uint8_t ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  memory_t memory;
+  rc_richpresence_t* richpresence;
+  char buffer[1024];
+
+  memory.ram = ram;
+  memory.size = sizeof(ram);
+
+  assert_parse_richpresence(&richpresence, buffer, "Format:Points\nFormatType=VALUE\n\nDisplay:\n@Points(Q:0xH000=0_M:0x 0001) Points");
+  assert_richpresence_output(richpresence, &memory, "13,330 Points");
+
+  ram[0] = 1;
+  assert_richpresence_output(richpresence, &memory, "0 Points");
+
+  ram[1] = 20;
+  assert_richpresence_output(richpresence, &memory, "0 Points");
+
+  ram[0] = 0;
+  assert_richpresence_output(richpresence, &memory, "13,332 Points");
+}
+
 static void test_macro_hundreds() {
   uint8_t ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
   memory_t memory;
@@ -1391,6 +1413,7 @@ void test_richpresence(void) {
   TEST(test_macro_value_divide_by_self);
   TEST(test_macro_value_remember_recall);
   TEST(test_macro_value_invalid);
+  TEST(test_macro_value_measured_if);
 
   /* hundreds macro */
   TEST(test_macro_hundreds);


### PR DESCRIPTION
https://discord.com/channels/310192285306454017/1149693430306447380/1412117814214393866

If a macro contained only a Measured conditions (no resets/pauses/hitcounts), the code was attempting to simplify from a condition set to a memref. However, MeasuredIf also classifies as a Measured condition, so the conversion to a memref was discarding the MeasuredIf.

Solution: Don't collapse to a memref if more than one condition classifies as a Measured condition.