### PR TITLE
handle buffer space in rc_client image URL functions

### DIFF
--- a/src/rc_client.c
+++ b/src/rc_client.c
@@ -637,7 +637,13 @@ static int rc_client_get_image_url(char buffer[], size_t buffer_size, int image_
   image_request.image_name = image_name;
   result = rc_api_init_fetch_image_request_hosted(&request, &image_request, NULL);
   if (result == RC_OK)
-    snprintf(buffer, buffer_size, "%s", request.url);
+  {
+    const size_t len = strlen(request.url);
+    if (len >= buffer_size)
+      result = RC_INSUFFICIENT_BUFFER;
+    else
+      memcpy(buffer, request.url, len + 1);
+  }
 
   rc_api_destroy_request(&request);
   return result;
@@ -898,7 +904,11 @@ int rc_client_user_get_image_url(const rc_client_user_t* user, char buffer[], si
     return RC_INVALID_STATE;
 
   if (user->avatar_url) {
-    snprintf(buffer, buffer_size, "%s", user->avatar_url);
+    const size_t len = strlen(user->avatar_url);
+    if (len >= buffer_size)
+      return RC_INSUFFICIENT_BUFFER;
+
+    memcpy(buffer, user->avatar_url, len + 1);
     return RC_OK;
   }
 
@@ -3514,7 +3524,11 @@ int rc_client_game_get_image_url(const rc_client_game_t* game, char buffer[], si
     return RC_INVALID_STATE;
 
   if (game->badge_url) {
-    snprintf(buffer, buffer_size, "%s", game->badge_url);
+    const size_t len = strlen(game->badge_url);
+    if (len >= buffer_size)
+      return RC_INSUFFICIENT_BUFFER;
+
+    memcpy(buffer, game->badge_url, len + 1);
     return RC_OK;
   }
 
@@ -4316,12 +4330,20 @@ int rc_client_achievement_get_image_url(const rc_client_achievement_t* achieveme
     return rc_client_get_image_url(buffer, buffer_size, image_type, "00000");
 
   if (image_type == RC_IMAGE_TYPE_ACHIEVEMENT && achievement->badge_url) {
-    snprintf(buffer, buffer_size, "%s", achievement->badge_url);
+    const size_t len = strlen(achievement->badge_url);
+    if (len >= buffer_size)
+      return RC_INSUFFICIENT_BUFFER;
+
+    memcpy(buffer, achievement->badge_url, len + 1);
     return RC_OK;
   }
 
   if (image_type == RC_IMAGE_TYPE_ACHIEVEMENT_LOCKED && achievement->badge_locked_url) {
-    snprintf(buffer, buffer_size, "%s", achievement->badge_locked_url);
+    const size_t len = strlen(achievement->badge_locked_url);
+    if (len >= buffer_size)
+      return RC_INSUFFICIENT_BUFFER;
+
+    memcpy(buffer, achievement->badge_locked_url, len + 1);
     return RC_OK;
   }
 

--- a/test/test_rc_client.c
+++ b/test/test_rc_client.c
@@ -1216,6 +1216,8 @@ static void test_user_get_image_url(void)
   ASSERT_NUM_EQUALS(rc_client_user_get_image_url(rc_client_get_user_info(g_client), buffer, sizeof(buffer)), RC_OK);
   ASSERT_STR_EQUALS(buffer, "http://server/UserPic/Username.png");
 
+  ASSERT_NUM_EQUALS(rc_client_user_get_image_url(rc_client_get_user_info(g_client), buffer, 10), RC_INSUFFICIENT_BUFFER);
+
   rc_client_destroy(g_client);
 }
 
@@ -3846,6 +3848,8 @@ static void test_game_get_image_url(void)
   ASSERT_NUM_EQUALS(rc_client_game_get_image_url(rc_client_get_game_info(g_client), buffer, sizeof(buffer)), RC_OK);
   ASSERT_STR_EQUALS(buffer, "http://server/Images/112233.png");
 
+  ASSERT_NUM_EQUALS(rc_client_game_get_image_url(rc_client_get_game_info(g_client), buffer, 10), RC_INSUFFICIENT_BUFFER);
+
   rc_client_destroy(g_client);
 }
 
@@ -5244,6 +5248,11 @@ static void test_achievement_get_image_url(void)
   ASSERT_NUM_EQUALS(rc_client_achievement_get_image_url(rc_client_get_achievement_info(g_client, 5501),
       RC_CLIENT_ACHIEVEMENT_STATE_INACTIVE, buffer, sizeof(buffer)), RC_OK);
   ASSERT_STR_EQUALS(buffer, "https://media.retroachievements.org/Badge/00234_lock.png");
+
+  ASSERT_NUM_EQUALS(rc_client_achievement_get_image_url(rc_client_get_achievement_info(g_client, 5501),
+    RC_CLIENT_ACHIEVEMENT_STATE_UNLOCKED, buffer, 10), RC_INSUFFICIENT_BUFFER);
+  ASSERT_NUM_EQUALS(rc_client_achievement_get_image_url(rc_client_get_achievement_info(g_client, 5501),
+    RC_CLIENT_ACHIEVEMENT_STATE_ACTIVE, buffer, 10), RC_INSUFFICIENT_BUFFER);
 
   rc_client_destroy(g_client);
 }


### PR DESCRIPTION
Since there is a status code return, indicate that the buffer was too small rather than silently truncating the URL.