### PR TITLE
add full-file ifdef for rc_client_external.c

### DIFF
--- a/src/rc_client_external.c
+++ b/src/rc_client_external.c
@@ -5,6 +5,8 @@
 
 #include "rc_api_runtime.h"
 
+#ifdef RC_CLIENT_SUPPORTS_EXTERNAL
+
 #define RC_CONVERSION_FILL(obj, obj_type, src_type) memset((uint8_t*)obj + sizeof(src_type), 0, sizeof(obj_type) - sizeof(src_type))
 
 /* https://media.retroachievements.org/Badge/123456_lock.png is 58 with null terminator */
@@ -275,3 +277,5 @@ rc_client_achievement_list_t* rc_client_external_convert_v1_achievement_list(con
 
   return (rc_client_achievement_list_t*)new_list;
 }
+
+#endif /* RC_CLIENT_SUPPORTS_EXTERNAL */


### PR DESCRIPTION
Allows inclusion of `rc_client_external.c` in the build even if `RC_CLIENT_SUPPORTS_EXTERNAL` is not defined.

https://discord.com/channels/476211979464343552/757767535293890682/1463621091674030255