### PR TITLE
don't send pings if not processing frames

### DIFF
--- a/src/rc_client.c
+++ b/src/rc_client.c
@@ -1720,10 +1720,13 @@ static void rc_client_activate_game(rc_client_load_state_t* load_state, rc_api_s
 
     /* make the loaded game active if another game is not aleady being loaded. */
     rc_mutex_lock(&client->state.mutex);
-    if (client->state.load == load_state)
+    if (client->state.load == load_state) {
       client->game = load_state->game;
-    else
+      client->state.frames_processed = client->state.frames_at_last_ping = 0;
+    }
+    else {
       load_state->progress = RC_CLIENT_LOAD_GAME_STATE_ABORTED;
+    }
     rc_mutex_unlock(&client->state.mutex);
 
     if (load_state->progress != RC_CLIENT_LOAD_GAME_STATE_ABORTED) {
@@ -2352,6 +2355,7 @@ static int rc_client_attach_load_state(rc_client_t* client, rc_client_load_state
 
     rc_mutex_lock(&client->state.mutex);
     client->state.load = load_state;
+    client->state.frames_processed = client->state.frames_at_last_ping = 0;
     rc_mutex_unlock(&client->state.mutex);
   }
   else if (client->state.load != load_state) {
@@ -5160,30 +5164,37 @@ static void rc_client_ping(rc_client_scheduled_callback_data_t* callback_data, r
   char buffer[256];
   int result;
 
-  if (!client->callbacks.rich_presence_override ||
-      !client->callbacks.rich_presence_override(client, buffer, sizeof(buffer))) {
-    rc_mutex_lock(&client->state.mutex);
+  /* if no frames have been processed since the last ping, the emulator is idle. let the
+   * server session expire. it will be resumed/restarted once frames start getting
+   * processed again. */
+  if (client->state.frames_processed != client->state.frames_at_last_ping) {
+    client->state.frames_at_last_ping = client->state.frames_processed;
 
-    rc_runtime_get_richpresence(&client->game->runtime, buffer, sizeof(buffer),
-        client->state.legacy_peek, client, NULL);
+    if (!client->callbacks.rich_presence_override ||
+        !client->callbacks.rich_presence_override(client, buffer, sizeof(buffer))) {
+      rc_mutex_lock(&client->state.mutex);
 
-    rc_mutex_unlock(&client->state.mutex);
-  }
+      rc_runtime_get_richpresence(&client->game->runtime, buffer, sizeof(buffer),
+          client->state.legacy_peek, client, NULL);
 
-  memset(&api_params, 0, sizeof(api_params));
-  api_params.username = client->user.username;
-  api_params.api_token = client->user.token;
-  api_params.game_id = client->game->public_.id;
-  api_params.rich_presence = buffer;
-  api_params.game_hash = client->game->public_.hash;
-  api_params.hardcore = client->state.hardcore;
+      rc_mutex_unlock(&client->state.mutex);
+    }
 
-  result = rc_api_init_ping_request_hosted(&request, &api_params, &client->state.host);
-  if (result != RC_OK) {
-    RC_CLIENT_LOG_WARN_FORMATTED(client, "Error generating ping request: %s", rc_error_str(result));
-  }
-  else {
-    client->callbacks.server_call(&request, rc_client_ping_callback, client, client);
+    memset(&api_params, 0, sizeof(api_params));
+    api_params.username = client->user.username;
+    api_params.api_token = client->user.token;
+    api_params.game_id = client->game->public_.id;
+    api_params.rich_presence = buffer;
+    api_params.game_hash = client->game->public_.hash;
+    api_params.hardcore = client->state.hardcore;
+
+    result = rc_api_init_ping_request_hosted(&request, &api_params, &client->state.host);
+    if (result != RC_OK) {
+      RC_CLIENT_LOG_WARN_FORMATTED(client, "Error generating ping request: %s", rc_error_str(result));
+    }
+    else {
+      client->callbacks.server_call(&request, rc_client_ping_callback, client, client);
+    }
   }
 
   callback_data->when = now + 120 * 1000;
@@ -5885,6 +5896,8 @@ void rc_client_do_frame(rc_client_t* client)
     rc_mutex_unlock(&client->state.mutex);
 
     rc_client_raise_pending_events(client, client->game);
+
+    ++client->state.frames_processed;
   }
 
   /* we've processed a frame. if there's a pause delay in effect, process it */

--- a/src/rc_client_internal.h
+++ b/src/rc_client_internal.h
@@ -316,6 +316,8 @@ typedef struct rc_client_state_t {
   rc_client_raintegration_t* raintegration;
 #endif
 
+  uint32_t frames_processed;
+  uint32_t frames_at_last_ping;
   uint16_t unpaused_frame_decay;
   uint16_t required_unpaused_frames;
 

--- a/test/test_rc_client.c
+++ b/test/test_rc_client.c
@@ -8733,7 +8733,10 @@ static void test_idle_ping(void)
 
     mock_api_response("r=ping&u=Username&t=ApiToken&g=1234&h=1&x=0123456789ABCDEF", "{\"Success\":true}");
 
+    g_client->state.frames_processed++; /* ping won't get called if no frames have been processed */
     rc_client_idle(g_client);
+
+    assert_api_called("r=ping&u=Username&t=ApiToken&g=1234&h=1&x=0123456789ABCDEF");
 
     ASSERT_PTR_NOT_NULL(g_client->state.scheduled_callbacks);
     ASSERT_NUM_EQUALS(g_client->state.scheduled_callbacks->when, g_now + 120 * 1000);
@@ -8770,7 +8773,10 @@ static void test_do_frame_ping_rich_presence(void)
     /* before rc_client_do_frame, memory will not have been read. all values will be 0 */
     mock_api_response("r=ping&u=Username&t=ApiToken&g=1234&m=Points%3a0&h=1&x=0123456789ABCDEF", "{\"Success\":true}");
 
+    g_client->state.frames_processed++; /* ping won't get called if no frames have been processed */
     rc_client_idle(g_client);
+
+    assert_api_called("r=ping&u=Username&t=ApiToken&g=1234&m=Points%3a0&h=1&x=0123456789ABCDEF");
 
     ASSERT_PTR_NOT_NULL(g_client->state.scheduled_callbacks);
     ASSERT_PTR_EQUALS(g_client->state.scheduled_callbacks->callback, ping_callback);
@@ -8849,19 +8855,16 @@ static void test_do_frame_ping_rich_presence_override_allowed(void)
 
     mock_memory(memory, sizeof(memory));
     memory[0x03] = 25;
+    mock_api_response("r=ping&u=Username&t=ApiToken&g=1234&m=Points%3a25&h=1&x=0123456789ABCDEF", "{\"Success\":true}");
 
-    /* before rc_client_do_frame, memory will not have been read. all values will be 0 */
-    mock_api_response("r=ping&u=Username&t=ApiToken&g=1234&m=Points%3a0&h=1&x=0123456789ABCDEF", "{\"Success\":true}");
+    /* ping won't get called if no frames have been processed. do_frame will increment frames_processed */
+    rc_client_do_frame(g_client);
 
-    rc_client_idle(g_client);
+    assert_api_called("r=ping&u=Username&t=ApiToken&g=1234&m=Points%3a25&h=1&x=0123456789ABCDEF");
 
     ASSERT_PTR_NOT_NULL(g_client->state.scheduled_callbacks);
     ASSERT_PTR_EQUALS(g_client->state.scheduled_callbacks->callback, ping_callback);
     ASSERT_NUM_EQUALS(g_client->state.scheduled_callbacks->when, g_now + 120 * 1000);
-    g_now += 120 * 1000;
-
-    /* rc_client_do_frame will update the memory, so the message will contain appropriate data */
-    mock_api_response("r=ping&u=Username&t=ApiToken&g=1234&m=Points%3a25&h=1&x=0123456789ABCDEF", "{\"Success\":true}");
   }
 
   rc_client_destroy(g_client);
@@ -8892,7 +8895,10 @@ static void test_do_frame_ping_rich_presence_override_replaced(void)
     /* before rc_client_do_frame, can_submit only ignores the m parameter. ping still occurs */
     mock_api_response("r=ping&u=Username&t=ApiToken&g=1234&m=Custom&h=1&x=0123456789ABCDEF", "{\"Success\":true}");
 
-    rc_client_idle(g_client);
+    /* ping won't get called if no frames have been processed. do_frame will increment frames_processed */
+    rc_client_do_frame(g_client);
+
+    assert_api_called("r=ping&u=Username&t=ApiToken&g=1234&m=Custom&h=1&x=0123456789ABCDEF");
 
     ASSERT_PTR_NOT_NULL(g_client->state.scheduled_callbacks);
     ASSERT_PTR_EQUALS(g_client->state.scheduled_callbacks->callback, ping_callback);
@@ -8905,6 +8911,69 @@ static void test_do_frame_ping_rich_presence_override_replaced(void)
 
   rc_client_destroy(g_client);
 }
+
+static void test_idle_ping_while_not_running(void)
+{
+  uint8_t memory[64];
+  memset(memory, 0, sizeof(memory));
+
+  g_client = mock_client_game_loaded(patchdata_exhaustive, no_unlocks);
+
+  ASSERT_PTR_NOT_NULL(g_client->game);
+  if (g_client->game) {
+    rc_client_scheduled_callback_t ping_callback;
+    memory[0x03] = 25;
+    mock_memory(memory, sizeof(memory));
+
+    ASSERT_PTR_NOT_NULL(g_client->state.scheduled_callbacks);
+    ping_callback = g_client->state.scheduled_callbacks->callback;
+
+    ASSERT_NUM_EQUALS(g_client->state.scheduled_callbacks->when, g_now + 30 * 1000);
+    g_now += 30 * 1000;
+
+    mock_api_response("r=ping&u=Username&t=ApiToken&g=1234&m=Points%3a25&h=1&x=0123456789ABCDEF", "{\"Success\":true}");
+
+    /* if no frames have been processed since the last ping, a ping shouldn't be sent */
+    g_client->state.frames_processed = g_client->state.frames_at_last_ping;
+    rc_client_idle(g_client);
+
+    assert_api_not_called("r=ping&u=Username&t=ApiToken&g=1234&m=Points%3a25&h=1&x=0123456789ABCDEF");
+
+    ASSERT_PTR_NOT_NULL(g_client->state.scheduled_callbacks);
+    ASSERT_NUM_EQUALS(g_client->state.scheduled_callbacks->when, g_now + 120 * 1000);
+    ASSERT_PTR_EQUALS(g_client->state.scheduled_callbacks->callback, ping_callback);
+    g_now += 120 * 1000;
+
+    /* do_frame will increment frames_processed, and ping will get called */
+
+    rc_client_do_frame(g_client);
+
+    assert_api_called("r=ping&u=Username&t=ApiToken&g=1234&m=Points%3a25&h=1&x=0123456789ABCDEF");
+
+    ASSERT_PTR_NOT_NULL(g_client->state.scheduled_callbacks);
+    ASSERT_PTR_EQUALS(g_client->state.scheduled_callbacks->callback, ping_callback);
+    ASSERT_NUM_EQUALS(g_client->state.scheduled_callbacks->when, g_now + 120 * 1000);
+    g_now += 120 * 1000;
+
+    /* no frames processed. ping shouldn't be sent, but still rescheduled */
+
+    rc_client_idle(g_client);
+
+    assert_api_call_count("r=ping&u=Username&t=ApiToken&g=1234&m=Points%3a25&h=1&x=0123456789ABCDEF", 1);
+
+    ASSERT_PTR_NOT_NULL(g_client->state.scheduled_callbacks);
+    ASSERT_NUM_EQUALS(g_client->state.scheduled_callbacks->when, g_now + 120 * 1000);
+    ASSERT_PTR_EQUALS(g_client->state.scheduled_callbacks->callback, ping_callback);
+  }
+
+  /* unloading game should unschedule ping */
+  rc_client_unload_game(g_client);
+  ASSERT_PTR_NULL(g_client->state.scheduled_callbacks);
+
+  rc_client_destroy(g_client);
+}
+
+/* ----- reset ----- */
 
 static void test_reset_hides_widgets(void)
 {
@@ -10133,6 +10202,7 @@ void test_client(void) {
   TEST(test_do_frame_ping_rich_presence);
   TEST(test_do_frame_ping_rich_presence_override_allowed);
   TEST(test_do_frame_ping_rich_presence_override_replaced);
+  TEST(test_idle_ping_while_not_running);
 
   /* reset */
   TEST(test_reset_hides_widgets);


### PR DESCRIPTION
Allows the server to suspend session while the user has the **emulator** paused, generating more accurate playtime statistics. If the user just pauses in game, the session won't be suspended.