### PR TITLE
modify validation logic to return most severe error instead of first error found

### DIFF
--- a/src/rcheevos/rc_internal.h
+++ b/src/rcheevos/rc_internal.h
@@ -382,7 +382,6 @@ rc_memrefs_t* rc_richpresence_get_memrefs(rc_richpresence_t* self);
 void rc_reset_richpresence_triggers(rc_richpresence_t* self);
 void rc_update_richpresence_internal(rc_richpresence_t* richpresence, rc_peek_t peek, void* peek_ud);
 
-int rc_validate_memrefs(const rc_memrefs_t* memrefs, char result[], const size_t result_size, uint32_t max_address);
 int rc_validate_memrefs_for_console(const rc_memrefs_t* memrefs, char result[], const size_t result_size, uint32_t console_id);
 
 RC_END_C_DECLS

--- a/src/rcheevos/rc_validate.c
+++ b/src/rcheevos/rc_validate.c
@@ -79,6 +79,24 @@ typedef struct rc_validation_state_t
   uint8_t has_hit_targets;
 } rc_validation_state_t;
 
+/* this returns a negative value if err1 is more severe than err2, or
+ * a positive value is err2 is more severe than err1. */
+static int rc_validation_compare_severity(const rc_validation_error_t* err1, const rc_validation_error_t* err2)
+{
+  /* lower err value is more severe */
+  int diff = (err1->err - err2->err);
+  if (diff != 0)
+    return diff;
+
+  /* lower group index is more severe */
+  diff = (err1->group_index - err2->group_index);
+  if (diff != 0)
+    return diff;
+
+  /* lower condition value is more severe */
+  return (err1->cond_index - err2->cond_index);
+}
+
 static const rc_validation_error_t* rc_validate_find_most_severe_error(const rc_validation_state_t* state)
 {
   const rc_validation_error_t* error = &state->errors[0];
@@ -86,15 +104,8 @@ static const rc_validation_error_t* rc_validate_find_most_severe_error(const rc_
   const rc_validation_error_t* stop = &state->errors[state->error_count];
 
   while (++error < stop) {
-    if (error->err < most_severe_error->err) {
+    if (rc_validation_compare_severity(error, most_severe_error) < 0)
       most_severe_error = error;
-    }
-    else if (error->err == most_severe_error->err) {
-      if (error->group_index < most_severe_error->group_index)
-        most_severe_error = error;
-      else if (error->group_index == most_severe_error->group_index && error->cond_index < most_severe_error->cond_index)
-        most_severe_error = error;
-    }
   }
 
   return most_severe_error;
@@ -107,15 +118,8 @@ static rc_validation_error_t* rc_validate_find_least_severe_error(rc_validation_
   rc_validation_error_t* stop = &state->errors[state->error_count];
 
   while (++error < stop) {
-    if (error->err > least_severe_error->err) {
+    if (rc_validation_compare_severity(error, least_severe_error) > 0)
       least_severe_error = error;
-    }
-    else if (error->err == least_severe_error->err) {
-      if (error->group_index > least_severe_error->group_index)
-        least_severe_error = error;
-      else if (error->group_index == least_severe_error->group_index && error->cond_index > least_severe_error->cond_index)
-        least_severe_error = error;
-    }
   }
 
   return least_severe_error;

--- a/src/rcheevos/rc_validate.c
+++ b/src/rcheevos/rc_validate.c
@@ -81,12 +81,20 @@ typedef struct rc_validation_state_t
 
 static const rc_validation_error_t* rc_validate_find_most_severe_error(const rc_validation_state_t* state)
 {
-  const rc_validation_error_t* most_severe_error = &state->errors[0];
-  uint32_t index;
+  const rc_validation_error_t* error = &state->errors[0];
+  const rc_validation_error_t* most_severe_error = error;
+  const rc_validation_error_t* stop = &state->errors[state->error_count];
 
-  for (index = 1; index < state->error_count; ++index) {
-    if (state->errors[index].err < most_severe_error->err)
-      most_severe_error = &state->errors[index];
+  while (++error < stop) {
+    if (error->err < most_severe_error->err) {
+      most_severe_error = error;
+    }
+    else if (error->err == most_severe_error->err) {
+      if (error->group_index < most_severe_error->group_index)
+        most_severe_error = error;
+      else if (error->group_index == most_severe_error->group_index && error->cond_index < most_severe_error->cond_index)
+        most_severe_error = error;
+    }
   }
 
   return most_severe_error;
@@ -94,12 +102,20 @@ static const rc_validation_error_t* rc_validate_find_most_severe_error(const rc_
 
 static rc_validation_error_t* rc_validate_find_least_severe_error(rc_validation_state_t* state)
 {
-  rc_validation_error_t* least_severe_error = &state->errors[0];
-  uint32_t index;
+  rc_validation_error_t* error = &state->errors[0];
+  rc_validation_error_t* least_severe_error = error;
+  rc_validation_error_t* stop = &state->errors[state->error_count];
 
-  for (index = 1; index < state->error_count; ++index) {
-    if (state->errors[index].err > least_severe_error->err)
-      least_severe_error = &state->errors[index];
+  while (++error < stop) {
+    if (error->err > least_severe_error->err) {
+      least_severe_error = error;
+    }
+    else if (error->err == least_severe_error->err) {
+      if (error->group_index > least_severe_error->group_index)
+        least_severe_error = error;
+      else if (error->group_index == least_severe_error->group_index && error->cond_index > least_severe_error->cond_index)
+        least_severe_error = error;
+    }
   }
 
   return least_severe_error;
@@ -601,14 +617,16 @@ static int rc_validate_condset_internal(const rc_condset_t* condset, rc_validati
       in_add_address = 0;
     }
 
-    if (rc_operand_is_recall(operand1)) {
-      if (rc_operand_type_is_memref(operand1->memref_access_type) && !operand1->value.memref)
-        return rc_validate_add_error(state, RC_VALIDATION_ERR_RECALL_BEFORE_REMEMBER, 0, 0);
+    /* if operand is {recall}, but memref is null, that means the Remember wasn't found */
+    if (rc_operand_is_recall(operand1) &&
+        rc_operand_type_is_memref(operand1->memref_access_type) &&
+        !operand1->value.memref) {
+      rc_validate_add_error(state, RC_VALIDATION_ERR_RECALL_BEFORE_REMEMBER, 0, 0);
     }
-
-    if (rc_operand_is_recall(&cond->operand2)) {
-      if (rc_operand_type_is_memref(cond->operand2.memref_access_type) && !cond->operand2.value.memref)
-        return rc_validate_add_error(state, RC_VALIDATION_ERR_RECALL_BEFORE_REMEMBER, 0, 0);
+    if (rc_operand_is_recall(&cond->operand2) &&
+        rc_operand_type_is_memref(cond->operand2.memref_access_type) &&
+        !cond->operand2.value.memref) {
+      rc_validate_add_error(state, RC_VALIDATION_ERR_RECALL_BEFORE_REMEMBER, 0, 0);
     }
 
     switch (cond->type) {
@@ -620,11 +638,11 @@ static int rc_validate_condset_internal(const rc_condset_t* condset, rc_validati
 
       case RC_CONDITION_ADD_ADDRESS:
         if (operand1->type == RC_OPERAND_DELTA || operand1->type == RC_OPERAND_PRIOR)
-          return rc_validate_add_error(state, RC_VALIDATION_ERR_POINTER_FROM_PREVIOUS_FRAME, 0, 0);
-        if (rc_operand_is_float(operand1) || rc_operand_is_float(&cond->operand2))
-          return rc_validate_add_error(state, RC_VALIDATION_ERR_POINTER_NON_INTEGER_OFFSET, 0, 0);
-        if (rc_operand_type_is_transform(operand1->type) && cond->oper != RC_OPERATOR_MULT)
-          return rc_validate_add_error(state, RC_VALIDATION_ERR_POINTER_TRANSFORMED_OFFSET, 0, 0);
+          rc_validate_add_error(state, RC_VALIDATION_ERR_POINTER_FROM_PREVIOUS_FRAME, 0, 0);
+        else if (rc_operand_is_float(operand1) || rc_operand_is_float(&cond->operand2))
+          rc_validate_add_error(state, RC_VALIDATION_ERR_POINTER_NON_INTEGER_OFFSET, 0, 0);
+        else if (rc_operand_type_is_transform(operand1->type) && cond->oper != RC_OPERATOR_MULT)
+          rc_validate_add_error(state, RC_VALIDATION_ERR_POINTER_TRANSFORMED_OFFSET, 0, 0);
 
         in_add_address = 1;
         is_combining = 1;
@@ -651,14 +669,14 @@ static int rc_validate_condset_internal(const rc_condset_t* condset, rc_validati
           break;
         }
         if (!state->has_hit_targets)
-          return rc_validate_add_error(state, RC_VALIDATION_ERR_NO_HITS_TO_RESET, 0, 0);
-        if (cond->required_hits == 1)
-          return rc_validate_add_error(state, RC_VALIDATION_ERR_RESET_HIT_TARGET_OF_ONE, 0, 0);
+          rc_validate_add_error(state, RC_VALIDATION_ERR_NO_HITS_TO_RESET, 0, 0);
+        else if (cond->required_hits == 1)
+          rc_validate_add_error(state, RC_VALIDATION_ERR_RESET_HIT_TARGET_OF_ONE, 0, 0);
         /* fallthrough */ /* to default */
       default:
         if (in_add_hits) {
           if (cond->required_hits == 0)
-            return rc_validate_add_error(state, RC_VALIDATION_ERR_ADDHITS_WITHOUT_TARGET, 0, 0);
+            rc_validate_add_error(state, RC_VALIDATION_ERR_ADDHITS_WITHOUT_TARGET, 0, 0);
 
           in_add_hits = 0;
         }
@@ -681,7 +699,7 @@ static int rc_validate_condset_internal(const rc_condset_t* condset, rc_validati
         operand1->value.memref->value.memref_type == RC_MEMREF_TYPE_MEMREF &&
         cond->operand2.value.memref->value.memref_type == RC_MEMREF_TYPE_MEMREF &&
         rc_max_value(operand1) != rc_max_value(&cond->operand2)) {
-      return rc_validate_add_error(state, RC_VALIDATION_ERR_COMPARING_DIFFERENT_MEMORY_SIZES, 0, 0);
+      rc_validate_add_error(state, RC_VALIDATION_ERR_COMPARING_DIFFERENT_MEMORY_SIZES, 0, 0);
     }
 
     if (is_memref1 && rc_operand_is_float(operand1)) {
@@ -730,11 +748,13 @@ static int rc_validate_condset_internal(const rc_condset_t* condset, rc_validati
             switch (oper) {
               case RC_OPERATOR_EQ:
                 typed_value.value.f32 = (float)operand2->value.dbl;
-                return rc_validate_add_error(state, RC_VALIDATION_ERR_COMPARISON_NEVER_TRUE_INTEGER_TO_FLOAT, typed_value.value.u32, 0);
+                rc_validate_add_error(state, RC_VALIDATION_ERR_COMPARISON_NEVER_TRUE_INTEGER_TO_FLOAT, typed_value.value.u32, 0);
+                break;
 
               case RC_OPERATOR_NE:
                 typed_value.value.f32 = (float)operand2->value.dbl;
-                return rc_validate_add_error(state, RC_VALIDATION_ERR_COMPARISON_ALWAYS_TRUE_INTEGER_TO_FLOAT, typed_value.value.u32, 0);
+                rc_validate_add_error(state, RC_VALIDATION_ERR_COMPARISON_ALWAYS_TRUE_INTEGER_TO_FLOAT, typed_value.value.u32, 0);
+                break;
 
               case RC_OPERATOR_GT: /* value could be greater than floor(float) */
               case RC_OPERATOR_LE: /* value could be less than or equal to floor(float) */
@@ -755,8 +775,7 @@ static int rc_validate_condset_internal(const rc_condset_t* condset, rc_validati
       }
 
       /* min_val and max_val are the range allowed by operand2. max is the upper value from operand1. */
-      if (!rc_validate_range(min_val, max_val, oper, max, state))
-        return 0;
+      rc_validate_range(min_val, max_val, oper, max, state);
     }
   }
 
@@ -767,15 +786,15 @@ static int rc_validate_condset_internal(const rc_condset_t* condset, rc_validati
     while (cond->next)
       cond = cond->next;
 
-    return rc_validate_add_error(state, RC_VALIDATION_ERR_TRAILING_CHAINING_CONDITION, cond->type, 0);
+    rc_validate_add_error(state, RC_VALIDATION_ERR_TRAILING_CHAINING_CONDITION, cond->type, 0);
   }
 
   if (measuredif_index != -1 && !has_measured) {
     state->cond_index = measuredif_index;
-    return rc_validate_add_error(state, RC_VALIDATION_ERR_MEASUREDIF_WITHOUT_MEASURED, 0, 0);
+    rc_validate_add_error(state, RC_VALIDATION_ERR_MEASUREDIF_WITHOUT_MEASURED, 0, 0);
   }
 
-  return 1;
+  return (state->error_count == 0);
 }
 
 static int rc_condset_has_hittargets(const rc_condset_t* condset)
@@ -1261,13 +1280,32 @@ static int rc_validate_conflicting_conditions(const rc_condset_t* conditions, co
           continue;
       }
 
-      return rc_validate_add_error(state, (overlap == RC_OVERLAP_REDUNDANT) ?
+      /* if condition A conflicts with condition B, condition B will also conflict with
+       * condition A. don't report both. */
+      {
+        int already_reported = 0;
+        const rc_validation_error_t* error = state->errors;
+        const rc_validation_error_t* stop = state->errors + state->error_count;
+        for (; error < stop; ++error) {
+          if (error->data2 == state->cond_index && error->data1 == state->group_index) {
+            if (error->err == RC_VALIDATION_ERR_REDUNDANT_CONDITION ||
+                error->err == RC_VALIDATION_ERR_CONFLICTING_CONDITION) {
+              already_reported = 1;
+            }
+          }
+        }
+
+        if (already_reported)
+          continue;
+      }
+
+      rc_validate_add_error(state, (overlap == RC_OVERLAP_REDUNDANT) ?
           RC_VALIDATION_ERR_REDUNDANT_CONDITION : RC_VALIDATION_ERR_CONFLICTING_CONDITION,
           group_index, rc_validate_get_condition_index(conditions, condition));
     }
   }
 
-  return 1;
+  return (state->error_count == 0);
 }
 
 static int rc_validate_trigger_internal(const rc_trigger_t* trigger, rc_validation_state_t* state)
@@ -1288,34 +1326,31 @@ static int rc_validate_trigger_internal(const rc_trigger_t* trigger, rc_validati
   }
 
   state->group_index = 0;
-  if (!rc_validate_condset_internal(trigger->requirement, state))
-    return 0;
-
-  /* compare core to itself */
-  if (!rc_validate_conflicting_conditions(trigger->requirement, trigger->requirement, 0, state))
-    return 0;
+  if (rc_validate_condset_internal(trigger->requirement, state)) {
+    /* compare core to itself */
+    rc_validate_conflicting_conditions(trigger->requirement, trigger->requirement, 0, state);
+  }
 
   index = 1;
   for (alt = trigger->alternative; alt; alt = alt->next, ++index) {
     state->group_index = index;
-    if (!rc_validate_condset_internal(alt, state))
-      return 0;
+    if (rc_validate_condset_internal(alt, state)) {
+      /* compare alt to itself */
+      if (!rc_validate_conflicting_conditions(alt, alt, index, state))
+        continue;
 
-    /* compare alt to itself */
-    if (!rc_validate_conflicting_conditions(alt, alt, index, state))
-      return 0;
+      /* compare alt to core */
+      if (!rc_validate_conflicting_conditions(trigger->requirement, alt, 0, state))
+        continue;
 
-    /* compare alt to core */
-    if (!rc_validate_conflicting_conditions(trigger->requirement, alt, 0, state))
-      return 0;
-
-    /* compare core to alt */
-    state->group_index = 0;
-    if (!rc_validate_conflicting_conditions(alt, trigger->requirement, index, state))
-      return 0;
+      /* compare core to alt */
+      state->group_index = 0;
+      if (!rc_validate_conflicting_conditions(alt, trigger->requirement, index, state))
+        continue;
+    }
   }
 
-  return 1;
+  return (state->error_count == 0);
 }
 
 int rc_validate_trigger(const rc_trigger_t* trigger, char result[], const size_t result_size, uint32_t max_address)

--- a/src/rcheevos/rc_validate.c
+++ b/src/rcheevos/rc_validate.c
@@ -16,11 +16,11 @@ enum
 
   /* errors that prevent the achievement from functioning */
   RC_VALIDATION_ERR_ADDRESS_OUT_OF_RANGE,
+  RC_VALIDATION_ERR_RECALL_BEFORE_REMEMBER,
   RC_VALIDATION_ERR_COMPARISON_NEVER_TRUE_WITH_MAX,
   RC_VALIDATION_ERR_COMPARISON_NEVER_TRUE_INTEGER_TO_FLOAT,
   RC_VALIDATION_ERR_COMPARISON_NEVER_TRUE,
   RC_VALIDATION_ERR_CONFLICTING_CONDITION,
-  RC_VALIDATION_ERR_RECALL_BEFORE_REMEMBER,
 
   /* warnings about logic that does nothing */
   RC_VALIDATION_ERR_COMPARISON_ALWAYS_TRUE_INTEGER_TO_FLOAT,
@@ -55,7 +55,7 @@ enum
 {
   RC_VALIDATION_VIRTUAL_RAM_OTHER,
   RC_VALIDATION_VIRTUAL_RAM_MIRROR,
-  RC_VALIDATION_VIRTUAL_RAM_ECHO,
+  RC_VALIDATION_VIRTUAL_RAM_ECHO
 };
 
 typedef struct rc_validation_error_t
@@ -333,23 +333,6 @@ static int rc_validate_memref(const rc_memref_t* memref, rc_validation_state_t* 
         return rc_validate_add_error(state, RC_VALIDATION_ERR_KERNAL_RAM_REQUIRES_BIOS, memref->address, 0);
       break;
   }
-
-  return 1;
-}
-
-static int rc_validate_memrefs(const rc_memrefs_t* memrefs, rc_validation_state_t* state, uint32_t max_address)
-{
-  const rc_memref_list_t* memref_list = &memrefs->memrefs;
-  do {
-    const rc_memref_t* memref = memref_list->items;
-    const rc_memref_t* memref_stop = memref + memref_list->count;
-    for (; memref < memref_stop; ++memref) {
-      if (!rc_validate_memref(memref, state))
-        return 0;
-    }
-
-    memref_list = memref_list->next;
-  } while (memref_list);
 
   return 1;
 }

--- a/src/rcheevos/rc_validate.c
+++ b/src/rcheevos/rc_validate.c
@@ -293,7 +293,7 @@ static int rc_validate_format_error(char buffer[], size_t buffer_size, const rc_
   return 0;
 }
 
-static int rc_validate_add_error(rc_validation_state_t* state, uint32_t error_code, uint32_t data1, uint32_t data2)
+static void rc_validate_add_error(rc_validation_state_t* state, uint32_t error_code, uint32_t data1, uint32_t data2)
 {
   rc_validation_error_t* error;
   if (state->error_count == sizeof(state->errors) / sizeof(state->errors[0]))
@@ -306,35 +306,33 @@ static int rc_validate_add_error(rc_validation_state_t* state, uint32_t error_co
   error->cond_index = state->cond_index;
   error->data1 = data1;
   error->data2 = data2;
-
-  return 0;
 }
 
-static int rc_validate_memref(const rc_memref_t* memref, rc_validation_state_t* state)
+static void rc_validate_memref(const rc_memref_t* memref, rc_validation_state_t* state)
 {
-  if (memref->address > state->max_address)
-    return rc_validate_add_error(state, RC_VALIDATION_ERR_ADDRESS_OUT_OF_RANGE, memref->address, state->max_address);
+  if (memref->address > state->max_address) {
+    rc_validate_add_error(state, RC_VALIDATION_ERR_ADDRESS_OUT_OF_RANGE, memref->address, state->max_address);
+    return;
+  }
 
   switch (state->console_id) {
     case RC_CONSOLE_NINTENDO:
     case RC_CONSOLE_FAMICOM_DISK_SYSTEM:
       if (memref->address >= 0x0800 && memref->address <= 0x1FFF)
-        return rc_validate_add_error(state, RC_VALIDATION_ERR_VIRTUAL_RAM_MAY_NOT_BE_EXPOSED, memref->address, RC_VALIDATION_VIRTUAL_RAM_MIRROR);
+        rc_validate_add_error(state, RC_VALIDATION_ERR_VIRTUAL_RAM_MAY_NOT_BE_EXPOSED, memref->address, RC_VALIDATION_VIRTUAL_RAM_MIRROR);
       break;
 
     case RC_CONSOLE_GAMEBOY:
     case RC_CONSOLE_GAMEBOY_COLOR:
       if (memref->address >= 0xE000 && memref->address <= 0xFDFF)
-        return rc_validate_add_error(state, RC_VALIDATION_ERR_VIRTUAL_RAM_MAY_NOT_BE_EXPOSED, memref->address, RC_VALIDATION_VIRTUAL_RAM_ECHO);
+        rc_validate_add_error(state, RC_VALIDATION_ERR_VIRTUAL_RAM_MAY_NOT_BE_EXPOSED, memref->address, RC_VALIDATION_VIRTUAL_RAM_ECHO);
       break;
 
     case RC_CONSOLE_PLAYSTATION:
       if (memref->address <= 0xFFFF)
-        return rc_validate_add_error(state, RC_VALIDATION_ERR_KERNAL_RAM_REQUIRES_BIOS, memref->address, 0);
+        rc_validate_add_error(state, RC_VALIDATION_ERR_KERNAL_RAM_REQUIRES_BIOS, memref->address, 0);
       break;
   }
-
-  return 1;
 }
 
 static uint32_t rc_console_max_address(uint32_t console_id)
@@ -363,7 +361,8 @@ int rc_validate_memrefs_for_console(const rc_memrefs_t* memrefs, char result[], 
     const rc_memref_t* memref_stop = memref + memref_list->count;
     for (; memref < memref_stop; ++memref)
     {
-      if (!rc_validate_memref(memref, &state)) {
+      rc_validate_memref(memref, &state);
+      if (state.error_count) {
         rc_validate_format_error(result, result_size, &state, &state.errors[0]);
         return 0;
       }
@@ -522,52 +521,50 @@ static int rc_validate_get_condition_index(const rc_condset_t* condset, const rc
    return 0;
 }
 
-static int rc_validate_range(uint32_t min_val, uint32_t max_val, char oper, uint32_t max, rc_validation_state_t* state)
+static void rc_validate_range(uint32_t min_val, uint32_t max_val, char oper, uint32_t max, rc_validation_state_t* state)
 {
   switch (oper) {
     case RC_OPERATOR_AND:
       if (min_val > max)
-        return rc_validate_add_error(state, RC_VALIDATION_ERR_MASK_TOO_LARGE, 0, 0);
+        rc_validate_add_error(state, RC_VALIDATION_ERR_MASK_TOO_LARGE, 0, 0);
       else if (min_val == 0 && max_val == 0)
-        return rc_validate_add_error(state, RC_VALIDATION_ERR_MASK_RESULT_ALWAYS_ZERO, 0, 0);
+        rc_validate_add_error(state, RC_VALIDATION_ERR_MASK_RESULT_ALWAYS_ZERO, 0, 0);
       break;
 
     case RC_OPERATOR_EQ:
       if (min_val > max)
-        return rc_validate_add_error(state, RC_VALIDATION_ERR_COMPARISON_NEVER_TRUE_WITH_MAX, max, 0);
+        rc_validate_add_error(state, RC_VALIDATION_ERR_COMPARISON_NEVER_TRUE_WITH_MAX, max, 0);
       break;
 
     case RC_OPERATOR_NE:
       if (min_val > max)
-        return rc_validate_add_error(state, RC_VALIDATION_ERR_COMPARISON_ALWAYS_TRUE_WITH_MAX, max, 0);
+        rc_validate_add_error(state, RC_VALIDATION_ERR_COMPARISON_ALWAYS_TRUE_WITH_MAX, max, 0);
       break;
 
     case RC_OPERATOR_GE:
       if (min_val > max)
-        return rc_validate_add_error(state, RC_VALIDATION_ERR_COMPARISON_NEVER_TRUE_WITH_MAX, max, 0);
-      if (max_val == 0)
-        return rc_validate_add_error(state, RC_VALIDATION_ERR_COMPARISON_ALWAYS_TRUE_WITH_MAX, max, 0);
+        rc_validate_add_error(state, RC_VALIDATION_ERR_COMPARISON_NEVER_TRUE_WITH_MAX, max, 0);
+      else if (max_val == 0)
+        rc_validate_add_error(state, RC_VALIDATION_ERR_COMPARISON_ALWAYS_TRUE_WITH_MAX, max, 0);
       break;
 
     case RC_OPERATOR_GT:
       if (min_val >= max)
-        return rc_validate_add_error(state, RC_VALIDATION_ERR_COMPARISON_NEVER_TRUE_WITH_MAX, max, 0);
+        rc_validate_add_error(state, RC_VALIDATION_ERR_COMPARISON_NEVER_TRUE_WITH_MAX, max, 0);
       break;
 
     case RC_OPERATOR_LE:
       if (min_val >= max)
-        return rc_validate_add_error(state, RC_VALIDATION_ERR_COMPARISON_ALWAYS_TRUE_WITH_MAX, max, 0);
+        rc_validate_add_error(state, RC_VALIDATION_ERR_COMPARISON_ALWAYS_TRUE_WITH_MAX, max, 0);
       break;
 
     case RC_OPERATOR_LT:
       if (min_val > max)
-        return rc_validate_add_error(state, RC_VALIDATION_ERR_COMPARISON_ALWAYS_TRUE_WITH_MAX, max, 0);
-      if (max_val == 0)
-        return rc_validate_add_error(state, RC_VALIDATION_ERR_COMPARISON_NEVER_TRUE, 0, 0);
+        rc_validate_add_error(state, RC_VALIDATION_ERR_COMPARISON_ALWAYS_TRUE_WITH_MAX, max, 0);
+      else if (max_val == 0)
+        rc_validate_add_error(state, RC_VALIDATION_ERR_COMPARISON_NEVER_TRUE, 0, 0);
       break;
   }
-
-  return 1;
 }
 
 static int rc_validate_condset_internal(const rc_condset_t* condset, rc_validation_state_t* state)
@@ -578,6 +575,7 @@ static int rc_validate_condset_internal(const rc_condset_t* condset, rc_validati
   int is_combining = 0;
   int has_measured = 0;
   int measuredif_index = -1;
+  uint32_t errors_before = state->error_count;
 
   if (!condset)
     return 1;
@@ -591,10 +589,10 @@ static int rc_validate_condset_internal(const rc_condset_t* condset, rc_validati
     const int is_memref2 = rc_operand_is_memref(&cond->operand2);
 
     if (!in_add_address) {
-      if (is_memref1 && !rc_validate_memref(operand1->value.memref, state))
-        return 0;
-      if (is_memref2 && !rc_validate_memref(cond->operand2.value.memref, state))
-        return 0;
+      if (is_memref1)
+        rc_validate_memref(operand1->value.memref, state);
+      if (is_memref2)
+        rc_validate_memref(cond->operand2.value.memref, state);
     }
     else {
       in_add_address = 0;
@@ -777,7 +775,7 @@ static int rc_validate_condset_internal(const rc_condset_t* condset, rc_validati
     rc_validate_add_error(state, RC_VALIDATION_ERR_MEASUREDIF_WITHOUT_MEASURED, 0, 0);
   }
 
-  return (state->error_count == 0);
+  return (state->error_count == errors_before);
 }
 
 static int rc_condset_has_hittargets(const rc_condset_t* condset)
@@ -810,7 +808,7 @@ int rc_validate_condset(const rc_condset_t* condset, char result[], const size_t
   state.max_address = max_address;
 
   result[0] = '\0';
-  if (!rc_validate_condset_internal(condset, &state)) {
+  if (rc_validate_condset_internal(condset, &state)) {
     const rc_validation_error_t* most_severe_error = rc_validate_find_most_severe_error(&state);
     return rc_validate_format_error(result, result_size, &state, most_severe_error);
   }
@@ -827,7 +825,7 @@ int rc_validate_condset_for_console(const rc_condset_t* condset, char result[], 
   state.has_hit_targets = rc_condset_has_hittargets(condset);
 
   result[0] = '\0';
-  if (!rc_validate_condset_internal(condset, &state)) {
+  if (rc_validate_condset_internal(condset, &state)) {
     const rc_validation_error_t* most_severe_error = rc_validate_find_most_severe_error(&state);
     return rc_validate_format_error(result, result_size, &state, most_severe_error);
   }
@@ -1064,6 +1062,7 @@ static int rc_validate_conflicting_conditions(const rc_condset_t* conditions, co
   const rc_condition_t* compare_condition;
   const rc_condition_t* condition;
   const rc_condition_t* condition_chain_start;
+  uint32_t errors_before = state->error_count;
   uint32_t condition_index;
   int overlap;
   int chain_matches;
@@ -1288,7 +1287,7 @@ static int rc_validate_conflicting_conditions(const rc_condset_t* conditions, co
     }
   }
 
-  return (state->error_count == 0);
+  return (state->error_count == errors_before);
 }
 
 static int rc_validate_trigger_internal(const rc_trigger_t* trigger, rc_validation_state_t* state)

--- a/src/rcheevos/rc_validate.c
+++ b/src/rcheevos/rc_validate.c
@@ -8,49 +8,327 @@
 #include <stddef.h>
 #include <stdlib.h>
 
-static int rc_validate_memref(const rc_memref_t* memref, char result[], const size_t result_size, uint32_t console_id, uint32_t max_address)
+enum
 {
-  if (memref->address > max_address) {
-    snprintf(result, result_size, "Address %04X out of range (max %04X)", memref->address, max_address);
-    return 0;
+  RC_VALIDATION_ERR_NONE,
+
+  /* sorted by severity - most severe first */
+
+  /* errors that prevent the achievement from functioning */
+  RC_VALIDATION_ERR_ADDRESS_OUT_OF_RANGE,
+  RC_VALIDATION_ERR_COMPARISON_NEVER_TRUE_WITH_MAX,
+  RC_VALIDATION_ERR_COMPARISON_NEVER_TRUE_INTEGER_TO_FLOAT,
+  RC_VALIDATION_ERR_COMPARISON_NEVER_TRUE,
+  RC_VALIDATION_ERR_CONFLICTING_CONDITION,
+  RC_VALIDATION_ERR_RECALL_BEFORE_REMEMBER,
+
+  /* warnings about logic that does nothing */
+  RC_VALIDATION_ERR_COMPARISON_ALWAYS_TRUE_INTEGER_TO_FLOAT,
+  RC_VALIDATION_ERR_COMPARISON_ALWAYS_TRUE_WITH_MAX,
+  RC_VALIDATION_ERR_TRAILING_CHAINING_CONDITION,
+  RC_VALIDATION_ERR_MEASUREDIF_WITHOUT_MEASURED,
+  RC_VALIDATION_ERR_ADDHITS_WITHOUT_TARGET,
+
+  /* warnings about pointer math */
+  RC_VALIDATION_ERR_POINTER_FROM_PREVIOUS_FRAME,
+  RC_VALIDATION_ERR_POINTER_NON_INTEGER_OFFSET,
+  RC_VALIDATION_ERR_POINTER_TRANSFORMED_OFFSET,
+
+  /* warnings about potential logic errors */
+  RC_VALIDATION_ERR_COMPARING_DIFFERENT_MEMORY_SIZES,
+  RC_VALIDATION_ERR_MASK_RESULT_ALWAYS_ZERO,
+
+  /* warnings that some areas of memory should be avoided */
+  RC_VALIDATION_ERR_KERNAL_RAM_REQUIRES_BIOS,
+  RC_VALIDATION_ERR_VIRTUAL_RAM_MAY_NOT_BE_EXPOSED,
+
+  /* warnings about redundant logic */
+  RC_VALIDATION_ERR_REDUNDANT_CONDITION,
+  RC_VALIDATION_ERR_NO_HITS_TO_RESET,
+  RC_VALIDATION_ERR_RESET_HIT_TARGET_OF_ONE,
+  RC_VALIDATION_ERR_MASK_TOO_LARGE,
+
+  RC_VALIDATION_ERR_COUNT
+};
+
+enum
+{
+  RC_VALIDATION_VIRTUAL_RAM_OTHER,
+  RC_VALIDATION_VIRTUAL_RAM_MIRROR,
+  RC_VALIDATION_VIRTUAL_RAM_ECHO,
+};
+
+typedef struct rc_validation_error_t
+{
+  uint32_t err;
+  uint16_t group_index;
+  uint16_t cond_index;
+  uint32_t data1;
+  uint32_t data2;
+} rc_validation_error_t;
+
+typedef struct rc_validation_state_t
+{
+  rc_validation_error_t errors[64];
+  uint32_t error_count;
+  uint16_t group_index;
+  uint16_t cond_index;
+  uint32_t console_id;
+  uint32_t max_address;
+  uint8_t has_alt_groups;
+  uint8_t has_hit_targets;
+} rc_validation_state_t;
+
+static const rc_validation_error_t* rc_validate_find_most_severe_error(const rc_validation_state_t* state)
+{
+  const rc_validation_error_t* most_severe_error = &state->errors[0];
+  uint32_t index;
+
+  for (index = 1; index < state->error_count; ++index) {
+    if (state->errors[index].err < most_severe_error->err)
+      most_severe_error = &state->errors[index];
   }
 
-  switch (console_id) {
+  return most_severe_error;
+}
+
+static rc_validation_error_t* rc_validate_find_least_severe_error(rc_validation_state_t* state)
+{
+  rc_validation_error_t* least_severe_error = &state->errors[0];
+  uint32_t index;
+
+  for (index = 1; index < state->error_count; ++index) {
+    if (state->errors[index].err > least_severe_error->err)
+      least_severe_error = &state->errors[index];
+  }
+
+  return least_severe_error;
+}
+
+static size_t rc_validate_format_cond_index(char buffer[], size_t buffer_size, const rc_validation_state_t* state, uint32_t group_index, uint32_t cond_index)
+{
+  int written = 0;
+
+  if (cond_index == 0)
+    return 0;
+
+  if (state->has_alt_groups) {
+    if (group_index == 0)
+      written = snprintf(buffer, buffer_size, "Core ");
+    else
+      written = snprintf(buffer, buffer_size, "Alt%u ", group_index);
+
+    buffer += written;
+    buffer_size -= written;
+  }
+
+  written += snprintf(buffer, buffer_size, "Condition %u", cond_index);
+  return written;
+}
+
+static const char* rc_validate_get_condition_type_string(uint32_t type)
+{
+  switch (type) {
+    case RC_CONDITION_ADD_ADDRESS: return "AddAddress";
+    case RC_CONDITION_ADD_HITS: return "AddHits";
+    case RC_CONDITION_ADD_SOURCE: return "AddSource";
+    case RC_CONDITION_AND_NEXT: return "AndNext";
+    case RC_CONDITION_MEASURED: return "Measured";
+    case RC_CONDITION_MEASURED_IF: return "MeasuredIf";
+    case RC_CONDITION_OR_NEXT: return "OrNext";
+    case RC_CONDITION_PAUSE_IF: return "PauseIf";
+    case RC_CONDITION_REMEMBER: return "Remember";
+    case RC_CONDITION_RESET_IF: return "ResetIf";
+    case RC_CONDITION_RESET_NEXT_IF: return "ResetNextIf";
+    case RC_CONDITION_SUB_HITS: return "SubHits";
+    case RC_CONDITION_SUB_SOURCE: return "SubSource";
+    case RC_CONDITION_TRIGGER: return "Trigger";
+    default: return "???";
+  }
+}
+
+static void rc_validate_format_error_compare_int_to_float(char buffer[], size_t buffer_size, uint32_t encoded_data, const char* limiter)
+{
+  int written;
+  rc_typed_value_t value;
+  value.value.u32 = encoded_data;
+
+  written = snprintf(buffer, buffer_size, "Comparison is %s true (integer can never be %.06f", limiter, value.value.f32);
+  while (buffer[written - 1] == '0')
+    written--;
+  if (buffer[written] == '.')
+    written++;
+  buffer[written] = ')';
+  buffer[written + 1] = '\0';
+}
+
+static int rc_validate_format_error(char buffer[], size_t buffer_size, const rc_validation_state_t* state, const rc_validation_error_t* error)
+{
+  size_t written = rc_validate_format_cond_index(buffer, buffer_size, state, error->group_index, error->cond_index);
+  buffer += written;
+  buffer_size -= written;
+
+  if (buffer_size < 2)
+    return 0;
+
+  buffer_size -= 2;
+  *buffer++ = ':';
+  *buffer++ = ' ';
+
+  switch (error->err) {
+    case RC_VALIDATION_ERR_ADDHITS_WITHOUT_TARGET:
+      snprintf(buffer, buffer_size, "Final condition in AddHits chain must have a hit target");
+      break;
+
+    case RC_VALIDATION_ERR_ADDRESS_OUT_OF_RANGE:
+      snprintf(buffer, buffer_size, "Address %04X out of range (max %04X)", error->data1, error->data2);
+      break;
+
+    case RC_VALIDATION_ERR_COMPARING_DIFFERENT_MEMORY_SIZES:
+      snprintf(buffer, buffer_size, "Comparing different memory sizes");
+      break;
+
+    case RC_VALIDATION_ERR_COMPARISON_ALWAYS_TRUE_INTEGER_TO_FLOAT:
+      rc_validate_format_error_compare_int_to_float(buffer, buffer_size, error->data1, "always");
+      break;
+
+    case RC_VALIDATION_ERR_COMPARISON_ALWAYS_TRUE_WITH_MAX:
+      snprintf(buffer, buffer_size, "Comparison is always true (max %u)", error->data1);
+      break;
+
+    case RC_VALIDATION_ERR_COMPARISON_NEVER_TRUE:
+      snprintf(buffer, buffer_size, "Comparison is never true");
+      break;
+
+    case RC_VALIDATION_ERR_COMPARISON_NEVER_TRUE_INTEGER_TO_FLOAT:
+      rc_validate_format_error_compare_int_to_float(buffer, buffer_size, error->data1, "never");
+      break;
+
+    case RC_VALIDATION_ERR_COMPARISON_NEVER_TRUE_WITH_MAX:
+      snprintf(buffer, buffer_size, "Comparison is never true (max %u)", error->data1);
+      break;
+
+    case RC_VALIDATION_ERR_CONFLICTING_CONDITION:
+      written = snprintf(buffer, buffer_size, "Conflicts with ");
+      buffer += written;
+      buffer_size -= written;
+      rc_validate_format_cond_index(buffer, buffer_size, state, error->data1, error->data2);
+      break;
+
+    case RC_VALIDATION_ERR_KERNAL_RAM_REQUIRES_BIOS:
+      snprintf(buffer, buffer_size, "Kernel RAM may not be initialized without real BIOS (address %04X)", error->data1);
+      break;
+
+    case RC_VALIDATION_ERR_MASK_RESULT_ALWAYS_ZERO:
+      snprintf(buffer, buffer_size, "Result of mask is always 0");
+      break;
+
+    case RC_VALIDATION_ERR_MASK_TOO_LARGE:
+      snprintf(buffer, buffer_size, "Mask has more bits than source");
+      break;
+
+    case RC_VALIDATION_ERR_MEASUREDIF_WITHOUT_MEASURED:
+      snprintf(buffer, buffer_size, "MeasuredIf without Measured");
+      break;
+
+    case RC_VALIDATION_ERR_NO_HITS_TO_RESET:
+      snprintf(buffer, buffer_size, "No captured hits to reset");
+      break;
+
+    case RC_VALIDATION_ERR_POINTER_FROM_PREVIOUS_FRAME:
+      snprintf(buffer, buffer_size, "Using pointer from previous frame");
+      break;
+
+    case RC_VALIDATION_ERR_POINTER_NON_INTEGER_OFFSET:
+      snprintf(buffer, buffer_size, "Using non-integer value in AddAddress calculation");
+      break;
+
+    case RC_VALIDATION_ERR_POINTER_TRANSFORMED_OFFSET:
+      snprintf(buffer, buffer_size, "Using transformed value in AddAddress calculation");
+      break;
+
+    case RC_VALIDATION_ERR_RECALL_BEFORE_REMEMBER:
+      snprintf(buffer, buffer_size, "Recall used before Remember");
+      break;
+
+    case RC_VALIDATION_ERR_RESET_HIT_TARGET_OF_ONE:
+      snprintf(buffer, buffer_size, "Hit target of 1 is redundant on ResetIf");
+      break;
+
+    case RC_VALIDATION_ERR_REDUNDANT_CONDITION:
+      written = snprintf(buffer, buffer_size, "Redundant with ");
+      buffer += written;
+      buffer_size -= written;
+      rc_validate_format_cond_index(buffer, buffer_size, state, error->data1, error->data2);
+      break;
+
+    case RC_VALIDATION_ERR_TRAILING_CHAINING_CONDITION:
+      snprintf(buffer, buffer_size, "%s condition type expects another condition to follow", rc_validate_get_condition_type_string(error->data1));
+      break;
+
+    case RC_VALIDATION_ERR_VIRTUAL_RAM_MAY_NOT_BE_EXPOSED:
+      snprintf(buffer, buffer_size, "%s RAM may not be exposed by emulator (address %04X)",
+        error->data2 == RC_VALIDATION_VIRTUAL_RAM_MIRROR ? "Mirror" :
+          error->data2 == RC_VALIDATION_VIRTUAL_RAM_ECHO ? "Echo" : "Virtual",
+        error->data1);
+      break;
+  }
+
+  return 0;
+}
+
+static int rc_validate_add_error(rc_validation_state_t* state, uint32_t error_code, uint32_t data1, uint32_t data2)
+{
+  rc_validation_error_t* error;
+  if (state->error_count == sizeof(state->errors) / sizeof(state->errors[0]))
+    error = rc_validate_find_least_severe_error(state);
+  else
+    error = &state->errors[state->error_count++];
+
+  error->err = error_code;
+  error->group_index = state->group_index;
+  error->cond_index = state->cond_index;
+  error->data1 = data1;
+  error->data2 = data2;
+
+  return 0;
+}
+
+static int rc_validate_memref(const rc_memref_t* memref, rc_validation_state_t* state)
+{
+  if (memref->address > state->max_address)
+    return rc_validate_add_error(state, RC_VALIDATION_ERR_ADDRESS_OUT_OF_RANGE, memref->address, state->max_address);
+
+  switch (state->console_id) {
     case RC_CONSOLE_NINTENDO:
     case RC_CONSOLE_FAMICOM_DISK_SYSTEM:
-      if (memref->address >= 0x0800 && memref->address <= 0x1FFF) {
-        snprintf(result, result_size, "Mirror RAM may not be exposed by emulator (address %04X)", memref->address);
-        return 0;
-      }
+      if (memref->address >= 0x0800 && memref->address <= 0x1FFF)
+        return rc_validate_add_error(state, RC_VALIDATION_ERR_VIRTUAL_RAM_MAY_NOT_BE_EXPOSED, memref->address, RC_VALIDATION_VIRTUAL_RAM_MIRROR);
       break;
 
     case RC_CONSOLE_GAMEBOY:
     case RC_CONSOLE_GAMEBOY_COLOR:
-      if (memref->address >= 0xE000 && memref->address <= 0xFDFF) {
-        snprintf(result, result_size, "Echo RAM may not be exposed by emulator (address %04X)", memref->address);
-        return 0;
-      }
+      if (memref->address >= 0xE000 && memref->address <= 0xFDFF)
+        return rc_validate_add_error(state, RC_VALIDATION_ERR_VIRTUAL_RAM_MAY_NOT_BE_EXPOSED, memref->address, RC_VALIDATION_VIRTUAL_RAM_ECHO);
       break;
 
     case RC_CONSOLE_PLAYSTATION:
-      if (memref->address <= 0xFFFF) {
-        snprintf(result, result_size, "Kernel RAM may not be initialized without real BIOS (address %04X)", memref->address);
-        return 0;
-      }
+      if (memref->address <= 0xFFFF)
+        return rc_validate_add_error(state, RC_VALIDATION_ERR_KERNAL_RAM_REQUIRES_BIOS, memref->address, 0);
       break;
   }
 
   return 1;
 }
 
-int rc_validate_memrefs(const rc_memrefs_t* memrefs, char result[], const size_t result_size, uint32_t max_address)
+static int rc_validate_memrefs(const rc_memrefs_t* memrefs, rc_validation_state_t* state, uint32_t max_address)
 {
   const rc_memref_list_t* memref_list = &memrefs->memrefs;
   do {
     const rc_memref_t* memref = memref_list->items;
     const rc_memref_t* memref_stop = memref + memref_list->count;
     for (; memref < memref_stop; ++memref) {
-      if (!rc_validate_memref(memref, result, result_size, 0, max_address))
+      if (!rc_validate_memref(memref, state))
         return 0;
     }
 
@@ -72,16 +350,24 @@ static uint32_t rc_console_max_address(uint32_t console_id)
 
 int rc_validate_memrefs_for_console(const rc_memrefs_t* memrefs, char result[], const size_t result_size, uint32_t console_id)
 {
-  const uint32_t max_address = rc_console_max_address(console_id);
   const rc_memref_list_t* memref_list = &memrefs->memrefs;
+
+  rc_validation_state_t state;
+  memset(&state, 0, sizeof(state));
+  state.console_id = console_id;
+  state.max_address = rc_console_max_address(console_id);
+
+  result[0] = '\0';
   do
   {
     const rc_memref_t* memref = memref_list->items;
     const rc_memref_t* memref_stop = memref + memref_list->count;
     for (; memref < memref_stop; ++memref)
     {
-      if (!rc_validate_memref(memref, result, result_size, console_id, max_address))
+      if (!rc_validate_memref(memref, &state)) {
+        rc_validate_format_error(result, result_size, &state, &state.errors[0]);
         return 0;
+      }
     }
 
     memref_list = memref_list->next;
@@ -237,122 +523,92 @@ static int rc_validate_get_condition_index(const rc_condset_t* condset, const rc
    return 0;
 }
 
-static int rc_validate_range(uint32_t min_val, uint32_t max_val, char oper, uint32_t max, char result[], const size_t result_size)
+static int rc_validate_range(uint32_t min_val, uint32_t max_val, char oper, uint32_t max, rc_validation_state_t* state)
 {
   switch (oper) {
     case RC_OPERATOR_AND:
-      if (min_val > max) {
-        snprintf(result, result_size, "Mask has more bits than source");
-        return 0;
-      }
-      else if (min_val == 0 && max_val == 0) {
-        snprintf(result, result_size, "Result of mask always 0");
-        return 0;
-      }
+      if (min_val > max)
+        return rc_validate_add_error(state, RC_VALIDATION_ERR_MASK_TOO_LARGE, 0, 0);
+      else if (min_val == 0 && max_val == 0)
+        return rc_validate_add_error(state, RC_VALIDATION_ERR_MASK_RESULT_ALWAYS_ZERO, 0, 0);
       break;
 
     case RC_OPERATOR_EQ:
-      if (min_val > max) {
-        snprintf(result, result_size, "Comparison is never true");
-        return 0;
-      }
+      if (min_val > max)
+        return rc_validate_add_error(state, RC_VALIDATION_ERR_COMPARISON_NEVER_TRUE_WITH_MAX, max, 0);
       break;
 
     case RC_OPERATOR_NE:
-      if (min_val > max) {
-        snprintf(result, result_size, "Comparison is always true");
-        return 0;
-      }
+      if (min_val > max)
+        return rc_validate_add_error(state, RC_VALIDATION_ERR_COMPARISON_ALWAYS_TRUE_WITH_MAX, max, 0);
       break;
 
     case RC_OPERATOR_GE:
-      if (min_val > max) {
-        snprintf(result, result_size, "Comparison is never true");
-        return 0;
-      }
-      if (max_val == 0) {
-        snprintf(result, result_size, "Comparison is always true");
-        return 0;
-      }
+      if (min_val > max)
+        return rc_validate_add_error(state, RC_VALIDATION_ERR_COMPARISON_NEVER_TRUE_WITH_MAX, max, 0);
+      if (max_val == 0)
+        return rc_validate_add_error(state, RC_VALIDATION_ERR_COMPARISON_ALWAYS_TRUE_WITH_MAX, max, 0);
       break;
 
     case RC_OPERATOR_GT:
-      if (min_val >= max) {
-        snprintf(result, result_size, "Comparison is never true");
-        return 0;
-      }
+      if (min_val >= max)
+        return rc_validate_add_error(state, RC_VALIDATION_ERR_COMPARISON_NEVER_TRUE_WITH_MAX, max, 0);
       break;
 
     case RC_OPERATOR_LE:
-      if (min_val >= max) {
-        snprintf(result, result_size, "Comparison is always true");
-        return 0;
-      }
+      if (min_val >= max)
+        return rc_validate_add_error(state, RC_VALIDATION_ERR_COMPARISON_ALWAYS_TRUE_WITH_MAX, max, 0);
       break;
 
     case RC_OPERATOR_LT:
-      if (min_val > max) {
-        snprintf(result, result_size, "Comparison is always true");
-        return 0;
-      }
-      if (max_val == 0) {
-        snprintf(result, result_size, "Comparison is never true");
-        return 0;
-      }
+      if (min_val > max)
+        return rc_validate_add_error(state, RC_VALIDATION_ERR_COMPARISON_ALWAYS_TRUE_WITH_MAX, max, 0);
+      if (max_val == 0)
+        return rc_validate_add_error(state, RC_VALIDATION_ERR_COMPARISON_NEVER_TRUE, 0, 0);
       break;
   }
 
   return 1;
 }
 
-static int rc_validate_condset_internal(const rc_condset_t* condset, char result[], const size_t result_size, uint32_t console_id, uint32_t max_address, int has_hits)
+static int rc_validate_condset_internal(const rc_condset_t* condset, rc_validation_state_t* state)
 {
   const rc_condition_t* cond;
-  char buffer[128];
-  int index = 1;
   int in_add_hits = 0;
   int in_add_address = 0;
   int is_combining = 0;
   int has_measured = 0;
   int measuredif_index = -1;
 
-  if (!condset) {
-    *result = '\0';
+  if (!condset)
     return 1;
-  }
 
-  for (cond = condset->conditions; cond; cond = cond->next, ++index) {
+  state->cond_index = 1;
+
+  for (cond = condset->conditions; cond; cond = cond->next, ++state->cond_index) {
     /* validate the original operands first */
     const rc_operand_t* operand1 = rc_condition_get_real_operand1(cond);
     int is_memref1 = rc_operand_is_memref(operand1);
     const int is_memref2 = rc_operand_is_memref(&cond->operand2);
 
     if (!in_add_address) {
-      if (is_memref1 && !rc_validate_memref(operand1->value.memref, buffer, sizeof(buffer), console_id, max_address)) {
-        snprintf(result, result_size, "Condition %d: %s", index, buffer);
+      if (is_memref1 && !rc_validate_memref(operand1->value.memref, state))
         return 0;
-      }
-      if (is_memref2 && !rc_validate_memref(cond->operand2.value.memref, buffer, sizeof(buffer), console_id, max_address)) {
-        snprintf(result, result_size, "Condition %d: %s", index, buffer);
+      if (is_memref2 && !rc_validate_memref(cond->operand2.value.memref, state))
         return 0;
-      }
     }
     else {
       in_add_address = 0;
     }
 
     if (rc_operand_is_recall(operand1)) {
-      if (rc_operand_type_is_memref(operand1->memref_access_type) && !operand1->value.memref) {
-        snprintf(result, result_size, "Condition %d: Recall used before Remember", index);
-        return 0;
-      }
+      if (rc_operand_type_is_memref(operand1->memref_access_type) && !operand1->value.memref)
+        return rc_validate_add_error(state, RC_VALIDATION_ERR_RECALL_BEFORE_REMEMBER, 0, 0);
     }
 
     if (rc_operand_is_recall(&cond->operand2)) {
-      if (rc_operand_type_is_memref(cond->operand2.memref_access_type) && !cond->operand2.value.memref) {
-        snprintf(result, result_size, "Condition %d: Recall used before Remember", index);
-        return 0;
-      }
+      if (rc_operand_type_is_memref(cond->operand2.memref_access_type) && !cond->operand2.value.memref)
+        return rc_validate_add_error(state, RC_VALIDATION_ERR_RECALL_BEFORE_REMEMBER, 0, 0);
     }
 
     switch (cond->type) {
@@ -363,18 +619,13 @@ static int rc_validate_condset_internal(const rc_condset_t* condset, char result
         continue;
 
       case RC_CONDITION_ADD_ADDRESS:
-        if (operand1->type == RC_OPERAND_DELTA || operand1->type == RC_OPERAND_PRIOR) {
-          snprintf(result, result_size, "Condition %d: Using pointer from previous frame", index);
-          return 0;
-        }
-        if (rc_operand_is_float(operand1) || rc_operand_is_float(&cond->operand2)) {
-          snprintf(result, result_size, "Condition %d: Using non-integer value in AddAddress calcuation", index);
-          return 0;
-        }
-        if (rc_operand_type_is_transform(operand1->type) && cond->oper != RC_OPERATOR_MULT) {
-          snprintf(result, result_size, "Condition %d: Using transformed value in AddAddress calcuation", index);
-          return 0;
-        }
+        if (operand1->type == RC_OPERAND_DELTA || operand1->type == RC_OPERAND_PRIOR)
+          return rc_validate_add_error(state, RC_VALIDATION_ERR_POINTER_FROM_PREVIOUS_FRAME, 0, 0);
+        if (rc_operand_is_float(operand1) || rc_operand_is_float(&cond->operand2))
+          return rc_validate_add_error(state, RC_VALIDATION_ERR_POINTER_NON_INTEGER_OFFSET, 0, 0);
+        if (rc_operand_type_is_transform(operand1->type) && cond->oper != RC_OPERATOR_MULT)
+          return rc_validate_add_error(state, RC_VALIDATION_ERR_POINTER_TRANSFORMED_OFFSET, 0, 0);
+
         in_add_address = 1;
         is_combining = 1;
         continue;
@@ -399,28 +650,22 @@ static int rc_validate_condset_internal(const rc_condset_t* condset, char result
           is_combining = 0;
           break;
         }
-        if (!has_hits) {
-          snprintf(result, result_size, "Condition %d: No captured hits to reset", index);
-          return 0;
-        }
-        if (cond->required_hits == 1) {
-          snprintf(result, result_size, "Condition %d: Hit target of 1 is redundant on ResetIf", index);
-          return 0;
-        }
+        if (!state->has_hit_targets)
+          return rc_validate_add_error(state, RC_VALIDATION_ERR_NO_HITS_TO_RESET, 0, 0);
+        if (cond->required_hits == 1)
+          return rc_validate_add_error(state, RC_VALIDATION_ERR_RESET_HIT_TARGET_OF_ONE, 0, 0);
         /* fallthrough */ /* to default */
       default:
         if (in_add_hits) {
-          if (cond->required_hits == 0) {
-            snprintf(result, result_size, "Condition %d: Final condition in AddHits chain must have a hit target", index);
-            return 0;
-          }
+          if (cond->required_hits == 0)
+            return rc_validate_add_error(state, RC_VALIDATION_ERR_ADDHITS_WITHOUT_TARGET, 0, 0);
 
           in_add_hits = 0;
         }
 
         has_measured |= (cond->type == RC_CONDITION_MEASURED);
         if (cond->type == RC_CONDITION_MEASURED_IF && measuredif_index == -1)
-          measuredif_index = index;
+          measuredif_index = state->cond_index;
 
         is_combining = 0;
         break;
@@ -436,8 +681,7 @@ static int rc_validate_condset_internal(const rc_condset_t* condset, char result
         operand1->value.memref->value.memref_type == RC_MEMREF_TYPE_MEMREF &&
         cond->operand2.value.memref->value.memref_type == RC_MEMREF_TYPE_MEMREF &&
         rc_max_value(operand1) != rc_max_value(&cond->operand2)) {
-      snprintf(result, result_size, "Condition %d: Comparing different memory sizes", index);
-      return 0;
+      return rc_validate_add_error(state, RC_VALIDATION_ERR_COMPARING_DIFFERENT_MEMORY_SIZES, 0, 0);
     }
 
     if (is_memref1 && rc_operand_is_float(operand1)) {
@@ -445,12 +689,12 @@ static int rc_validate_condset_internal(const rc_condset_t* condset, char result
     }
     else if (is_memref1 || is_memref2) {
       /* if either side is a memref, check for impossible comparisons */
-      const size_t prefix_length = snprintf(result, result_size, "Condition %d: ", index);
       const rc_operand_t* operand2 = &cond->operand2;
       uint8_t oper = cond->oper;
       uint32_t min, max;
       uint32_t max_val = rc_max_value(operand2);
       uint32_t min_val;
+      rc_typed_value_t typed_value;
 
       rc_chain_get_value_range(operand1, &min, &max);
       if (min > max) { /* underflow */
@@ -485,14 +729,17 @@ static int rc_validate_condset_internal(const rc_condset_t* condset, char result
           if (!rc_operand_is_float_memref(operand1) && (float)min_val != operand2->value.dbl) {
             switch (oper) {
               case RC_OPERATOR_EQ:
-                snprintf(result + prefix_length, result_size - prefix_length, "Comparison is never true");
-                return 0;
+                typed_value.value.f32 = (float)operand2->value.dbl;
+                return rc_validate_add_error(state, RC_VALIDATION_ERR_COMPARISON_NEVER_TRUE_INTEGER_TO_FLOAT, typed_value.value.u32, 0);
+
               case RC_OPERATOR_NE:
-                snprintf(result + prefix_length, result_size - prefix_length, "Comparison is always true");
-                return 0;
+                typed_value.value.f32 = (float)operand2->value.dbl;
+                return rc_validate_add_error(state, RC_VALIDATION_ERR_COMPARISON_ALWAYS_TRUE_INTEGER_TO_FLOAT, typed_value.value.u32, 0);
+
               case RC_OPERATOR_GT: /* value could be greater than floor(float) */
               case RC_OPERATOR_LE: /* value could be less than or equal to floor(float) */
                 break;
+
               case RC_OPERATOR_GE: /* value could be greater than or equal to ceil(float) */
               case RC_OPERATOR_LT: /* value could be less than ceil(float) */
                 ++min_val;
@@ -508,22 +755,26 @@ static int rc_validate_condset_internal(const rc_condset_t* condset, char result
       }
 
       /* min_val and max_val are the range allowed by operand2. max is the upper value from operand1. */
-      if (!rc_validate_range(min_val, max_val, oper, max, result + prefix_length, result_size - prefix_length))
+      if (!rc_validate_range(min_val, max_val, oper, max, state))
         return 0;
     }
   }
 
   if (is_combining) {
-    snprintf(result, result_size, "Final condition type expects another condition to follow");
-    return 0;
+    /* find the final condition so we can extract the type */
+    state->cond_index--;
+    cond = condset->conditions;
+    while (cond->next)
+      cond = cond->next;
+
+    return rc_validate_add_error(state, RC_VALIDATION_ERR_TRAILING_CHAINING_CONDITION, cond->type, 0);
   }
 
   if (measuredif_index != -1 && !has_measured) {
-    snprintf(result, result_size, "Condition %d: MeasuredIf without Measured", measuredif_index);
-    return 0;
+    state->cond_index = measuredif_index;
+    return rc_validate_add_error(state, RC_VALIDATION_ERR_MEASUREDIF_WITHOUT_MEASURED, 0, 0);
   }
 
-  *result = '\0';
   return 1;
 }
 
@@ -551,17 +802,38 @@ static int rc_condset_has_hittargets(const rc_condset_t* condset)
 
 int rc_validate_condset(const rc_condset_t* condset, char result[], const size_t result_size, uint32_t max_address)
 {
-  int has_hits = rc_condset_has_hittargets(condset);
-  return rc_validate_condset_internal(condset, result, result_size, 0, max_address, has_hits);
+  rc_validation_state_t state;
+  memset(&state, 0, sizeof(state));
+  state.has_hit_targets = rc_condset_has_hittargets(condset);
+  state.max_address = max_address;
+
+  result[0] = '\0';
+  if (!rc_validate_condset_internal(condset, &state)) {
+    const rc_validation_error_t* most_severe_error = rc_validate_find_most_severe_error(&state);
+    return rc_validate_format_error(result, result_size, &state, most_severe_error);
+  }
+
+  return 1;
 }
 
 int rc_validate_condset_for_console(const rc_condset_t* condset, char result[], const size_t result_size, uint32_t console_id)
 {
-  const uint32_t max_address = rc_console_max_address(console_id);
-  int has_hits = rc_condset_has_hittargets(condset);
-  return rc_validate_condset_internal(condset, result, result_size, console_id, max_address, has_hits);
+  rc_validation_state_t state;
+  memset(&state, 0, sizeof(state));
+  state.console_id = console_id;
+  state.max_address = rc_console_max_address(console_id);
+  state.has_hit_targets = rc_condset_has_hittargets(condset);
+
+  result[0] = '\0';
+  if (!rc_validate_condset_internal(condset, &state)) {
+    const rc_validation_error_t* most_severe_error = rc_validate_find_most_severe_error(&state);
+    return rc_validate_format_error(result, result_size, &state, most_severe_error);
+  }
+
+  return 1;
 }
 
+/* rc_condition_is_combining doesn't look at conditions that build a memref (like AddSource) */
 static int rc_validate_is_combining_condition(const rc_condition_t* condition)
 {
   switch (condition->type)
@@ -781,7 +1053,7 @@ static int rc_validate_comparison_overlap(int comparison1, uint32_t value1, int 
 }
 
 static int rc_validate_conflicting_conditions(const rc_condset_t* conditions, const rc_condset_t* compare_conditions,
-    int has_hits, const char* prefix, const char* compare_prefix, char result[], const size_t result_size)
+    uint32_t group_index, rc_validation_state_t* state)
 {
   int comparison1, comparison2;
   uint32_t value1, value2;
@@ -790,6 +1062,7 @@ static int rc_validate_conflicting_conditions(const rc_condset_t* conditions, co
   const rc_condition_t* compare_condition;
   const rc_condition_t* condition;
   const rc_condition_t* condition_chain_start;
+  uint32_t condition_index;
   int overlap;
   int chain_matches;
 
@@ -798,11 +1071,13 @@ static int rc_validate_conflicting_conditions(const rc_condset_t* conditions, co
     return 1;
 
   /* outer loop is the source conditions */
-  for (condition = conditions->conditions; condition != NULL; condition = condition->next)
-  {
+  condition_index = 1;
+  for (condition = conditions->conditions; condition != NULL; condition = condition->next, ++state->cond_index) {
     condition_chain_start = condition;
-    while (condition && rc_condition_is_combining(condition))
+    while (condition && rc_condition_is_combining(condition)) {
+      ++condition_index;
       condition = condition->next;
+    }
     if (!condition)
       break;
 
@@ -814,8 +1089,7 @@ static int rc_validate_conflicting_conditions(const rc_condset_t* conditions, co
     if (!operand1)
       continue;
 
-    switch (condition->type)
-    {
+    switch (condition->type) {
       case RC_CONDITION_PAUSE_IF:
         if (conditions != compare_conditions)
           break;
@@ -830,13 +1104,14 @@ static int rc_validate_conflicting_conditions(const rc_condset_t* conditions, co
     }
 
     /* inner loop is the potentially conflicting conditions */
-    for (compare_condition = compare_conditions->conditions; compare_condition != NULL; compare_condition = compare_condition->next)
-    {
-      if (compare_condition == condition_chain_start)
-      {
+    state->cond_index = 1;
+    for (compare_condition = compare_conditions->conditions; compare_condition != NULL; compare_condition = compare_condition->next, ++state->cond_index) {
+      if (compare_condition == condition_chain_start) {
         /* skip condition we're already looking at */
-        while (compare_condition != condition)
+        while (compare_condition != condition) {
+          ++state->cond_index;
           compare_condition = compare_condition->next;
+        }
 
         continue;
       }
@@ -844,11 +1119,9 @@ static int rc_validate_conflicting_conditions(const rc_condset_t* conditions, co
       /* if combining conditions exist, make sure the same combining conditions exist in the
        * compare logic. conflicts can only occur if the combinining conditions match. */
       chain_matches = 1;
-      if (condition_chain_start != condition)
-      {
+      if (condition_chain_start != condition) {
         const rc_condition_t* condition_chain_iter = condition_chain_start;
-        while (condition_chain_iter != condition)
-        {
+        while (condition_chain_iter != condition) {
           if (compare_condition->type != condition_chain_iter->type ||
             compare_condition->oper != condition_chain_iter->oper ||
             compare_condition->required_hits != condition_chain_iter->required_hits ||
@@ -865,8 +1138,7 @@ static int rc_validate_conflicting_conditions(const rc_condset_t* conditions, co
             break;
           }
 
-          if (!compare_condition->next)
-          {
+          if (!compare_condition->next) {
             chain_matches = 0;
             break;
           }
@@ -881,14 +1153,14 @@ static int rc_validate_conflicting_conditions(const rc_condset_t* conditions, co
             break;
           }
 
+          ++state->cond_index;
           compare_condition = compare_condition->next;
           condition_chain_iter = condition_chain_iter->next;
         }
       }
 
       /* combining field didn't match, or there's more unmatched combining fields. ignore this condition */
-      if (!chain_matches || rc_validate_is_combining_condition(compare_condition))
-      {
+      if (!chain_matches || rc_validate_is_combining_condition(compare_condition)) {
         while (compare_condition->next && rc_validate_is_combining_condition(compare_condition))
           compare_condition = compare_condition->next;
         continue;
@@ -902,8 +1174,7 @@ static int rc_validate_conflicting_conditions(const rc_condset_t* conditions, co
           operand2->size != operand1->size || operand2->type != operand1->type)
         continue;
 
-      switch (compare_condition->type)
-      {
+      switch (compare_condition->type) {
         case RC_CONDITION_PAUSE_IF:
           if (conditions != compare_conditions) /* PauseIf only affects conditions in same group */
             break;
@@ -930,7 +1201,7 @@ static int rc_validate_conflicting_conditions(const rc_condset_t* conditions, co
           break;
 
         case RC_OVERLAP_REDUNDANT:
-          if (prefix != compare_prefix && strcmp(compare_prefix, "Core") == 0)
+          if (group_index != state->group_index && state->group_index == 0)
           {
             /* if the alt condition is more restrictive than the core condition, ignore it */
             if (rc_validate_comparison_overlap(comparison2, value2, comparison1, value1) != RC_OVERLAP_REDUNDANT)
@@ -955,14 +1226,14 @@ static int rc_validate_conflicting_conditions(const rc_condset_t* conditions, co
           {
             /* only ever report the redundancy on the non-ResetIf condition. The ResetIf is allowed to
              * fire when the non-ResetIf condition is not true. */
-            if (has_hits)
+            if (state->has_hit_targets)
               continue;
           }
           else if (condition->type == RC_CONDITION_RESET_IF && compare_condition->type != RC_CONDITION_RESET_IF)
           {
             /* if the ResetIf condition is more restrictive than the non-ResetIf condition,
                and there aren't any hits to clear, ignore it */
-            if (has_hits)
+            if (state->has_hit_targets)
               continue;
           }
           else if (compare_condition->type == RC_CONDITION_MEASURED_IF || condition->type == RC_CONDITION_MEASURED_IF)
@@ -990,88 +1261,90 @@ static int rc_validate_conflicting_conditions(const rc_condset_t* conditions, co
           continue;
       }
 
-      if (compare_prefix && *compare_prefix)
-      {
-        snprintf(result, result_size, "%s Condition %d: %s with %s Condition %d",
-            compare_prefix, rc_validate_get_condition_index(compare_conditions, compare_condition),
-            (overlap == RC_OVERLAP_REDUNDANT) ? "Redundant" : "Conflicts",
-            prefix, rc_validate_get_condition_index(conditions, condition));
-      }
-      else
-      {
-        snprintf(result, result_size, "Condition %d: %s with Condition %d",
-            rc_validate_get_condition_index(compare_conditions, compare_condition),
-            (overlap == RC_OVERLAP_REDUNDANT) ? "Redundant" : "Conflicts",
-            rc_validate_get_condition_index(conditions, condition));
-      }
-      return 0;
+      return rc_validate_add_error(state, (overlap == RC_OVERLAP_REDUNDANT) ?
+          RC_VALIDATION_ERR_REDUNDANT_CONDITION : RC_VALIDATION_ERR_CONFLICTING_CONDITION,
+          group_index, rc_validate_get_condition_index(conditions, condition));
     }
   }
 
   return 1;
 }
 
-static int rc_validate_trigger_internal(const rc_trigger_t* trigger, char result[], const size_t result_size, uint32_t console_id, uint32_t max_address)
+static int rc_validate_trigger_internal(const rc_trigger_t* trigger, rc_validation_state_t* state)
 {
-  const rc_condset_t* alt;
-  int index;
-  int has_hits = trigger->requirement && rc_condset_has_hittargets(trigger->requirement);
-  if (!has_hits) {
+  rc_condset_t* alt;
+  uint32_t index;
+
+  state->has_alt_groups = (trigger->alternative != NULL);
+
+  state->has_hit_targets = trigger->requirement && rc_condset_has_hittargets(trigger->requirement);
+  if (!state->has_hit_targets) {
     for (alt = trigger->alternative; alt; alt = alt->next) {
       if (rc_condset_has_hittargets(alt)) {
-        has_hits = 1;
+        state->has_hit_targets = 1;
         break;
       }
     }
   }
 
-  if (!trigger->alternative) {
-    if (!rc_validate_condset_internal(trigger->requirement, result, result_size, console_id, max_address, has_hits))
-      return 0;
-
-    return rc_validate_conflicting_conditions(trigger->requirement, trigger->requirement, has_hits, "", "", result, result_size);
-  }
-
-  snprintf(result, result_size, "Core ");
-  if (!rc_validate_condset_internal(trigger->requirement, result + 5, result_size - 5, console_id, max_address, has_hits))
+  state->group_index = 0;
+  if (!rc_validate_condset_internal(trigger->requirement, state))
     return 0;
 
   /* compare core to itself */
-  if (!rc_validate_conflicting_conditions(trigger->requirement, trigger->requirement, has_hits, "Core", "Core", result, result_size))
+  if (!rc_validate_conflicting_conditions(trigger->requirement, trigger->requirement, 0, state))
     return 0;
 
   index = 1;
   for (alt = trigger->alternative; alt; alt = alt->next, ++index) {
-    char altname[16];
-    const size_t prefix_length = snprintf(result, result_size, "Alt%d ", index);
-    if (!rc_validate_condset_internal(alt, result + prefix_length, result_size - prefix_length, console_id, max_address, has_hits))
+    state->group_index = index;
+    if (!rc_validate_condset_internal(alt, state))
       return 0;
 
     /* compare alt to itself */
-    snprintf(altname, sizeof(altname), "Alt%d", index);
-    if (!rc_validate_conflicting_conditions(alt, alt, has_hits, altname, altname, result, result_size))
+    if (!rc_validate_conflicting_conditions(alt, alt, index, state))
       return 0;
 
     /* compare alt to core */
-    if (!rc_validate_conflicting_conditions(trigger->requirement, alt, has_hits, "Core", altname, result, result_size))
+    if (!rc_validate_conflicting_conditions(trigger->requirement, alt, 0, state))
       return 0;
 
     /* compare core to alt */
-    if (!rc_validate_conflicting_conditions(alt, trigger->requirement, has_hits, altname, "Core", result, result_size))
+    state->group_index = 0;
+    if (!rc_validate_conflicting_conditions(alt, trigger->requirement, index, state))
       return 0;
   }
 
-  *result = '\0';
   return 1;
 }
 
 int rc_validate_trigger(const rc_trigger_t* trigger, char result[], const size_t result_size, uint32_t max_address)
 {
-  return rc_validate_trigger_internal(trigger, result, result_size, 0, max_address);
+  rc_validation_state_t state;
+  memset(&state, 0, sizeof(state));
+  state.max_address = max_address;
+
+  result[0] = '\0';
+  if (!rc_validate_trigger_internal(trigger, &state)) {
+    const rc_validation_error_t* most_severe_error = rc_validate_find_most_severe_error(&state);
+    return rc_validate_format_error(result, result_size, &state, most_severe_error);
+  }
+
+  return 1;
 }
 
 int rc_validate_trigger_for_console(const rc_trigger_t* trigger, char result[], const size_t result_size, uint32_t console_id)
 {
-  const uint32_t max_address = rc_console_max_address(console_id);
-  return rc_validate_trigger_internal(trigger, result, result_size, console_id, max_address);
+  rc_validation_state_t state;
+  memset(&state, 0, sizeof(state));
+  state.console_id = console_id;
+  state.max_address = rc_console_max_address(console_id);
+
+  result[0] = '\0';
+  if (!rc_validate_trigger_internal(trigger, &state)) {
+    const rc_validation_error_t* most_severe_error = rc_validate_find_most_severe_error(&state);
+    return rc_validate_format_error(result, result_size, &state, most_severe_error);
+  }
+
+  return 1;
 }

--- a/test/rcheevos/test_rc_validate.c
+++ b/test/rcheevos/test_rc_validate.c
@@ -460,6 +460,13 @@ void test_remember_recall_errors() {
   TEST_PARAMS2(test_validate_trigger, "K:0xH1234*2_{recall}=5_P:{recall}>6", "Condition 3: Recall used before Remember"); /* Pause happens before remembered value. */
 }
 
+void test_error_priorities() {
+  TEST_PARAMS2(test_validate_trigger, "R:0xH1234=1_0xH2345=500", "Condition 2: Comparison is never true (max 255)"); /* impossible condition more important than unnecessary reset */
+  TEST_PARAMS2(test_validate_trigger, "0xH1234>5_0xH1234!=0_A:0xH2345", "Condition 3: AddSource condition type expects another condition to follow"); /* impotent condition more important than redundant */
+  TEST_PARAMS2(test_validate_trigger, "0xH1234!=d0x 1234_I:d0x2345_0=6", "Condition 2: Using pointer from previous frame"); /* pointer math more important that potential logic errors */
+  TEST_PARAMS2(test_validate_trigger, "R:0xH1234=1.1.S0xH2345=500", "Alt1 Condition 1: Comparison is never true (max 255)"); /* impossible condition in alt more important than redundant condition in core */
+}
+
 void test_rc_validate(void) {
   TEST_SUITE_BEGIN();
 
@@ -482,6 +489,7 @@ void test_rc_validate(void) {
   test_redundant_hitcounts();
   test_variable_operand_errors();
   test_remember_recall_errors();
+  test_error_priorities();
 
   TEST_SUITE_END();
 }

--- a/test/rcheevos/test_rc_validate.c
+++ b/test/rcheevos/test_rc_validate.c
@@ -113,16 +113,16 @@ static void test_validate_trigger_console(const char* trigger, const char* expec
 }
 
 static void test_combining_conditions_at_end_of_definition() {
-  TEST_PARAMS2(test_validate_trigger, "0xH1234=1_A:0xH2345=2", "Final condition type expects another condition to follow");
-  TEST_PARAMS2(test_validate_trigger, "0xH1234=1_B:0xH2345=2", "Final condition type expects another condition to follow");
-  TEST_PARAMS2(test_validate_trigger, "0xH1234=1_C:0xH2345=2", "Final condition type expects another condition to follow");
-  TEST_PARAMS2(test_validate_trigger, "0xH1234=1_D:0xH2345=2", "Final condition type expects another condition to follow");
-  TEST_PARAMS2(test_validate_trigger, "0xH1234=1_N:0xH2345=2", "Final condition type expects another condition to follow");
-  TEST_PARAMS2(test_validate_trigger, "0xH1234=1_O:0xH2345=2", "Final condition type expects another condition to follow");
-  TEST_PARAMS2(test_validate_trigger, "0xH1234=1_Z:0xH2345=2", "Final condition type expects another condition to follow");
+  TEST_PARAMS2(test_validate_trigger, "0xH1234=1_A:0xH2345=2", "Condition 2: AddSource condition type expects another condition to follow");
+  TEST_PARAMS2(test_validate_trigger, "0xH1234=1_B:0xH2345=2", "Condition 2: SubSource condition type expects another condition to follow");
+  TEST_PARAMS2(test_validate_trigger, "0xH1234=1_C:0xH2345=2", "Condition 2: AddHits condition type expects another condition to follow");
+  TEST_PARAMS2(test_validate_trigger, "0xH1234=1_D:0xH2345=2", "Condition 2: SubHits condition type expects another condition to follow");
+  TEST_PARAMS2(test_validate_trigger, "0xH1234=1_N:0xH2345=2", "Condition 2: AndNext condition type expects another condition to follow");
+  TEST_PARAMS2(test_validate_trigger, "0xH1234=1_O:0xH2345=2", "Condition 2: OrNext condition type expects another condition to follow");
+  TEST_PARAMS2(test_validate_trigger, "0xH1234=1_Z:0xH2345=2", "Condition 2: ResetNextIf condition type expects another condition to follow");
 
-  TEST_PARAMS2(test_validate_trigger, "0xH1234=1_A:0xH2345=2S0x3456=1", "Core Final condition type expects another condition to follow");
-  TEST_PARAMS2(test_validate_trigger, "0x3456=1S0xH1234=1_A:0xH2345=2", "Alt1 Final condition type expects another condition to follow");
+  TEST_PARAMS2(test_validate_trigger, "0xH1234=1_A:0xH2345=2S0x3456=1", "Core Condition 2: AddSource condition type expects another condition to follow");
+  TEST_PARAMS2(test_validate_trigger, "0x3456=1S0xH1234=1_A:0xH2345=2", "Alt1 Condition 2: AddSource condition type expects another condition to follow");
 
   /* combining conditions not at end of definition */
   TEST_PARAMS2(test_validate_trigger, "A:0xH1234=1_0xH2345=2", "");
@@ -149,59 +149,59 @@ static void test_range_comparisons() {
 
   TEST_PARAMS2(test_validate_trigger, "0xH1234=255", "");
   TEST_PARAMS2(test_validate_trigger, "0xH1234!=255", "");
-  TEST_PARAMS2(test_validate_trigger, "0xH1234>255", "Condition 1: Comparison is never true");
+  TEST_PARAMS2(test_validate_trigger, "0xH1234>255", "Condition 1: Comparison is never true (max 255)");
   TEST_PARAMS2(test_validate_trigger, "0xH1234>=255", "");
   TEST_PARAMS2(test_validate_trigger, "0xH1234<255", "");
-  TEST_PARAMS2(test_validate_trigger, "0xH1234<=255", "Condition 1: Comparison is always true");
+  TEST_PARAMS2(test_validate_trigger, "0xH1234<=255", "Condition 1: Comparison is always true (max 255)");
 
   /* while a BCD value shouldn't exceed 99, it can reach 165: 0xFF => 15*10+15 */
   TEST_PARAMS2(test_validate_trigger, "b0xH1234<165", "");
-  TEST_PARAMS2(test_validate_trigger, "b0xH1234<=165", "Condition 1: Comparison is always true");
+  TEST_PARAMS2(test_validate_trigger, "b0xH1234<=165", "Condition 1: Comparison is always true (max 165)");
 
   TEST_PARAMS2(test_validate_trigger, "R:0xH1234<255_0xH0000=1.1.", "");
-  TEST_PARAMS2(test_validate_trigger, "R:0xH1234<=255_0xH0000=1.1.", "Condition 1: Comparison is always true");
+  TEST_PARAMS2(test_validate_trigger, "R:0xH1234<=255_0xH0000=1.1.", "Condition 1: Comparison is always true (max 255)");
 
-  TEST_PARAMS2(test_validate_trigger, "0xH1234=256", "Condition 1: Comparison is never true");
-  TEST_PARAMS2(test_validate_trigger, "0xH1234!=256", "Condition 1: Comparison is always true");
-  TEST_PARAMS2(test_validate_trigger, "0xH1234>256", "Condition 1: Comparison is never true");
-  TEST_PARAMS2(test_validate_trigger, "0xH1234>=256", "Condition 1: Comparison is never true");
-  TEST_PARAMS2(test_validate_trigger, "0xH1234<256", "Condition 1: Comparison is always true");
-  TEST_PARAMS2(test_validate_trigger, "0xH1234<=256", "Condition 1: Comparison is always true");
+  TEST_PARAMS2(test_validate_trigger, "0xH1234=256", "Condition 1: Comparison is never true (max 255)");
+  TEST_PARAMS2(test_validate_trigger, "0xH1234!=256", "Condition 1: Comparison is always true (max 255)");
+  TEST_PARAMS2(test_validate_trigger, "0xH1234>256", "Condition 1: Comparison is never true (max 255)");
+  TEST_PARAMS2(test_validate_trigger, "0xH1234>=256", "Condition 1: Comparison is never true (max 255)");
+  TEST_PARAMS2(test_validate_trigger, "0xH1234<256", "Condition 1: Comparison is always true (max 255)");
+  TEST_PARAMS2(test_validate_trigger, "0xH1234<=256", "Condition 1: Comparison is always true (max 255)");
 
   TEST_PARAMS2(test_validate_trigger, "0x 1234>=65535", "");
-  TEST_PARAMS2(test_validate_trigger, "0x 1234>=65536", "Condition 1: Comparison is never true");
+  TEST_PARAMS2(test_validate_trigger, "0x 1234>=65536", "Condition 1: Comparison is never true (max 65535)");
 
   TEST_PARAMS2(test_validate_trigger, "b0x 1234>=16665", "");
-  TEST_PARAMS2(test_validate_trigger, "b0x 1234>=16666", "Condition 1: Comparison is never true");
+  TEST_PARAMS2(test_validate_trigger, "b0x 1234>=16666", "Condition 1: Comparison is never true (max 16665)");
 
   TEST_PARAMS2(test_validate_trigger, "0xW1234>=16777215", "");
-  TEST_PARAMS2(test_validate_trigger, "0xW1234>=16777216", "Condition 1: Comparison is never true");
+  TEST_PARAMS2(test_validate_trigger, "0xW1234>=16777216", "Condition 1: Comparison is never true (max 16777215)");
 
   TEST_PARAMS2(test_validate_trigger, "b0xW1234>=1666665", "");
-  TEST_PARAMS2(test_validate_trigger, "b0xW1234>=1666666", "Condition 1: Comparison is never true");
+  TEST_PARAMS2(test_validate_trigger, "b0xW1234>=1666666", "Condition 1: Comparison is never true (max 1666665)");
 
   TEST_PARAMS2(test_validate_trigger, "0xX1234>=4294967295", "");
-  TEST_PARAMS2(test_validate_trigger, "0xX1234>4294967295", "Condition 1: Comparison is never true");
+  TEST_PARAMS2(test_validate_trigger, "0xX1234>4294967295", "Condition 1: Comparison is never true (max 4294967295)");
 
   TEST_PARAMS2(test_validate_trigger, "b0xX1234>=166666665", "");
-  TEST_PARAMS2(test_validate_trigger, "b0xX1234>=166666666", "Condition 1: Comparison is never true");
+  TEST_PARAMS2(test_validate_trigger, "b0xX1234>=166666666", "Condition 1: Comparison is never true (max 166666665)");
 
   TEST_PARAMS2(test_validate_trigger, "0xT1234>=1", "");
-  TEST_PARAMS2(test_validate_trigger, "0xT1234>1", "Condition 1: Comparison is never true");
+  TEST_PARAMS2(test_validate_trigger, "0xT1234>1", "Condition 1: Comparison is never true (max 1)");
 
   /* max for AddSource is the sum of all parts (255+255=510) */
   TEST_PARAMS2(test_validate_trigger, "A:0xH1234_0<255", "");
-  TEST_PARAMS2(test_validate_trigger, "A:0xH1234_0<=255", "Condition 2: Comparison is always true");
+  TEST_PARAMS2(test_validate_trigger, "A:0xH1234_0<=255", "Condition 2: Comparison is always true (max 255)");
   TEST_PARAMS2(test_validate_trigger, "A:0xH1234_0xH1235<510", "");
-  TEST_PARAMS2(test_validate_trigger, "A:0xH1234_0xH1235<=510", "Condition 2: Comparison is always true");
+  TEST_PARAMS2(test_validate_trigger, "A:0xH1234_0xH1235<=510", "Condition 2: Comparison is always true (max 510)");
   TEST_PARAMS2(test_validate_trigger, "A:0xH1234*10_0xH1235>=2805", "");
-  TEST_PARAMS2(test_validate_trigger, "A:0xH1234*10_0xH1235>2805", "Condition 2: Comparison is never true");
+  TEST_PARAMS2(test_validate_trigger, "A:0xH1234*10_0xH1235>2805", "Condition 2: Comparison is never true (max 2805)");
   TEST_PARAMS2(test_validate_trigger, "A:0xH1234/10_0xH1235>=280", "");
-  TEST_PARAMS2(test_validate_trigger, "A:0xH1234/10_0xH1235>280", "Condition 2: Comparison is never true");
+  TEST_PARAMS2(test_validate_trigger, "A:0xH1234/10_0xH1235>280", "Condition 2: Comparison is never true (max 280)");
   TEST_PARAMS2(test_validate_trigger, "A:0xH1234&10_0xH1235>=265", "");
-  TEST_PARAMS2(test_validate_trigger, "A:0xH1234&10_0xH1235>265", "Condition 2: Comparison is never true");
+  TEST_PARAMS2(test_validate_trigger, "A:0xH1234&10_0xH1235>265", "Condition 2: Comparison is never true (max 265)");
   TEST_PARAMS2(test_validate_trigger, "A:b0xH1234*100_b0xH1235>=16665", "");
-  TEST_PARAMS2(test_validate_trigger, "A:b0xH1234*100_b0xH1235>16665", "Condition 2: Comparison is never true");
+  TEST_PARAMS2(test_validate_trigger, "A:b0xH1234*100_b0xH1235>16665", "Condition 2: Comparison is never true (max 16665)");
 
   /* max for SubSource is always 0xFFFFFFFF */
   TEST_PARAMS2(test_validate_trigger, "B:0xH1234_0xH1235<510", "");
@@ -213,7 +213,7 @@ static void test_range_comparisons() {
   TEST_PARAMS2(test_validate_trigger, "I:0xG1234&536870911_R:0xG0000=4294967294_0xH2222=1.1.", "");
 
   TEST_PARAMS2(test_validate_trigger, "B:0xH1241/0xH1241_B:0xH124c/0xH124c_M:2=2", "");
-  TEST_PARAMS2(test_validate_trigger, "B:0xH1241/0xH1241_B:0xH124c/0xH124c_M:2>2", "Condition 3: Comparison is never true");
+  TEST_PARAMS2(test_validate_trigger, "B:0xH1241/0xH1241_B:0xH124c/0xH124c_M:2>2", "Condition 3: Comparison is never true (max 2)");
 }
 
 void test_size_comparisons() {
@@ -285,13 +285,13 @@ void test_delta_pointers() {
 }
 
 void test_nonsized_pointers() {
-  TEST_PARAMS2(test_validate_trigger, "I:Ff1234_0xH0000=1", "Condition 1: Using non-integer value in AddAddress calcuation");
-  TEST_PARAMS2(test_validate_trigger, "I:Fb1234_0xH0000=1", "Condition 1: Using non-integer value in AddAddress calcuation");
-  TEST_PARAMS2(test_validate_trigger, "I:Fm1234_0xH0000=1", "Condition 1: Using non-integer value in AddAddress calcuation");
-  TEST_PARAMS2(test_validate_trigger, "I:Fh1234_0xH0000=1", "Condition 1: Using non-integer value in AddAddress calcuation");
-  TEST_PARAMS2(test_validate_trigger, "I:0xH1234*f1.5_0xH0000=1", "Condition 1: Using non-integer value in AddAddress calcuation");
-  TEST_PARAMS2(test_validate_trigger, "I:b0xH1234_0xH0000=1", "Condition 1: Using transformed value in AddAddress calcuation");
-  TEST_PARAMS2(test_validate_trigger, "I:~0xH1234_0xH0000=1", "Condition 1: Using transformed value in AddAddress calcuation");
+  TEST_PARAMS2(test_validate_trigger, "I:Ff1234_0xH0000=1", "Condition 1: Using non-integer value in AddAddress calculation");
+  TEST_PARAMS2(test_validate_trigger, "I:Fb1234_0xH0000=1", "Condition 1: Using non-integer value in AddAddress calculation");
+  TEST_PARAMS2(test_validate_trigger, "I:Fm1234_0xH0000=1", "Condition 1: Using non-integer value in AddAddress calculation");
+  TEST_PARAMS2(test_validate_trigger, "I:Fh1234_0xH0000=1", "Condition 1: Using non-integer value in AddAddress calculation");
+  TEST_PARAMS2(test_validate_trigger, "I:0xH1234*f1.5_0xH0000=1", "Condition 1: Using non-integer value in AddAddress calculation");
+  TEST_PARAMS2(test_validate_trigger, "I:b0xH1234_0xH0000=1", "Condition 1: Using transformed value in AddAddress calculation");
+  TEST_PARAMS2(test_validate_trigger, "I:~0xH1234_0xH0000=1", "Condition 1: Using transformed value in AddAddress calculation");
   TEST_PARAMS2(test_validate_trigger, "I:~0xH1234*1_0xH0000=1", ""); /* don't report scaled values - assume indexed array */
   TEST_PARAMS2(test_validate_trigger, "I:~0xM1234*4096_0xH0000=1", ""); /* don't report scaled values - assume indexed array */
   TEST_PARAMS2(test_validate_trigger, "I:b0x 1234*8_0xH0000=1", ""); /* don't report scaled values - assume indexed array */
@@ -302,21 +302,21 @@ void test_float_comparisons() {
   TEST_PARAMS2(test_validate_trigger, "fM1234=f2.3", "");
   TEST_PARAMS2(test_validate_trigger, "fF1234=2", "");
   TEST_PARAMS2(test_validate_trigger, "0xX1234=2", "");
-  TEST_PARAMS2(test_validate_trigger, "0xX1234=f2.3", "Condition 1: Comparison is never true"); /* non integral comparison */
-  TEST_PARAMS2(test_validate_trigger, "0xX1234!=f2.3", "Condition 1: Comparison is always true"); /* non integral comparison */
+  TEST_PARAMS2(test_validate_trigger, "0xX1234=f2.3", "Condition 1: Comparison is never true (integer can never be 2.3)"); /* non integral comparison */
+  TEST_PARAMS2(test_validate_trigger, "0xX1234!=f2.3", "Condition 1: Comparison is always true (integer can never be 2.3)"); /* non integral comparison */
   TEST_PARAMS2(test_validate_trigger, "0xX1234<f2.3", ""); /* will be converted to < 3 */
   TEST_PARAMS2(test_validate_trigger, "0xX1234<=f2.3", ""); /* will be converted to <= 2 */
   TEST_PARAMS2(test_validate_trigger, "0xX1234>f2.3", ""); /* will be converted to > 2 */
   TEST_PARAMS2(test_validate_trigger, "0xX1234>=f2.3", ""); /* will be converted to >= 3 */
   TEST_PARAMS2(test_validate_trigger, "0xX1234=f2.0", ""); /* float can be converted to int without loss of data*/
-  TEST_PARAMS2(test_validate_trigger, "0xH1234=f2.3", "Condition 1: Comparison is never true");
-  TEST_PARAMS2(test_validate_trigger, "0xH1234=f300.0", "Condition 1: Comparison is never true"); /* value out of range */
+  TEST_PARAMS2(test_validate_trigger, "0xH1234=f2.3", "Condition 1: Comparison is never true (integer can never be 2.3)");
+  TEST_PARAMS2(test_validate_trigger, "0xH1234=f300.0", "Condition 1: Comparison is never true (max 255)"); /* value out of range */
   TEST_PARAMS2(test_validate_trigger, "f2.3=fF1234", "");
-  TEST_PARAMS2(test_validate_trigger, "f2.3=0xX1234", "Condition 1: Comparison is never true"); /* non integral comparison */
+  TEST_PARAMS2(test_validate_trigger, "f2.3=0xX1234", "Condition 1: Comparison is never true (integer can never be 2.3)"); /* non integral comparison */
   TEST_PARAMS2(test_validate_trigger, "f2.0=0xX1234", "");
   TEST_PARAMS2(test_validate_trigger, "A:Ff2345_fF1234=f2.3", "");
   TEST_PARAMS2(test_validate_trigger, "A:0xX2345_fF1234=f2.3", "");
-  TEST_PARAMS2(test_validate_trigger, "A:Ff2345_0x1234=f2.3", "Condition 2: Comparison is never true"); /* non integral comparison */
+  TEST_PARAMS2(test_validate_trigger, "A:Ff2345_0x1234=f2.3", "Condition 2: Comparison is never true (integer can never be 2.3)"); /* non integral comparison */
   TEST_PARAMS2(test_validate_trigger, "fM1234>f2.3", "");
   TEST_PARAMS2(test_validate_trigger, "fM1234>f-2.3", "");
   TEST_PARAMS2(test_validate_trigger, "I:0xX2345_fM1234>f1.0", "");
@@ -328,9 +328,9 @@ void test_float_comparisons() {
   TEST_PARAMS2(test_validate_trigger, "fM1234>=0", "");
   TEST_PARAMS2(test_validate_trigger, "fB1234>=0", "");
   TEST_PARAMS2(test_validate_trigger, "0xH1234>=f0.1", ""); /* 0 can be less than 0.1 */
-  TEST_PARAMS2(test_validate_trigger, "0xH1234>=f255.1", "Condition 1: Comparison is never true"); /* 255 cannot be >= 255.1 */
+  TEST_PARAMS2(test_validate_trigger, "0xH1234>=f255.1", "Condition 1: Comparison is never true (max 255)"); /* 255 cannot be >= 255.1 */
   TEST_PARAMS2(test_validate_trigger, "f0.1<=0xH1234", ""); /* 0 can be less than 0.1 */
-  TEST_PARAMS2(test_validate_trigger, "f255.1<=0xH1234", "Condition 1: Comparison is never true"); /* 255 cannot be >= 255.1 */
+  TEST_PARAMS2(test_validate_trigger, "f255.1<=0xH1234", "Condition 1: Comparison is never true (max 255)"); /* 255 cannot be >= 255.1 */
 }
 
 void test_dependent_conditions() {


### PR DESCRIPTION
Ensures things like "using an invalid address" in an alt are reported before things like "no hits to reset" in the core group.