### PR TITLE
Mark status code 520 as retryable

### DIFF
--- a/src/rapi/rc_api_common.c
+++ b/src/rapi/rc_api_common.c
@@ -375,6 +375,10 @@ int rc_json_parse_server_response(rc_api_response_t* response, const rc_api_serv
         response->error_message = "Request has timed out.";
         break;
 
+      case 520: /* 520 Unknown Error */
+        response->error_message = "Unknown server error occurred.";
+        break;
+
       case 521: /* 521 Web Server is Down */
       case 523: /* 523 Origin is Unreachable */
         response->error_message = "Could not connect to server.";

--- a/src/rc_client.c
+++ b/src/rc_client.c
@@ -586,20 +586,24 @@ static int rc_client_should_retry(const rc_api_server_response_t* server_respons
       /* too many unlocks occurred at the same time */
       return 1;
 
+    case 520: /* 520 Unknown Error */
+      /* origin server returned an empty, unknown, or unexpected response to Cloudflare */
+      return 1;
+
     case 521: /* 521 Web Server is Down */
-      /* cloudfare could not find the server */
+      /* cloudflare could not find the server */
       return 1;
 
     case 522: /* 522 Connection Timed Out */
-      /* timeout connecting to server from cloudfare */
+      /* timeout connecting to server from cloudflare */
       return 1;
 
     case 523: /* 523 Origin is Unreachable */
-      /* cloudfare cannot find server */
+      /* cloudflare cannot find server */
       return 1;
 
     case 524: /* 524 A Timeout Occurred */
-      /* connection to server from cloudfare was dropped before request was completed */
+      /* connection to server from cloudflare was dropped before request was completed */
       return 1;
 
     case 525: /* 525 SSL Handshake Failed */


### PR DESCRIPTION
This change considers the HTTP status code 520 ("Web Server Returned an Unknown Error") as a retryable error.

CloudFlare documentation reference:
https://developers.cloudflare.com/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-520/