### PR TITLE
don't send ping if game changes

### DIFF
--- a/src/rc_client.c
+++ b/src/rc_client.c
@@ -5438,6 +5438,14 @@ static void rc_client_ping(rc_client_scheduled_callback_data_t* callback_data, r
   if (client->state.frames_processed != client->state.frames_at_last_ping) {
     client->state.frames_at_last_ping = client->state.frames_processed;
 
+    memset(&api_params, 0, sizeof(api_params));
+    api_params.username = client->user.username;
+    api_params.api_token = client->user.token;
+    api_params.game_id = client->game->public_.id;
+    api_params.rich_presence = buffer;
+    api_params.game_hash = client->game->public_.hash;
+    api_params.hardcore = client->state.hardcore;
+
     if (!client->callbacks.rich_presence_override ||
         !client->callbacks.rich_presence_override(client, buffer, sizeof(buffer))) {
       rc_mutex_lock(&client->state.mutex);
@@ -5448,13 +5456,12 @@ static void rc_client_ping(rc_client_scheduled_callback_data_t* callback_data, r
       rc_mutex_unlock(&client->state.mutex);
     }
 
-    memset(&api_params, 0, sizeof(api_params));
-    api_params.username = client->user.username;
-    api_params.api_token = client->user.token;
-    api_params.game_id = client->game->public_.id;
-    api_params.rich_presence = buffer;
-    api_params.game_hash = client->game->public_.hash;
-    api_params.hardcore = client->state.hardcore;
+    /* there's a miniscule chance the game will be changed out while we're waiting for the lock.
+     * if that happens, discard this ping. the new game will have scheduled its own ping.
+     * don't reschedule this one. */
+    if (!client->game || client->game->public_.id != api_params.game_id) {
+      return;
+    }
 
     result = rc_api_init_ping_request_hosted(&request, &api_params, &client->state.host);
     if (result != RC_OK) {

--- a/test/test_rc_client.c
+++ b/test/test_rc_client.c
@@ -8998,6 +8998,48 @@ static void test_do_frame_ping_rich_presence_override_replaced(void)
   rc_client_destroy(g_client);
 }
 
+static int rc_client_callback_rich_presence_override_change_game(rc_client_t* client, char buffer[], size_t buffersize)
+{
+  client->game->public_.id++; /* simulate game change */
+  memcpy(buffer, "Custom", 7);
+  return 6;
+}
+
+static void test_do_frame_ping_rich_presence_game_changed(void)
+{
+  uint8_t memory[64];
+  memset(memory, 0, sizeof(memory));
+
+  g_client = mock_client_game_loaded(patchdata_exhaustive, no_unlocks);
+  g_client->callbacks.rich_presence_override = rc_client_callback_rich_presence_override_change_game;
+
+  ASSERT_PTR_NOT_NULL(g_client->game);
+  if (g_client->game)
+  {
+    rc_client_scheduled_callback_t ping_callback;
+
+    ASSERT_PTR_NOT_NULL(g_client->state.scheduled_callbacks);
+    ping_callback = g_client->state.scheduled_callbacks->callback;
+
+    /* ping won't get called if no frames have been processed. do_frame will increment frames_processed */
+    rc_client_do_frame(g_client);
+
+    ASSERT_NUM_EQUALS(g_client->state.scheduled_callbacks->when, g_now + 30 * 1000);
+    g_now += 30 * 1000;
+
+    rc_client_idle(g_client);
+
+    /* make sure the API didn't get called for the old game id or the new game id */
+    assert_api_not_called("r=ping&u=Username&t=ApiToken&g=1234&m=Custom&h=1&x=0123456789ABCDEF");
+    assert_api_not_called("r=ping&u=Username&t=ApiToken&g=1235&m=Custom&h=1&x=0123456789ABCDEF");
+
+    /* ping should not be rescheduled - expect new ping scheduled from alternate game */
+    ASSERT_PTR_NULL(g_client->state.scheduled_callbacks);
+  }
+
+  rc_client_destroy(g_client);
+}
+
 static void test_idle_ping_while_not_running(void)
 {
   uint8_t memory[64];
@@ -10292,6 +10334,7 @@ void test_client(void) {
   TEST(test_do_frame_ping_rich_presence);
   TEST(test_do_frame_ping_rich_presence_override_allowed);
   TEST(test_do_frame_ping_rich_presence_override_replaced);
+  TEST(test_do_frame_ping_rich_presence_game_changed);
   TEST(test_idle_ping_while_not_running);
 
   /* reset */

--- a/test/test_rc_client.c
+++ b/test/test_rc_client.c
@@ -9016,10 +9016,7 @@ static void test_do_frame_ping_rich_presence_game_changed(void)
   ASSERT_PTR_NOT_NULL(g_client->game);
   if (g_client->game)
   {
-    rc_client_scheduled_callback_t ping_callback;
-
     ASSERT_PTR_NOT_NULL(g_client->state.scheduled_callbacks);
-    ping_callback = g_client->state.scheduled_callbacks->callback;
 
     /* ping won't get called if no frames have been processed. do_frame will increment frames_processed */
     rc_client_do_frame(g_client);


### PR DESCRIPTION
Potential fix for https://discord.com/channels/476211979464343552/1461926569764196414/1461926569764196414

There's a small window between generating the RP string and constructing the API call where the game id might get changed. This double-checks the game id before sending the ping.