### PR TITLE
destroy parse state in rc_find_next_classification()

### DIFF
--- a/src/rcheevos/condset.c
+++ b/src/rcheevos/condset.c
@@ -134,10 +134,12 @@ static int rc_find_next_classification(const char* memaddr) {
         break;
 
       default:
+        rc_destroy_parse_state(&parse);
         return classification;
     }
   } while (*memaddr++ == '_');
 
+  rc_destroy_parse_state(&parse);
   return RC_CONDITION_CLASSIFICATION_OTHER;
 }
 


### PR DESCRIPTION
Was causing the following memory leak:
```
Indirect leak of 202240 byte(s) in 790 object(s) allocated from:
    #0 0x5650cf2d5be8 in malloc (/home/user/dev/duckstation/build/bin/duckstation-qt+0xbefbe8) (BuildId: f0336d2034c2404bd60f07d9ced0cbc1266aef4d)
    #1 0x5650d112641a in rc_buffer_reserve /home/user/dev/duckstation/dep/rcheevos/src/rc_util.c:72:41
    #2 0x5650d112698c in rc_buffer_alloc /home/user/dev/duckstation/dep/rcheevos/src/rc_util.c:114:18
    #3 0x5650d10eb683 in rc_alloc_scratch /home/user/dev/duckstation/dep/rcheevos/src/rcheevos/alloc.c:22:10
    #4 0x5650d10e61ff in rc_alloc_memref /home/user/dev/duckstation/dep/rcheevos/src/rcheevos/memref.c:60:26
    #5 0x5650d10ef28a in rc_parse_operand_memory /home/user/dev/duckstation/dep/rcheevos/src/rcheevos/operand.c:128:26
    #6 0x5650d10ee7f9 in rc_parse_operand /home/user/dev/duckstation/dep/rcheevos/src/rcheevos/operand.c:260:15
    #7 0x5650d10ff0bb in rc_parse_condition_internal /home/user/dev/duckstation/dep/rcheevos/src/rcheevos/condition.c:240:12
    #8 0x5650d10fb289 in rc_find_next_classification /home/user/dev/duckstation/dep/rcheevos/src/rcheevos/condset.c:126:5
    #9 0x5650d10fa2d6 in rc_parse_condset /home/user/dev/duckstation/dep/rcheevos/src/rcheevos/condset.c:352:40
    #10 0x5650d11050be in rc_parse_trigger_internal /home/user/dev/duckstation/dep/rcheevos/src/rcheevos/trigger.c:22:25
    #11 0x5650d10c849e in rc_client_copy_achievements /home/user/dev/duckstation/dep/rcheevos/src/rc_client.c:2098:7
    #12 0x5650d10c5a87 in rc_client_fetch_game_sets_callback /home/user/dev/duckstation/dep/rcheevos/src/rc_client.c:2342:7
```