### PR TITLE
improve range validation logic

### DIFF
--- a/test/rcheevos/test_rc_validate.c
+++ b/test/rcheevos/test_rc_validate.c
@@ -211,6 +211,9 @@ static void test_range_comparisons() {
   TEST_PARAMS2(test_validate_trigger, "A:255_B:d0xH1234_0xH1234>255", "");
 
   TEST_PARAMS2(test_validate_trigger, "I:0xG1234&536870911_R:0xG0000=4294967294_0xH2222=1.1.", "");
+
+  TEST_PARAMS2(test_validate_trigger, "B:0xH1241/0xH1241_B:0xH124c/0xH124c_M:2=2", "");
+  TEST_PARAMS2(test_validate_trigger, "B:0xH1241/0xH1241_B:0xH124c/0xH124c_M:2>2", "Condition 3: Comparison is never true");
 }
 
 void test_size_comparisons() {


### PR DESCRIPTION
https://discord.com/channels/310192285306454017/962817919698501702/1423180958827282454

Instead of just trying to figure out the maximum value a chain of conditions can have, also track the minimum value so underflow can be accounted for.

Also add special logic for dividing something by itself.