### PR TITLE
Leaderboard list: Fix uninitialized read

### DIFF
--- a/src/rc_client.c
+++ b/src/rc_client.c
@@ -4371,7 +4371,7 @@ rc_client_leaderboard_list_t* rc_client_create_leaderboard_list(rc_client_t* cli
   };
 
   if (!client)
-    return (rc_client_leaderboard_list_t*)calloc(1, sizeof(rc_client_leaderboard_list_t));
+    return (rc_client_leaderboard_list_t*)calloc(1, list_size);
 
 #ifdef RC_CLIENT_SUPPORTS_EXTERNAL
   if (client->state.external_client && client->state.external_client->create_leaderboard_list)
@@ -4379,7 +4379,7 @@ rc_client_leaderboard_list_t* rc_client_create_leaderboard_list(rc_client_t* cli
 #endif
 
   if (!client->game)
-    return (rc_client_leaderboard_list_t*)calloc(1, sizeof(rc_client_leaderboard_list_t));
+    return (rc_client_leaderboard_list_t*)calloc(1, list_size);
 
   memset(&bucket_counts, 0, sizeof(bucket_counts));
 


### PR DESCRIPTION
Allocate enough memory for a `rc_client_leaderboard_list_info_t` (using `list_size`) instead of just a `rc_client_leaderboard_list_t` when `client` or `client->game` are null in `rc_client_create_leaderboard_list`.

This fixes an uninitialized read in `rc_client_destroy_leaderboard_list` when passed such a list because the memory for `destroy_func` wasn't allocated.

If the uninitialized memory happened to not be zero, `rc_client_destroy_leaderboard_list` would attempt to call `destroy_func` with a nonsense address. In particular this happened when Visual Studio's debugger inserted `0xFD` guard bytes after the allocated `rc_client_leaderboard_list_t`, which were then interpreted as the first four bytes of `destroy_func`.