### PR TITLE
allow unmapped memory for NDS

### DIFF
--- a/src/rc_libretro.c
+++ b/src/rc_libretro.c
@@ -649,27 +649,23 @@ static void rc_libretro_memory_init_from_unmapped_memory(rc_libretro_memory_regi
   uint32_t i, j;
   rc_libretro_core_memory_info_t info;
   size_t offset;
-
-  if (console_regions->region[console_regions->num_regions - 1].end_address > 0x01000000) {
-    /* assume anything exposing more than 16MB of regions with at least one UNUSED region
-     * is padding so things align with real addresses and cannot support unmapped memory */
-    for (i = 0; i < console_regions->num_regions; ++i) {
-      const rc_memory_region_t* console_region = &console_regions->region[i];
-      if (console_region->type == RC_MEMORY_TYPE_UNUSED) {
-        const size_t console_region_size = console_region->end_address - console_region->start_address + 1;
-        if (console_region_size >= 0x10000) {
-          rc_libretro_memory_register_region(regions, RC_MEMORY_TYPE_READONLY, NULL, console_regions->region[console_regions->num_regions - 1].end_address + 1, "null filler");
-          return;
-        }
-      }
-    }
-  }
+  int found_aligning_padding = 0;
 
   for (i = 0; i < console_regions->num_regions; ++i) {
     const rc_memory_region_t* console_region = &console_regions->region[i];
     const size_t console_region_size = console_region->end_address - console_region->start_address + 1;
     const uint32_t type = rc_libretro_memory_console_region_to_ram_type(console_region->type);
     uint32_t base_address = 0;
+
+    if (console_region->type == RC_MEMORY_TYPE_UNUSED && !found_aligning_padding) {
+      if (console_regions->region[console_regions->num_regions - 1].end_address > 0x01000000) {
+        /* assume anything exposing more than 16MB of regions with at least one UNUSED region
+         * is padding so things align with real addresses and cannot support unmapped memory */
+        const size_t console_region_size = console_region->end_address - console_region->start_address + 1;
+        if (console_region_size >= 0x10000)
+          found_aligning_padding = 1;
+      }
+    }
 
     for (j = 0; j <= i; ++j) {
       const rc_memory_region_t* console_region2 = &console_regions->region[j];
@@ -680,7 +676,13 @@ static void rc_libretro_memory_init_from_unmapped_memory(rc_libretro_memory_regi
     }
     offset = console_region->start_address - base_address;
 
-    get_core_memory_info(type, &info);
+    if (!found_aligning_padding) {
+      get_core_memory_info(type, &info);
+    }
+    else {
+      info.data = NULL;
+      info.size = console_region_size;
+    }
 
     if (offset < info.size) {
       info.size -= offset;

--- a/src/rc_libretro.c
+++ b/src/rc_libretro.c
@@ -657,13 +657,13 @@ static void rc_libretro_memory_init_from_unmapped_memory(rc_libretro_memory_regi
     const uint32_t type = rc_libretro_memory_console_region_to_ram_type(console_region->type);
     uint32_t base_address = 0;
 
-    if (console_region->type == RC_MEMORY_TYPE_UNUSED && !found_aligning_padding) {
+    if (console_region->type == RC_MEMORY_TYPE_UNUSED && console_region_size >= 0x10000 && !found_aligning_padding) {
       if (console_regions->region[console_regions->num_regions - 1].end_address > 0x01000000) {
-        /* assume anything exposing more than 16MB of regions with at least one UNUSED region
-         * is padding so things align with real addresses and cannot support unmapped memory */
-        const size_t console_region_size = console_region->end_address - console_region->start_address + 1;
-        if (console_region_size >= 0x10000)
-          found_aligning_padding = 1;
+        /* assume anything exposing more than 16MB of regions with at least one 64KB+ UNUSED region
+         * is padding so things align with real addresses. this indicates the memory is disjoint
+         * in the system, so we cannot expect it to be contiguous in the RETRO_SYSTEM_RAM.
+         * stop processing regions now, and just fill the remaining memory map with null filler. */
+        found_aligning_padding = 1;
       }
     }
 

--- a/test/test_rc_libretro.c
+++ b/test/test_rc_libretro.c
@@ -245,6 +245,28 @@ static void test_memory_init_from_unmapped_memory_no_ram() {
   ASSERT_PTR_NULL(rc_libretro_memory_find(&regions, 0x20002));
 }
 
+static void test_memory_init_from_unmapped_memory_ds() {
+  rc_libretro_memory_regions_t regions;
+  uint8_t* buffer1 = (uint8_t*)malloc(0x02000000); /* have to malloc to prevent array-bounds compiler warnings */
+  retro_memory_data[RETRO_MEMORY_SYSTEM_RAM] = buffer1;
+  retro_memory_size[RETRO_MEMORY_SYSTEM_RAM] = 0x02000000;
+  retro_memory_data[RETRO_MEMORY_SAVE_RAM] = NULL;
+  retro_memory_size[RETRO_MEMORY_SAVE_RAM] = 0;
+
+  /* init returns true */
+  ASSERT_TRUE(rc_libretro_memory_init(&regions, NULL, libretro_get_core_memory_info, RC_CONSOLE_NINTENDO_DS));
+
+  /* primary region should be generated, but TCM won't be available */
+  ASSERT_NUM_EQUALS(regions.count, 2);
+  ASSERT_NUM_EQUALS(regions.total_size, 0x1004000);
+  ASSERT_PTR_NOT_NULL(rc_libretro_memory_find(&regions, 0x00000002));
+  ASSERT_PTR_NOT_NULL(rc_libretro_memory_find(&regions, 0x003FFFFF));
+  ASSERT_PTR_NULL(rc_libretro_memory_find(&regions, 0x00400000));
+  ASSERT_PTR_NULL(rc_libretro_memory_find(&regions, 0x01000002));
+
+  free(buffer1);
+}
+
 static void test_memory_init_from_unmapped_memory_wii() {
   rc_libretro_memory_regions_t regions;
   retro_memory_data[RETRO_MEMORY_SYSTEM_RAM] = NULL;
@@ -252,7 +274,7 @@ static void test_memory_init_from_unmapped_memory_wii() {
   retro_memory_data[RETRO_MEMORY_SAVE_RAM] = NULL;
   retro_memory_size[RETRO_MEMORY_SAVE_RAM] = 0;
 
-  /* init returns true */
+  /* init returns false */
   ASSERT_FALSE(rc_libretro_memory_init(&regions, NULL, libretro_get_core_memory_info, RC_CONSOLE_WII));
 
   /* but one null-filled region is still generated */
@@ -899,6 +921,7 @@ void test_rc_libretro(void) {
   TEST(test_memory_init_from_unmapped_memory_no_save_ram);
   TEST(test_memory_init_from_unmapped_memory_merge_neighbors);
   TEST(test_memory_init_from_unmapped_memory_no_ram);
+  TEST(test_memory_init_from_unmapped_memory_ds);
   TEST(test_memory_init_from_unmapped_memory_wii);
 
   TEST(test_memory_init_from_memory_map);


### PR DESCRIPTION
Fixes an issue introduced by #472 where memory was not being mapped for the melonds ds core. That core does not provide memory maps, and the NDS map does have a sizable gap to expose the TCM memory.

This modifies the solution implemented by #472 to not discard the unmapped memory entirely. Instead, it stops mapping when the padding is encountered.