### PR TITLE
greatly improve performance converting long AddSource chains into modified_memref chains

### DIFF
--- a/src/rcheevos/condset.c
+++ b/src/rcheevos/condset.c
@@ -62,8 +62,10 @@ static int32_t rc_classify_conditions(rc_condset_t* self, const char* memaddr, c
   do {
     rc_parse_condition_internal(&condition, &memaddr, &parse);
 
-    if (parse.offset < 0)
+    if (parse.offset < 0) {
+      rc_destroy_parse_state(&parse);
       return parse.offset;
+    }
 
     ++index;
 
@@ -106,7 +108,9 @@ static int32_t rc_classify_conditions(rc_condset_t* self, const char* memaddr, c
    * logic in rc_find_next_classification */
   self->num_other_conditions += chain_length - 1;
 
-  return index;
+  rc_destroy_parse_state(&parse);
+
+  return (int32_t)index;
 }
 
 static int rc_find_next_classification(const char* memaddr) {

--- a/src/rcheevos/memref.c
+++ b/src/rcheevos/memref.c
@@ -154,7 +154,13 @@ rc_modified_memref_t* rc_alloc_modified_memref(rc_parse_state_t* parse, uint8_t 
   memcpy(&modified_memref->parent, parent, sizeof(modified_memref->parent));
   memcpy(&modified_memref->modifier, modifier, sizeof(modified_memref->modifier));
   modified_memref->modifier_type = modifier_type;
+  modified_memref->depth = 0;
   modified_memref->memref.address = rc_operand_is_memref(modifier) ? modifier->value.memref->address : modifier->value.num;
+
+  if (rc_operand_is_memref(parent) && parent->value.memref->value.memref_type == RC_MEMREF_TYPE_MODIFIED_MEMREF) {
+    const rc_modified_memref_t* parent_modified_memref = (rc_modified_memref_t*)parent->value.memref;
+    modified_memref->depth = parent_modified_memref->depth + 1;
+  }
 
   return modified_memref;
 }

--- a/src/rcheevos/operand.c
+++ b/src/rcheevos/operand.c
@@ -334,8 +334,11 @@ int rc_operands_are_equal(const rc_operand_t* left, const rc_operand_t* right) {
       const rc_modified_memref_t* left_memref = (const rc_modified_memref_t*)left->value.memref;
       const rc_modified_memref_t* right_memref = (const rc_modified_memref_t*)right->value.memref;
       return (left_memref->modifier_type == right_memref->modifier_type &&
+              left_memref->depth == right_memref->depth &&
+              rc_operands_are_equal(&left_memref->modifier, &right_memref->modifier) &&
               rc_operands_are_equal(&left_memref->parent, &right_memref->parent) &&
-              rc_operands_are_equal(&left_memref->modifier, &right_memref->modifier));
+              1 == 1
+        );
     }
 
     default:

--- a/src/rcheevos/rc_internal.h
+++ b/src/rcheevos/rc_internal.h
@@ -14,10 +14,11 @@ typedef struct rc_scratch_string {
 rc_scratch_string_t;
 
 typedef struct rc_modified_memref_t {
-  rc_memref_t memref;              /* for compatibility with rc_operand_t.value.memref */
+  rc_memref_t memref;              /* For compatibility with rc_operand_t.value.memref */
   rc_operand_t parent;             /* The parent memref this memref is derived from (type will always be a memref type) */
   rc_operand_t modifier;           /* The modifier to apply to the parent. */
   uint8_t modifier_type;           /* How to apply the modifier to the parent. (RC_OPERATOR_*) */
+  uint16_t depth;                  /* The number of parents this memref has. */
 }
 rc_modified_memref_t;
 

--- a/test/rcheevos/test_condset.c
+++ b/test/rcheevos/test_condset.c
@@ -3,7 +3,7 @@
 #include "../test_framework.h"
 #include "mock_memory.h"
 
-#include <stdlib.h>
+#include "../src/rc_compat.h"
 
 static void _assert_parse_condset(rc_condset_t** condset, rc_memrefs_t* memrefs, void* buffer, const char* memaddr)
 {
@@ -2880,6 +2880,7 @@ static void test_addsource_long_chain() {
   const size_t buffer_size = 384 * cond_count;
   char* buffer = (char*)malloc(buffer_size);
   char* ptr = buffer;
+  const char* memaddr = buffer;
   rc_condset_t* condset;
   rc_memrefs_t memrefs;
   rc_parse_state_t parse;
@@ -2900,8 +2901,7 @@ static void test_addsource_long_chain() {
   rc_init_parse_state_memrefs(&parse, &memrefs);
 
   start = clock();
-  ptr = buffer;
-  condset = rc_parse_condset(&ptr, &parse);
+  condset = rc_parse_condset(&memaddr, &parse);
   end = clock();
 
   rc_destroy_parse_state(&parse);

--- a/test/rcheevos/test_condset.c
+++ b/test/rcheevos/test_condset.c
@@ -2878,27 +2878,16 @@ static void test_addsource_long_chain() {
    */
   const size_t cond_count = 1500;
   const size_t buffer_size = 384 * cond_count;
-  char* buffer;
-  char* ptr;
-  const char* memaddr;
+  char* buffer = (char*)malloc(buffer_size);
+  char* ptr = buffer;
+  const char* memaddr = buffer;
   rc_condset_t* condset;
   rc_memrefs_t memrefs;
   rc_parse_state_t parse;
   clock_t start, end;
   size_t i, len, remaining;
 
-  printf("[%u]\n", (uint32_t)buffer_size);
-  fflush(stdout);
-
-  memaddr = ptr = buffer = (char*)malloc(buffer_size);
-
-  printf("a\n");
-  fflush(stdout);
-
   ASSERT_PTR_NOT_NULL(buffer);
-
-  printf("b\n");
-  fflush(stdout);
 
   remaining = buffer_size;
   for (i = 0; i < cond_count; i++) {
@@ -2916,47 +2905,26 @@ static void test_addsource_long_chain() {
   }
   ptr += snprintf(ptr, remaining, "=499");
 
-  printf("1\n");
-  fflush(stdout);
-
   ptr = (char*)RC_ALIGN((size_t)ptr);
   remaining = buffer_size - (ptr - buffer);
 
-  printf("2\n");
-  fflush(stdout);
-
   rc_init_parse_state(&parse, ptr);
   rc_init_parse_state_memrefs(&parse, &memrefs);
-
-  printf("3\n");
-  fflush(stdout);
 
   start = clock();
   condset = rc_parse_condset(&memaddr, &parse);
   end = clock();
 
-  printf("4\n");
-  fflush(stdout);
-
   rc_destroy_parse_state(&parse);
-
-  printf("5\n");
-  fflush(stdout);
 
   ASSERT_NUM_GREATER(parse.offset, 0);
   ASSERT_NUM_LESS(parse.offset, remaining);
   ASSERT_PTR_NOT_NULL(condset);
 
-  printf("6\n");
-  fflush(stdout);
-
   double elapsed = (double)(end - start) * 1000 / CLOCKS_PER_SEC;
   /* this shouldn't take more than 20-40ms (depending on the machine its running on).
    * allow up to 1 full second before this errors. it was taking over 10s when reported */
   ASSERT_NUM_LESS(elapsed, 1000);
-
-  printf("7\n");
-  fflush(stdout);
 
   /* each condition and its delta should share a memref */
   ASSERT_NUM_EQUALS(rc_memrefs_count_memrefs(&memrefs), cond_count);
@@ -2964,13 +2932,7 @@ static void test_addsource_long_chain() {
    * plus one for the final condition: cond_count - 1 + 1 */
   ASSERT_NUM_EQUALS(rc_memrefs_count_modified_memrefs(&memrefs), cond_count);
 
-  printf("8\n");
-  fflush(stdout);
-
   free(buffer);
-
-  printf("9\n");
-  fflush(stdout);
 }
 
 static void test_addhits() {

--- a/test/rcheevos/test_condset.c
+++ b/test/rcheevos/test_condset.c
@@ -3,6 +3,8 @@
 #include "../test_framework.h"
 #include "mock_memory.h"
 
+#include <stdlib.h>
+
 static void _assert_parse_condset(rc_condset_t** condset, rc_memrefs_t* memrefs, void* buffer, const char* memaddr)
 {
   rc_parse_state_t parse;
@@ -2869,6 +2871,59 @@ static void test_addsource_recall_float_division() {
   assert_evaluate_condset(condset, memrefs, &memory, 1);
 }
 
+static void test_addsource_long_chain() {
+  /* assume 22 bytes per cond (10 for base, 11 for delta, 1 for separator)
+   * and approximately 320 bytes per cond when convered to data structures.
+   * 320+22 = 342. Round that up to 384 just to be safe.
+   */
+  const size_t cond_count = 1500;
+  const size_t buffer_size = 384 * cond_count;
+  char* buffer = (char*)malloc(buffer_size);
+  char* ptr = buffer;
+  rc_condset_t* condset;
+  rc_memrefs_t memrefs;
+  rc_parse_state_t parse;
+  clock_t start, end;
+  size_t i;
+
+  for (i = 0; i < cond_count; i++)
+    ptr += snprintf(ptr, buffer_size, "A:0xH%04x_", (uint32_t)i);
+  ptr += snprintf(ptr, buffer_size, "0=500");
+  for (i = 0; i < cond_count; i++)
+    ptr += snprintf(ptr, buffer_size, "_A:d0xH%04x", (uint32_t)i);
+  ptr += snprintf(ptr, buffer_size, "=499");
+
+  ptr = (char*)RC_ALIGN((size_t)ptr);
+  i = ptr - buffer;
+
+  rc_init_parse_state(&parse, ptr);
+  rc_init_parse_state_memrefs(&parse, &memrefs);
+
+  start = clock();
+  ptr = buffer;
+  condset = rc_parse_condset(&ptr, &parse);
+  end = clock();
+
+  rc_destroy_parse_state(&parse);
+
+  ASSERT_NUM_GREATER(parse.offset, 0);
+  ASSERT_NUM_LESS(parse.offset, buffer_size - i);
+  ASSERT_PTR_NOT_NULL(condset);
+
+  double elapsed = (double)(end - start) * 1000 / CLOCKS_PER_SEC;
+  /* this shouldn't take more than 20-40ms (depending on the machine its running on).
+   * allow up to 1 full second before this errors. it was taking over 10s when reported */
+  ASSERT_NUM_LESS(elapsed, 1000);
+
+  /* each condition and its delta should share a memref */
+  ASSERT_NUM_EQUALS(rc_memrefs_count_memrefs(&memrefs), cond_count);
+  /* one modified memref should be generated for each condition past the first
+   * plus one for the final condition: cond_count - 1 + 1 */
+  ASSERT_NUM_EQUALS(rc_memrefs_count_modified_memrefs(&memrefs), cond_count);
+
+  free(buffer);
+}
+
 static void test_addhits() {
   uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
@@ -5003,6 +5058,7 @@ void test_condset(void) {
   TEST(test_addsource_unfinished);
   TEST(test_addsource_float_division);
   TEST(test_addsource_recall_float_division);
+  TEST(test_addsource_long_chain);
 
   /* addhits/subhits */
   TEST(test_addhits);

--- a/test/rcheevos/test_condset.c
+++ b/test/rcheevos/test_condset.c
@@ -2889,7 +2889,7 @@ static void test_addsource_long_chain() {
 
   printf("0\n");
 
-  ASSERT_NOT_NULL(buffer);
+  ASSERT_PTR_NOT_NULL(buffer);
 
   for (i = 0; i < cond_count; i++)
     ptr += snprintf(ptr, buffer_size, "A:0xH%04x_", (uint32_t)i);

--- a/test/rcheevos/test_condset.c
+++ b/test/rcheevos/test_condset.c
@@ -2887,6 +2887,10 @@ static void test_addsource_long_chain() {
   clock_t start, end;
   size_t i;
 
+  printf("0\n");
+
+  ASSERT_NOT_NULL(buffer);
+
   for (i = 0; i < cond_count; i++)
     ptr += snprintf(ptr, buffer_size, "A:0xH%04x_", (uint32_t)i);
   ptr += snprintf(ptr, buffer_size, "0=500");
@@ -2894,26 +2898,40 @@ static void test_addsource_long_chain() {
     ptr += snprintf(ptr, buffer_size, "_A:d0xH%04x", (uint32_t)i);
   ptr += snprintf(ptr, buffer_size, "=499");
 
+  printf("1\n");
+
   ptr = (char*)RC_ALIGN((size_t)ptr);
   i = ptr - buffer;
 
+  printf("2\n");
+
   rc_init_parse_state(&parse, ptr);
   rc_init_parse_state_memrefs(&parse, &memrefs);
+
+  printf("3\n");
 
   start = clock();
   condset = rc_parse_condset(&memaddr, &parse);
   end = clock();
 
+  printf("4\n");
+
   rc_destroy_parse_state(&parse);
+
+  printf("5\n");
 
   ASSERT_NUM_GREATER(parse.offset, 0);
   ASSERT_NUM_LESS(parse.offset, buffer_size - i);
   ASSERT_PTR_NOT_NULL(condset);
 
+  printf("6\n");
+
   double elapsed = (double)(end - start) * 1000 / CLOCKS_PER_SEC;
   /* this shouldn't take more than 20-40ms (depending on the machine its running on).
    * allow up to 1 full second before this errors. it was taking over 10s when reported */
   ASSERT_NUM_LESS(elapsed, 1000);
+
+  printf("7\n");
 
   /* each condition and its delta should share a memref */
   ASSERT_NUM_EQUALS(rc_memrefs_count_memrefs(&memrefs), cond_count);
@@ -2921,7 +2939,11 @@ static void test_addsource_long_chain() {
    * plus one for the final condition: cond_count - 1 + 1 */
   ASSERT_NUM_EQUALS(rc_memrefs_count_modified_memrefs(&memrefs), cond_count);
 
+  printf("8\n");
+
   free(buffer);
+
+  printf("9\n");
 }
 
 static void test_addhits() {

--- a/test/rcheevos/test_condset.c
+++ b/test/rcheevos/test_condset.c
@@ -2885,26 +2885,42 @@ static void test_addsource_long_chain() {
   rc_memrefs_t memrefs;
   rc_parse_state_t parse;
   clock_t start, end;
-  size_t i;
+  size_t i, len, remaining;
 
   printf("[%u]\n", (uint32_t)buffer_size);
   fflush(stdout);
 
   memaddr = ptr = buffer = (char*)malloc(buffer_size);
+
+  printf("a\n");
+  fflush(stdout);
+
   ASSERT_PTR_NOT_NULL(buffer);
 
-  for (i = 0; i < cond_count; i++)
-    ptr += snprintf(ptr, buffer_size, "A:0xH%04x_", (uint32_t)i);
-  ptr += snprintf(ptr, buffer_size, "0=500");
-  for (i = 0; i < cond_count; i++)
-    ptr += snprintf(ptr, buffer_size, "_A:d0xH%04x", (uint32_t)i);
-  ptr += snprintf(ptr, buffer_size, "=499");
+  printf("b\n");
+  fflush(stdout);
+
+  remaining = buffer_size;
+  for (i = 0; i < cond_count; i++) {
+    len = snprintf(ptr, remaining, "A:0xH%04x_", (uint32_t)i);
+    remaining -= len;
+    ptr += len;
+  }
+  len = snprintf(ptr, remaining, "0=500");
+  remaining -= len;
+  ptr += len;
+  for (i = 0; i < cond_count; i++) {
+    len = snprintf(ptr, remaining, "_A:d0xH%04x", (uint32_t)i);
+    remaining -= len;
+    ptr += len;
+  }
+  ptr += snprintf(ptr, remaining, "=499");
 
   printf("1\n");
   fflush(stdout);
 
   ptr = (char*)RC_ALIGN((size_t)ptr);
-  i = ptr - buffer;
+  remaining = buffer_size - (ptr - buffer);
 
   printf("2\n");
   fflush(stdout);
@@ -2928,7 +2944,7 @@ static void test_addsource_long_chain() {
   fflush(stdout);
 
   ASSERT_NUM_GREATER(parse.offset, 0);
-  ASSERT_NUM_LESS(parse.offset, buffer_size - i);
+  ASSERT_NUM_LESS(parse.offset, remaining);
   ASSERT_PTR_NOT_NULL(condset);
 
   printf("6\n");

--- a/test/rcheevos/test_condset.c
+++ b/test/rcheevos/test_condset.c
@@ -2878,17 +2878,18 @@ static void test_addsource_long_chain() {
    */
   const size_t cond_count = 1500;
   const size_t buffer_size = 384 * cond_count;
-  char* buffer = (char*)malloc(buffer_size);
-  char* ptr = buffer;
-  const char* memaddr = buffer;
+  char* buffer;
+  char* ptr;
+  const char* memaddr;
   rc_condset_t* condset;
   rc_memrefs_t memrefs;
   rc_parse_state_t parse;
   clock_t start, end;
   size_t i;
 
-  printf("0\n");
+  printf("[%u]\n", (uint32_t)buffer_size);
 
+  memaddr = ptr = buffer = (char*)malloc(buffer_size);
   ASSERT_PTR_NOT_NULL(buffer);
 
   for (i = 0; i < cond_count; i++)

--- a/test/rcheevos/test_condset.c
+++ b/test/rcheevos/test_condset.c
@@ -2888,6 +2888,7 @@ static void test_addsource_long_chain() {
   size_t i;
 
   printf("[%u]\n", (uint32_t)buffer_size);
+  fflush(stdout);
 
   memaddr = ptr = buffer = (char*)malloc(buffer_size);
   ASSERT_PTR_NOT_NULL(buffer);
@@ -2900,32 +2901,38 @@ static void test_addsource_long_chain() {
   ptr += snprintf(ptr, buffer_size, "=499");
 
   printf("1\n");
+  fflush(stdout);
 
   ptr = (char*)RC_ALIGN((size_t)ptr);
   i = ptr - buffer;
 
   printf("2\n");
+  fflush(stdout);
 
   rc_init_parse_state(&parse, ptr);
   rc_init_parse_state_memrefs(&parse, &memrefs);
 
   printf("3\n");
+  fflush(stdout);
 
   start = clock();
   condset = rc_parse_condset(&memaddr, &parse);
   end = clock();
 
   printf("4\n");
+  fflush(stdout);
 
   rc_destroy_parse_state(&parse);
 
   printf("5\n");
+  fflush(stdout);
 
   ASSERT_NUM_GREATER(parse.offset, 0);
   ASSERT_NUM_LESS(parse.offset, buffer_size - i);
   ASSERT_PTR_NOT_NULL(condset);
 
   printf("6\n");
+  fflush(stdout);
 
   double elapsed = (double)(end - start) * 1000 / CLOCKS_PER_SEC;
   /* this shouldn't take more than 20-40ms (depending on the machine its running on).
@@ -2933,6 +2940,7 @@ static void test_addsource_long_chain() {
   ASSERT_NUM_LESS(elapsed, 1000);
 
   printf("7\n");
+  fflush(stdout);
 
   /* each condition and its delta should share a memref */
   ASSERT_NUM_EQUALS(rc_memrefs_count_memrefs(&memrefs), cond_count);
@@ -2941,10 +2949,12 @@ static void test_addsource_long_chain() {
   ASSERT_NUM_EQUALS(rc_memrefs_count_modified_memrefs(&memrefs), cond_count);
 
   printf("8\n");
+  fflush(stdout);
 
   free(buffer);
 
   printf("9\n");
+  fflush(stdout);
 }
 
 static void test_addhits() {


### PR DESCRIPTION
When trying to match an AddSource chain to an existing modified_memref chain, the logic was traversing up the chain to match the root. And it would do this for each subchain as it went.

For example: given the following AddSource chain:
```
AddSource Mem Byte 0x1230
AddSource Mem Byte 0x1231
AddSource Mem Byte 0x1232
AddSource Mem Byte 0x1233
          Mem Byte 0x1234 = 5
```
The first `Byte 0x1230` would be allocated as a standard memref.

The next `Byte 0x1231` would be allocated as a standard memref, and a modified_memref would be created to combine them.

The third `Byte 0x1232` is also allocated as a standard memref, and then it looks at the existing modified_memrefs to see if one already exists before creating a new modified_memref that adds the first modified_memref and the new byte.

For the fourth `Byte 0x1233`, there's two modified_memrefs to examine looking for a match. Neither do, but when checking the second, it walks up the chain 1232->1231->1230 before deciding that it's a different chain than the 1233->1232->1231->1230 it's looking for. This is due to a flaw in the recursion where it has to match the parents of the parents in order to say the parents are the same.

For something like an AddSource chain of 500 items, the code was walking up N log N parents (499+498+497+496...) to not find a match.

Luckily, this only happens when parsing the logic, but it's still unfortunate. With a debug build of PCSX2, loading the FFX subset was taking close to a minute. I'm sure the release build is faster, but would still be more than a few seconds. With these changes, the subset loads almost instantaneously.

I've made two changes in this PR to improve this behavior.

1) Each node now keeps track of how long its parent chain is, and if the chains have different lengths, it doesn't try to match the parents.
2) The modifier is checked before the parent chain. If two chains are identical, but one is adding 5 and the other is adding 6, there's no need to check the chains.
