### PR TITLE
Fix function name in comment

### DIFF
--- a/include/rc_client.h
+++ b/include/rc_client.h
@@ -582,7 +582,7 @@ enum {
 RC_EXPORT rc_client_leaderboard_list_t* RC_CCONV rc_client_create_leaderboard_list(rc_client_t* client, int grouping);
 
 /**
- * Destroys a list allocated by rc_client_get_leaderboard_list.
+ * Destroys a list allocated by rc_client_create_leaderboard_list.
  */
 RC_EXPORT void RC_CCONV rc_client_destroy_leaderboard_list(rc_client_leaderboard_list_t* list);
 


### PR DESCRIPTION
`rc_client_get_leaderboard_list` is a typo of `rc_client_create_leaderboard_list`.