### PR TITLE
don't zero-out measured value if measured alt is paused, but not entire achievement

### DIFF
--- a/src/rcheevos/trigger.c
+++ b/src/rcheevos/trigger.c
@@ -235,8 +235,14 @@ int rc_evaluate_trigger(rc_trigger_t* self, rc_peek_t peek, void* ud, void* unus
     is_paused |= sub_paused;
   }
 
-  /* if paused, the measured value may not be captured, keep the old value */
-  if (!is_paused) {
+  if (is_paused) {
+    /* if the trigger is fully paused, ignore any updates to the measured value */
+  }
+  else if (measured_value.type == RC_VALUE_TYPE_NONE) {
+    /* if a measured value was not captured, keep the old value (it's possible to pause
+     * an alt that is generating the measured value without fully pausing the trigger) */
+  }
+  else {
     rc_typed_value_convert(&measured_value, RC_VALUE_TYPE_UNSIGNED);
     self->measured_value = measured_value.value.u32;
   }

--- a/test/rcheevos/test_trigger.c
+++ b/test/rcheevos/test_trigger.c
@@ -948,6 +948,43 @@ static void test_measured_while_paused_reset_non_hitcount() {
   ASSERT_NUM_EQUALS(trigger->measured_value, 60U);
 }
 
+static void test_measured_while_paused_extra_alts() {
+  uint8_t ram[] = { 0x00, 0x00, 0x34, 0xAB, 0x56 };
+  memory_t memory;
+  rc_trigger_t* trigger;
+  char buffer[512];
+
+  memory.ram = ram;
+  memory.size = sizeof(ram);
+
+  /* (measured(byte(2) == 99) && unless(byte(1) == 1)) || (byte(3) == 1) */
+  assert_parse_trigger(&trigger, buffer, "SM:0xH0002=99_P:0xH0001=1S0xH0003=1");
+
+  /* alt1 will capture measured value */
+  assert_evaluate_trigger(trigger, &memory, 0);
+  ASSERT_NUM_EQUALS(trigger->measured_value, 52U);
+  ASSERT_NUM_EQUALS(trigger->measured_target, 99U);
+
+  /* first alt paused - expect last measured value to be kept */
+  ram[1] = 1;
+  assert_evaluate_trigger(trigger, &memory, 0);
+  ASSERT_NUM_EQUALS(trigger->measured_value, 52U);
+  ASSERT_NUM_EQUALS(trigger->measured_target, 99U);
+
+  /* measured value changed but alt still paused - expect last measured value to be kept */
+  ram[2] = 61;
+  assert_evaluate_trigger(trigger, &memory, 0);
+  ASSERT_NUM_EQUALS(trigger->measured_value, 52U);
+  ASSERT_NUM_EQUALS(trigger->measured_target, 99U);
+
+  /* first alt unpaused - it will update, measured will use the active value */
+  ram[1] = 0;
+  ram[2] = 63;
+  assert_evaluate_trigger(trigger, &memory, 0);
+  ASSERT_NUM_EQUALS(trigger->measured_value, 63U);
+  ASSERT_NUM_EQUALS(trigger->measured_target, 99U);
+}
+
 static void test_measured_reset_hitcount() {
   uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
@@ -2368,6 +2405,7 @@ void test_trigger(void) {
   TEST(test_measured_while_paused_reset_alt);
   TEST(test_measured_while_paused_reset_core);
   TEST(test_measured_while_paused_reset_non_hitcount);
+  TEST(test_measured_while_paused_extra_alts);
   TEST(test_measured_reset_hitcount);
   TEST(test_measured_reset_comparison);
   TEST(test_measured_if);


### PR DESCRIPTION
https://discord.com/channels/310192285306454017/1149693430306447380/1430591949118767248

Currently, if an achievement is paused, the measured value is not updated. 

However, if an alt group is paused, it does not calculate a measured value. If the entire achievement is not paused, it is assumed that a different alt group will generate the measured value. If the other alt groups do not generate a measured value, the overall measured state of the achievement will be 0 because no measured value was generated.

I've updated the logic to use the previous measured value if no measured value is generated (in addition to the previous logic of using the previous measured value if the entire achievement is paused).