### PR TITLE
prevent bleedthrough of state from incomplete previous trigger

### DIFF
--- a/src/rcheevos/condset.c
+++ b/src/rcheevos/condset.c
@@ -261,6 +261,11 @@ rc_condset_t* rc_parse_condset(const char** memaddr, rc_parse_state_t* parse) {
 
   next = &self->conditions;
 
+  /* prevent bleedthrough of incomplete conditions from other groups */
+  parse->addsource_oper = RC_OPERATOR_NONE;
+  parse->addsource_parent.type = RC_OPERAND_NONE;
+  parse->indirect_parent.type = RC_OPERAND_NONE;
+
   /* each condition set has a functionally new recall accumulator */
   parse->remember.type = RC_OPERAND_NONE;
 

--- a/test/rcheevos/test_richpresence.c
+++ b/test/rcheevos/test_richpresence.c
@@ -400,6 +400,27 @@ static void test_conditional_display_invalid() {
   ASSERT_NUM_EQUALS(lines_read, 2);
 }
 
+static void test_conditional_display_training_addaddress() {
+  uint8_t ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  memory_t memory;
+  rc_richpresence_t* richpresence;
+  char buffer[1024];
+
+  memory.ram = ram;
+  memory.size = sizeof(ram);
+
+  assert_parse_richpresence(&richpresence, buffer, "Display:\n?I:0xH0000_M:0xH0002=h01_I:0xH0000*2?True\n@Number(I:0xH0001_M:0xH0000_Q:0xH0004=8)\n");
+  /* $($0 + 2) == 1 ? True : $4 == 8 ? $($1) : 0 */
+  assert_richpresence_output(richpresence, &memory, "0");
+
+  ram[1] = 3;
+  ram[4] = 8;
+  assert_richpresence_output(richpresence, &memory, "171"); /* $($1) = > $3 => 0xAB */
+
+  ram[2] = 1;
+  assert_richpresence_output(richpresence, &memory, "True"); /* $($0) => $2 => 1 */
+}
+
 static void test_macro_value_adjusted_negative() {
   uint8_t ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
   memory_t memory;
@@ -1405,7 +1426,7 @@ void test_richpresence(void) {
   /* buffer boundary */
   test_buffer_boundary();
 
-  /* condition display */
+  /* conditional display */
   TEST(test_conditional_display_simple);
   TEST(test_conditional_display_after_default);
   TEST(test_conditional_display_no_default);
@@ -1418,6 +1439,7 @@ void test_richpresence(void) {
   TEST(test_conditional_display_unnecessary_measured);
   TEST(test_conditional_display_unnecessary_measured_indirect);
   TEST(test_conditional_display_invalid);
+  TEST(test_conditional_display_training_addaddress);
 
   /* value macros */
   TEST(test_macro_value);


### PR DESCRIPTION
https://discord.com/channels/310192285306454017/1149693430306447380/1451951532294803496

An incomplete AddAddress on a previous conditional display trigger was being attached to logic in the following display string.