### PR TITLE
require memory map for systems with padded regions

### DIFF
--- a/src/rc_libretro.c
+++ b/src/rc_libretro.c
@@ -650,6 +650,21 @@ static void rc_libretro_memory_init_from_unmapped_memory(rc_libretro_memory_regi
   rc_libretro_core_memory_info_t info;
   size_t offset;
 
+  if (console_regions->region[console_regions->num_regions - 1].end_address > 0x01000000) {
+    /* assume anything exposing more than 16MB of regions with at least one UNUSED region
+     * is padding so things align with real addresses and cannot support unmapped memory */
+    for (i = 0; i < console_regions->num_regions; ++i) {
+      const rc_memory_region_t* console_region = &console_regions->region[i];
+      if (console_region->type == RC_MEMORY_TYPE_UNUSED) {
+        const size_t console_region_size = console_region->end_address - console_region->start_address + 1;
+        if (console_region_size >= 0x10000) {
+          rc_libretro_memory_register_region(regions, RC_MEMORY_TYPE_READONLY, NULL, console_regions->region[console_regions->num_regions - 1].end_address + 1, "null filler");
+          return;
+        }
+      }
+    }
+  }
+
   for (i = 0; i < console_regions->num_regions; ++i) {
     const rc_memory_region_t* console_region = &console_regions->region[i];
     const size_t console_region_size = console_region->end_address - console_region->start_address + 1;

--- a/test/test_rc_libretro.c
+++ b/test/test_rc_libretro.c
@@ -245,6 +245,23 @@ static void test_memory_init_from_unmapped_memory_no_ram() {
   ASSERT_PTR_NULL(rc_libretro_memory_find(&regions, 0x20002));
 }
 
+static void test_memory_init_from_unmapped_memory_wii() {
+  rc_libretro_memory_regions_t regions;
+  retro_memory_data[RETRO_MEMORY_SYSTEM_RAM] = NULL;
+  retro_memory_size[RETRO_MEMORY_SYSTEM_RAM] = 0;
+  retro_memory_data[RETRO_MEMORY_SAVE_RAM] = NULL;
+  retro_memory_size[RETRO_MEMORY_SAVE_RAM] = 0;
+
+  /* init returns true */
+  ASSERT_FALSE(rc_libretro_memory_init(&regions, NULL, libretro_get_core_memory_info, RC_CONSOLE_WII));
+
+  /* but one null-filled region is still generated */
+  ASSERT_NUM_EQUALS(regions.count, 1);
+  ASSERT_NUM_EQUALS(regions.total_size, 0x14000000);
+  ASSERT_PTR_NULL(rc_libretro_memory_find(&regions, 0x00000002));
+  ASSERT_PTR_NULL(rc_libretro_memory_find(&regions, 0x14000002));
+}
+
 static void test_memory_init_from_memory_map() {
   rc_libretro_memory_regions_t regions;
   uint8_t buffer1[8], buffer2[8];
@@ -882,6 +899,7 @@ void test_rc_libretro(void) {
   TEST(test_memory_init_from_unmapped_memory_no_save_ram);
   TEST(test_memory_init_from_unmapped_memory_merge_neighbors);
   TEST(test_memory_init_from_unmapped_memory_no_ram);
+  TEST(test_memory_init_from_unmapped_memory_wii);
 
   TEST(test_memory_init_from_memory_map);
   TEST(test_memory_init_from_memory_map_null_filler);


### PR DESCRIPTION
Prevents trying to shoehorn `RETRO_MEMORY_SYSTEM_RAM` into regions defined in such a way as to expose the actual system memory addresses.

The logic currently identifies any system exposing more than 16MB of RAM with an UNUSED region larger than 64KB. Currently, only the Wii and DOS memory maps fall under this scope, but we're likely to lean in this direction for future systems.

Cores that wish to support achievements for these systems must implement `RETRO_ENVIRONMENT_SET_MEMORY_MAPS`.