### PR TITLE
fix validation warning for AddSource chain maximum

### DIFF
--- a/src/rcheevos/rc_validate.c
+++ b/src/rcheevos/rc_validate.c
@@ -510,6 +510,7 @@ static void rc_combine_ranges(uint32_t* min_val, uint32_t* max_val, uint8_t oper
       break;
 
     case RC_OPERATOR_ADD:
+    case RC_OPERATOR_ADD_ACCUMULATOR:
       if (*min_val > *max_val) { /* underflow occurred */
         *max_val += oper_max_val;
       }
@@ -522,6 +523,7 @@ static void rc_combine_ranges(uint32_t* min_val, uint32_t* max_val, uint8_t oper
       break;
 
     case RC_OPERATOR_SUB:
+    case RC_OPERATOR_SUB_ACCUMULATOR:
       *min_val -= oper_max_val;
       *max_val -= oper_min_val;
       break;

--- a/test/rcheevos/test_rc_validate.c
+++ b/test/rcheevos/test_rc_validate.c
@@ -212,6 +212,8 @@ static void test_range_comparisons() {
   TEST_PARAMS2(test_validate_trigger, "A:255_B:d0xH1234_0xH1234>255", "");
 
   /* division by self results in a 0 or 1 */
+  TEST_PARAMS2(test_validate_trigger, "A:0xH1234/0xH1234_A:0xH1235/0xH1235_0=2", "");
+  TEST_PARAMS2(test_validate_trigger, "A:0xH1234/0xH1234_A:0xH1235/0xH1235_0=3", "Condition 3: Comparison is never true (max 2)");
   TEST_PARAMS2(test_validate_trigger, "B:0xH1241/0xH1241_B:0xH124c/0xH124c_M:2=2", "");
   TEST_PARAMS2(test_validate_trigger, "B:0xH1241/0xH1241_B:0xH124c/0xH124c_M:2>2", "Condition 3: Comparison is never true (max 2)");
 }


### PR DESCRIPTION
new enums added in #479 were not added to a switch in the validation logic, causing the combining of AddSource ranges to fail, which could lead to an invalid warning about the sum not being able to reach the comparison target.