### PR TITLE
Add API for batch fetching game title information

### DIFF
--- a/include/rc_client.h
+++ b/include/rc_client.h
@@ -399,6 +399,41 @@ RC_EXPORT rc_client_async_handle_t* RC_CCONV rc_client_begin_fetch_hash_library(
 RC_EXPORT void RC_CCONV rc_client_destroy_hash_library(rc_client_hash_library_t* list);
 
 /*****************************************************************************\
+| Fetch Game Titles                                                           |
+\*****************************************************************************/
+
+typedef struct rc_client_game_title_entry_t {
+  uint32_t game_id;
+  const char* title;
+  char badge_name[16];
+} rc_client_game_title_entry_t;
+
+typedef struct rc_client_game_title_list_t {
+  rc_client_game_title_entry_t* entries;
+  uint32_t num_entries;
+} rc_client_game_title_list_t;
+
+/**
+ * Callback that is fired when a game titles request completes. list may be null if the query failed.
+ */
+typedef void(RC_CCONV* rc_client_fetch_game_titles_callback_t)(int result, const char* error_message,
+                                                               rc_client_game_title_list_t* list, rc_client_t* client,
+                                                               void* callback_userdata);
+
+/**
+ * Starts an asynchronous request for titles and badge names for the specified games.
+ * The caller must provide an array of game IDs and the number of IDs in the array.
+ */
+RC_EXPORT rc_client_async_handle_t* RC_CCONV rc_client_begin_fetch_game_titles(
+  rc_client_t* client, const uint32_t* game_ids, uint32_t num_game_ids,
+  rc_client_fetch_game_titles_callback_t callback, void* callback_userdata);
+
+/**
+ * Destroys a previously-allocated result from the rc_client_begin_fetch_game_titles() callback.
+ */
+RC_EXPORT void RC_CCONV rc_client_destroy_game_title_list(rc_client_game_title_list_t* list);
+
+/*****************************************************************************\
 | Achievements                                                                |
 \*****************************************************************************/
 

--- a/src/rc_client.c
+++ b/src/rc_client.c
@@ -3599,6 +3599,146 @@ void rc_client_destroy_hash_library(rc_client_hash_library_t* list)
   free(list);
 }
 
+/* ===== Fetch Game Titles ===== */
+
+typedef struct rc_client_fetch_game_titles_callback_data_t {
+  rc_client_t* client;
+  rc_client_fetch_game_titles_callback_t callback;
+  void* callback_userdata;
+  rc_client_async_handle_t async_handle;
+} rc_client_fetch_game_titles_callback_data_t;
+
+static void rc_client_fetch_game_titles_callback(const rc_api_server_response_t* server_response, void* callback_data)
+{
+  rc_client_fetch_game_titles_callback_data_t* titles_callback_data =
+    (rc_client_fetch_game_titles_callback_data_t*)callback_data;
+  rc_client_t* client = titles_callback_data->client;
+  rc_api_fetch_game_titles_response_t titles_response;
+  const char* error_message;
+  int result;
+
+  result = rc_client_end_async(client, &titles_callback_data->async_handle);
+  if (result) {
+    if (result != RC_CLIENT_ASYNC_DESTROYED)
+      RC_CLIENT_LOG_VERBOSE(client, "Fetch game titles aborted");
+
+    free(titles_callback_data);
+    return;
+  }
+
+  result = rc_api_process_fetch_game_titles_server_response(&titles_response, server_response);
+  error_message =
+    rc_client_server_error_message(&result, server_response->http_status_code, &titles_response.response);
+  if (error_message) {
+    RC_CLIENT_LOG_ERR_FORMATTED(client, "Fetch game titles failed: %s", error_message);
+    titles_callback_data->callback(result, error_message, NULL, client, titles_callback_data->callback_userdata);
+  } else {
+    rc_client_game_title_list_t* list;
+    size_t strings_size = 0;
+    const rc_api_game_title_entry_t* src;
+    const rc_api_game_title_entry_t* stop;
+    size_t list_size;
+
+    /* calculate string buffer size */
+    for (src = titles_response.entries, stop = src + titles_response.num_entries; src < stop; ++src) {
+      if (src->title)
+        strings_size += strlen(src->title) + 1;
+    }
+
+    list_size = sizeof(*list) + sizeof(rc_client_game_title_entry_t) * titles_response.num_entries + strings_size;
+    list = (rc_client_game_title_list_t*)malloc(list_size);
+    if (!list) {
+      titles_callback_data->callback(RC_OUT_OF_MEMORY, rc_error_str(RC_OUT_OF_MEMORY), NULL, client,
+                                     titles_callback_data->callback_userdata);
+    } else {
+      rc_client_game_title_entry_t* entry = list->entries =
+        (rc_client_game_title_entry_t*)((uint8_t*)list + sizeof(*list));
+      char* strings = (char*)((uint8_t*)list + sizeof(*list) +
+                              sizeof(rc_client_game_title_entry_t) * titles_response.num_entries);
+
+      for (src = titles_response.entries, stop = src + titles_response.num_entries; src < stop; ++src, ++entry) {
+        entry->game_id = src->id;
+
+        if (src->title) {
+          const size_t len = strlen(src->title) + 1;
+          entry->title = strings;
+          memcpy(strings, src->title, len);
+          strings += len;
+        } else {
+          entry->title = NULL;
+        }
+
+        if (src->image_name)
+          snprintf(entry->badge_name, sizeof(entry->badge_name), "%s", src->image_name);
+        else
+          entry->badge_name[0] = '\0';
+      }
+
+      list->num_entries = titles_response.num_entries;
+
+      titles_callback_data->callback(RC_OK, NULL, list, client, titles_callback_data->callback_userdata);
+    }
+  }
+
+  rc_api_destroy_fetch_game_titles_response(&titles_response);
+  free(titles_callback_data);
+}
+
+rc_client_async_handle_t* rc_client_begin_fetch_game_titles(rc_client_t* client, const uint32_t* game_ids,
+                                                            uint32_t num_game_ids,
+                                                            rc_client_fetch_game_titles_callback_t callback,
+                                                            void* callback_userdata)
+{
+  rc_api_fetch_game_titles_request_t api_params;
+  rc_client_fetch_game_titles_callback_data_t* callback_data;
+  rc_client_async_handle_t* async_handle;
+  rc_api_request_t request;
+  int result;
+  const char* error_message;
+
+  if (!client) {
+    callback(RC_INVALID_STATE, "client is required", NULL, client, callback_userdata);
+    return NULL;
+  }
+
+  if (!game_ids || num_game_ids == 0) {
+    callback(RC_INVALID_STATE, "game_ids is required", NULL, client, callback_userdata);
+    return NULL;
+  }
+
+  api_params.game_ids = game_ids;
+  api_params.num_game_ids = num_game_ids;
+  result = rc_api_init_fetch_game_titles_request_hosted(&request, &api_params, &client->state.host);
+
+  if (result != RC_OK) {
+    error_message = rc_error_str(result);
+    callback(result, error_message, NULL, client, callback_userdata);
+    return NULL;
+  }
+
+  callback_data = (rc_client_fetch_game_titles_callback_data_t*)calloc(1, sizeof(*callback_data));
+  if (!callback_data) {
+    callback(RC_OUT_OF_MEMORY, rc_error_str(RC_OUT_OF_MEMORY), NULL, client, callback_userdata);
+    return NULL;
+  }
+
+  callback_data->client = client;
+  callback_data->callback = callback;
+  callback_data->callback_userdata = callback_userdata;
+
+  async_handle = &callback_data->async_handle;
+  rc_client_begin_async(client, async_handle);
+  client->callbacks.server_call(&request, rc_client_fetch_game_titles_callback, callback_data, client);
+  rc_api_destroy_request(&request);
+
+  return rc_client_async_handle_valid(client, async_handle) ? async_handle : NULL;
+}
+
+void rc_client_destroy_game_title_list(rc_client_game_title_list_t* list)
+{
+  free(list);
+}
+
 /* ===== Achievements ===== */
 
 static void rc_client_update_achievement_display_information(rc_client_t* client, rc_client_achievement_info_t* achievement, time_t recent_unlock_time)

--- a/test/test_rc_client.c
+++ b/test/test_rc_client.c
@@ -3884,6 +3884,45 @@ static void test_fetch_hash_library(void)
   rc_client_destroy(g_client);
 }
 
+/* ----- fetch game titles ----- */
+
+static void test_fetch_game_titles_response(int result, const char* error_message,
+  rc_client_game_title_list_t* list, rc_client_t* client, void* callback_userdata)
+{
+  rc_client_callback_expect_success(result, error_message, client, callback_userdata);
+  if (result != RC_OK)
+    return;
+
+  ASSERT_NUM_EQUALS(list->num_entries, 3);
+  ASSERT_NUM_EQUALS(list->entries[0].game_id, 3);
+  ASSERT_STR_EQUALS(list->entries[0].title, "Game Name 3");
+  ASSERT_STR_EQUALS(list->entries[0].badge_name, "010003");
+  ASSERT_NUM_EQUALS(list->entries[1].game_id, 4);
+  ASSERT_STR_EQUALS(list->entries[1].title, "Game Name 4");
+  ASSERT_STR_EQUALS(list->entries[1].badge_name, "010004");
+  ASSERT_NUM_EQUALS(list->entries[2].game_id, 7);
+  ASSERT_STR_EQUALS(list->entries[2].title, "Game Name 7");
+  ASSERT_STR_EQUALS(list->entries[2].badge_name, "010007");
+
+  rc_client_destroy_game_title_list(list);
+}
+
+static void test_fetch_game_titles(void)
+{
+  const uint32_t game_ids[] = { 3, 4, 7 };
+  g_client = mock_client_not_logged_in();
+
+  reset_mock_api_handlers();
+  mock_api_response("r=gameinfolist&g=3,4,7", "{\"Success\":true,\"Response\":["
+    "{\"ID\": 3, \"Title\":\"Game Name 3\", \"ImageIcon\": \"/Images/010003.png\"},"
+    "{\"ID\": 4, \"Title\":\"Game Name 4\", \"ImageIcon\": \"/Images/010004.png\"},"
+    "{\"ID\": 7, \"Title\":\"Game Name 7\", \"ImageIcon\": \"/Images/010007.png\"}"
+    "]}");
+
+  rc_client_begin_fetch_game_titles(g_client, game_ids, 3, test_fetch_game_titles_response, g_callback_userdata);
+  rc_client_destroy(g_client);
+}
+
 /* ----- all user progress ----- */
 
 static void test_fetch_all_user_progress_response(int result, const char* error_message,
@@ -10115,6 +10154,9 @@ void test_client(void) {
 
   /* hash library */
   TEST(test_fetch_hash_library);
+
+  /* game titles */
+  TEST(test_fetch_game_titles);
 
   /* all user progress */
   TEST(test_fetch_all_user_progress);


### PR DESCRIPTION
Added a new `rc_client` API for fetching game titles and badge names.

### New API
```c
rc_client_async_handle_t* rc_client_begin_fetch_game_titles(
  rc_client_t* client, const uint32_t* game_ids, uint32_t num_game_ids,
  rc_client_fetch_game_titles_callback_t callback, void* callback_userdata);

void rc_client_destroy_game_title_list(rc_client_game_title_list_t* list);
```

This allows consumers to fetch game title information (including badge names for game icons) through the `rc_client` interface rather than using `rc_api` directly, consistent with other fetch operations like `rc_client_begin_fetch_hash_library` and `rc_client_begin_fetch_all_user_progress`.

## Testing
Tested in Duckstation in https://github.com/stenzek/duckstation/pull/3658