### PR TITLE
add rc_client_get_next_achievement_info

### DIFF
--- a/include/rc_client.h
+++ b/include/rc_client.h
@@ -524,6 +524,11 @@ typedef struct rc_client_achievement_t {
 RC_EXPORT const rc_client_achievement_t* RC_CCONV rc_client_get_achievement_info(rc_client_t* client, uint32_t id);
 
 /**
+ * Gets the next achievement after a provided achievement that fits in the specified bucket. Returns NULL if none found.
+ */
+RC_EXPORT const rc_client_achievement_t * RC_CCONV rc_client_get_next_achievement_info(rc_client_t * client, const rc_client_achievement_t * achievement, int bucket);
+
+/**
  * Gets the URL for the achievement image.
  * Returns RC_OK on success.
  */

--- a/src/rc_client.c
+++ b/src/rc_client.c
@@ -4307,6 +4307,62 @@ const rc_client_achievement_t* rc_client_get_achievement_info(rc_client_t* clien
   return NULL;
 }
 
+const rc_client_achievement_t* rc_client_get_next_achievement_info(rc_client_t* client,
+    const rc_client_achievement_t* achievement, int bucket)
+{
+  const rc_client_achievement_info_t* after = (const rc_client_achievement_info_t*)achievement;
+  rc_client_achievement_info_t* achievement_info;
+  time_t recent_unlock_time;
+  rc_client_subset_info_t* subset;
+
+  if (!client)
+    return NULL;
+
+#ifdef RC_CLIENT_SUPPORTS_EXTERNAL
+  if (client->state.external_client && client->state.external_client->get_next_achievement_info)
+    return client->state.external_client->get_next_achievement_info(achievement ? achievement->id : 0, bucket);
+#endif
+
+  if (!client->game)
+    return NULL;
+
+  recent_unlock_time = time(NULL) - RC_CLIENT_RECENT_UNLOCK_DELAY_SECONDS;
+  for (subset = client->game->subsets; subset; subset = subset->next) {
+    if (subset->active && subset->public_.num_achievements > 0) {
+      const rc_client_achievement_info_t* start = subset->achievements;
+      const rc_client_achievement_info_t* stop = start + subset->public_.num_achievements;
+      if (after == NULL || (after >= start && after <= stop)) {
+        /* found a subset containing the provided achievement. look for the next
+         * achievement matching the requested bucket */
+        uint32_t index = after ? (uint32_t)(after - start) + 1 : 0;
+        do {
+          if (index >= subset->public_.num_achievements) {
+            /* done with this subset. find the next active subset with achievements */
+            do {
+              subset = subset->next;
+              if (!subset)
+                return NULL;
+            } while (!subset->active || subset->public_.num_achievements == 0);
+
+            index = 0;
+          }
+
+          /* found an achievement. check to see if it matches the requested bucket. */
+          achievement_info = &subset->achievements[index];
+          rc_client_update_achievement_display_information(client, achievement_info, recent_unlock_time);
+          if (achievement_info->public_.bucket == bucket)
+            return &achievement_info->public_;
+
+          ++index;
+        } while (1);
+      }
+    }
+  }
+
+  return NULL;
+}
+
+
 int rc_client_achievement_get_image_url(const rc_client_achievement_t* achievement, int state, char buffer[], size_t buffer_size)
 {
   const int image_type = (state == RC_CLIENT_ACHIEVEMENT_STATE_UNLOCKED) ?

--- a/src/rc_client_external.h
+++ b/src/rc_client_external.h
@@ -46,6 +46,7 @@ typedef void (RC_CCONV* rc_client_external_add_game_hash_func_t)(const char* has
 struct rc_client_achievement_list_info_t;
 typedef struct rc_client_achievement_list_info_t* (RC_CCONV *rc_client_external_create_achievement_list_func_t)(int category, int grouping);
 typedef const rc_client_achievement_t* (RC_CCONV *rc_client_external_get_achievement_info_func_t)(uint32_t id);
+typedef const rc_client_achievement_t* (RC_CCONV* rc_client_external_get_next_achievement_info_func_t)(uint32_t id, int grouping);
 
 /* NOTE: rc_client_external_create_leaderboard_list_func_t returns an internal wrapper structure which contains the public list
  * and a destructor function. */
@@ -152,9 +153,12 @@ typedef struct rc_client_external_t
   /* VERSION 6 */
   rc_client_external_create_subset_list_func_t create_subset_list;
 
+  /* VERSION 7 */
+  rc_client_external_get_next_achievement_info_func_t get_next_achievement_info;
+
 } rc_client_external_t;
 
-#define RC_CLIENT_EXTERNAL_VERSION 5
+#define RC_CLIENT_EXTERNAL_VERSION 7
 
 void rc_client_add_game_hash(rc_client_t* client, const char* hash, uint32_t game_id);
 void rc_client_load_unknown_game(rc_client_t* client, const char* hash);

--- a/test/test_rc_client.c
+++ b/test/test_rc_client.c
@@ -5224,6 +5224,72 @@ static void test_achievement_list_subset_buckets(void)
   rc_client_destroy(g_client);
 }
 
+static void test_get_next_achievement_first(void)
+{
+  const rc_client_achievement_t* achievement;
+  g_client = mock_client_game_loaded(patchdata_subset, unlock_6_8h_and_9);
+
+  achievement = rc_client_get_next_achievement_info(g_client, NULL, RC_CLIENT_ACHIEVEMENT_BUCKET_LOCKED);
+  ASSERT_PTR_NOT_NULL(achievement);
+  ASSERT_NUM_EQUALS(achievement->id, 5); /* 5 is the first locked achievement */
+
+  achievement = rc_client_get_next_achievement_info(g_client, NULL, RC_CLIENT_ACHIEVEMENT_BUCKET_UNLOCKED);
+  ASSERT_PTR_NOT_NULL(achievement);
+  ASSERT_NUM_EQUALS(achievement->id, 8); /* 8 is the first unlocked achievement since 6 only has a softcore unlock */
+
+  achievement = rc_client_get_next_achievement_info(g_client, NULL, RC_CLIENT_ACHIEVEMENT_BUCKET_UNSUPPORTED);
+  ASSERT_PTR_NULL(achievement); /* all achievements in this set should be supported */
+
+  rc_client_destroy(g_client);
+}
+
+static void test_get_next_achievement_sequence(void)
+{
+  const rc_client_achievement_t* achievement;
+  g_client = mock_client_game_loaded(patchdata_subset, unlock_6_8h_and_9);
+
+  achievement = rc_client_get_next_achievement_info(g_client, NULL, RC_CLIENT_ACHIEVEMENT_BUCKET_LOCKED);
+  ASSERT_PTR_NOT_NULL(achievement);
+  ASSERT_NUM_EQUALS(achievement->id, 5); /* 5 is the first locked achievement */
+
+  achievement = rc_client_get_next_achievement_info(g_client, achievement, RC_CLIENT_ACHIEVEMENT_BUCKET_LOCKED);
+  ASSERT_PTR_NOT_NULL(achievement);
+  ASSERT_NUM_EQUALS(achievement->id, 6);
+
+  achievement = rc_client_get_next_achievement_info(g_client, achievement, RC_CLIENT_ACHIEVEMENT_BUCKET_LOCKED);
+  ASSERT_PTR_NOT_NULL(achievement);
+  ASSERT_NUM_EQUALS(achievement->id, 7);
+
+  achievement = rc_client_get_next_achievement_info(g_client, achievement, RC_CLIENT_ACHIEVEMENT_BUCKET_LOCKED);
+  ASSERT_PTR_NOT_NULL(achievement);
+  ASSERT_NUM_EQUALS(achievement->id, 9); /* 8 was unlocked and is skipped */
+
+  achievement = rc_client_get_next_achievement_info(g_client, achievement, RC_CLIENT_ACHIEVEMENT_BUCKET_LOCKED);
+  ASSERT_PTR_NOT_NULL(achievement);
+  ASSERT_NUM_EQUALS(achievement->id, 70);
+
+  achievement = rc_client_get_next_achievement_info(g_client, achievement, RC_CLIENT_ACHIEVEMENT_BUCKET_LOCKED);
+  ASSERT_PTR_NOT_NULL(achievement);
+  ASSERT_NUM_EQUALS(achievement->id, 71);
+
+  achievement = rc_client_get_next_achievement_info(g_client, achievement, RC_CLIENT_ACHIEVEMENT_BUCKET_LOCKED);
+  ASSERT_PTR_NOT_NULL(achievement);
+  ASSERT_NUM_EQUALS(achievement->id, 5501); /* done with core set, start iterating subset */
+
+  achievement = rc_client_get_next_achievement_info(g_client, achievement, RC_CLIENT_ACHIEVEMENT_BUCKET_LOCKED);
+  ASSERT_PTR_NOT_NULL(achievement);
+  ASSERT_NUM_EQUALS(achievement->id, 5502);
+
+  achievement = rc_client_get_next_achievement_info(g_client, achievement, RC_CLIENT_ACHIEVEMENT_BUCKET_LOCKED);
+  ASSERT_PTR_NOT_NULL(achievement);
+  ASSERT_NUM_EQUALS(achievement->id, 5503);
+
+  achievement = rc_client_get_next_achievement_info(g_client, achievement, RC_CLIENT_ACHIEVEMENT_BUCKET_LOCKED);
+  ASSERT_PTR_NULL(achievement); /* done iterating subset */
+
+  rc_client_destroy(g_client);
+}
+
 static void test_achievement_get_image_url(void)
 {
   char buffer[256];
@@ -10224,6 +10290,9 @@ void test_client(void) {
   TEST(test_achievement_list_buckets_with_unsynced);
   TEST(test_achievement_list_subset_with_unofficial_and_unsupported);
   TEST(test_achievement_list_subset_buckets);
+
+  TEST(test_get_next_achievement_first);
+  TEST(test_get_next_achievement_sequence);
 
   TEST(test_achievement_get_image_url);
 

--- a/test/test_rc_client_external.c
+++ b/test/test_rc_client_external.c
@@ -1585,6 +1585,32 @@ static void test_get_achievement_info(void)
   rc_client_destroy(g_client);
 }
 
+static const rc_client_achievement_t* rc_client_external_get_next_achievement_info(uint32_t id, int grouping)
+{
+  if (grouping != RC_CLIENT_ACHIEVEMENT_BUCKET_LOCKED)
+    return NULL;
+
+  return rc_client_external_get_achievement_info_v3((id + 1) * 4);
+}
+
+static void test_get_next_achievement_info(void)
+{
+  const rc_client_achievement_t* achievement;
+
+  g_client = mock_client_with_external();
+  g_client->state.external_client->get_next_achievement_info = rc_client_external_get_next_achievement_info;
+
+  achievement = rc_client_get_next_achievement_info(g_client, NULL, RC_CLIENT_ACHIEVEMENT_BUCKET_LOCKED);
+  ASSERT_PTR_NOT_NULL(achievement);
+  ASSERT_NUM_EQUALS(achievement->id, 4);
+
+  achievement = rc_client_get_next_achievement_info(g_client, achievement, RC_CLIENT_ACHIEVEMENT_BUCKET_LOCKED);
+  ASSERT_PTR_NOT_NULL(achievement);
+  ASSERT_NUM_EQUALS(achievement->id, 20);
+
+  rc_client_destroy(g_client);
+}
+
 static void test_v1_achievement_list_field_offsets(void)
 {
   ASSERT_FIELD_OFFSET(rc_client_achievement_list_info_t, v1_rc_client_achievement_list_info_t, public_);
@@ -2137,6 +2163,7 @@ void test_client_external(void) {
   TEST(test_get_achievement_info_v1);
   TEST(test_get_achievement_info_v1_not_found);
   TEST(test_get_achievement_info);
+  TEST(test_get_next_achievement_info);
 
   TEST(test_v1_achievement_list_field_offsets);
   TEST(test_v3_achievement_list_field_offsets);


### PR DESCRIPTION
Allows asking for the next achievement in a list without having to allocate the entire list. This should allow the client to "predict" which achievement is most likely to unlock next and prefetch the image for it, without having to prefetch all the images.