### PR TITLE
prevent memory corruption when last condition is combining

### DIFF
--- a/src/rcheevos/condset.c
+++ b/src/rcheevos/condset.c
@@ -343,8 +343,12 @@ rc_condset_t* rc_parse_condset(const char** memaddr, rc_parse_state_t* parse) {
     if (parse->buffer) {
       classification = rc_classify_condition(&condition);
       if (classification == RC_CONDITION_CLASSIFICATION_COMBINING) {
-        if (combining_classification == RC_CONDITION_CLASSIFICATION_COMBINING)
-          combining_classification = rc_find_next_classification(&(*memaddr)[1]); /* skip over '_' */
+        if (combining_classification == RC_CONDITION_CLASSIFICATION_COMBINING) {
+          if (**memaddr == '_')
+            combining_classification = rc_find_next_classification(&(*memaddr)[1]); /* skip over '_' */
+          else
+            combining_classification = RC_CONDITION_CLASSIFICATION_OTHER;
+        }
 
         classification = combining_classification;
       }


### PR DESCRIPTION
https://discord.com/channels/310192285306454017/1149693430306447380/1412383875677556797

When attempting to classify a combining condition, the next condition is examined. This didn't care about the next condition being in an alt group, so the trailing condition of the core group would get classified based on the first condition of the first alt group, overwriting a valid condition in the logic and breaking the linked list.