### PR TITLE
feat: add native CHD support to cdreader (createcd + createdvd)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "deps/libchdr"]
+	path = deps/libchdr
+	url = https://github.com/rtissera/libchdr.git

--- a/src/rhash/cdreader.c
+++ b/src/rhash/cdreader.c
@@ -749,11 +749,142 @@ static void* cdreader_open_gdi_track(const char* path, uint32_t track, const rc_
   return cdrom;
 }
 
+#ifdef HAVE_CHD
+#include "libchdr/chd.h"
+#include "libchdr/cdrom.h"
+typedef struct rc_chd_reader_t {
+  chd_file* chd;
+  uint32_t hunkbytes;
+  uint8_t* hunk_buffer;
+  uint32_t buffered_hunk;
+  int64_t current_pos;
+  int64_t total_bytes;
+} rc_chd_reader_t;
+#endif /* HAVE_CHD */
+
+#ifdef HAVE_CHD
+static void chd_filereader_seek(void* h, int64_t o, int origin) {
+  rc_chd_reader_t* r = (rc_chd_reader_t*)h;
+  if (origin == SEEK_SET) r->current_pos = o;
+  else if (origin == SEEK_CUR) r->current_pos += o;
+  else r->current_pos = r->total_bytes + o;
+  if (r->current_pos < 0) r->current_pos = 0;
+  if (r->current_pos > r->total_bytes) r->current_pos = r->total_bytes;
+}
+static int64_t chd_filereader_tell(void* h) { return ((rc_chd_reader_t*)h)->current_pos; }
+static size_t chd_filereader_read(void* h, void* buf, size_t n) {
+  rc_chd_reader_t* r = (rc_chd_reader_t*)h;
+  uint8_t* out = (uint8_t*)buf;
+  size_t total = 0;
+  while (n > 0 && r->current_pos < r->total_bytes) {
+    uint32_t hi = (uint32_t)(r->current_pos / r->hunkbytes);
+    uint32_t off = (uint32_t)(r->current_pos % r->hunkbytes);
+    size_t avail = (size_t)(r->hunkbytes - off);
+    size_t copy = avail < n ? avail : n;
+    if (r->current_pos + (int64_t)copy > r->total_bytes)
+      copy = (size_t)(r->total_bytes - r->current_pos);
+    if (!copy) break;
+    if (hi != r->buffered_hunk) {
+      if (chd_read(r->chd, hi, r->hunk_buffer) != CHDERR_NONE) break;
+      r->buffered_hunk = hi;
+    }
+    memcpy(out, r->hunk_buffer + off, copy);
+    out += copy; r->current_pos += copy; total += copy; n -= copy;
+  }
+  return total;
+}
+static void chd_filereader_close(void* h) {
+  rc_chd_reader_t* r = (rc_chd_reader_t*)h;
+  if (r) { if (r->hunk_buffer) free(r->hunk_buffer); if (r->chd) chd_close(r->chd); free(r); }
+}
+static const rc_hash_filereader_t s_chd_filereader = {
+  NULL, chd_filereader_seek, chd_filereader_tell, chd_filereader_read, chd_filereader_close
+};
+#endif /* HAVE_CHD */
+
+#ifdef HAVE_CHD
+static void cdreader_get_chd_sector_info(const char* t, int* ss, int* hs, int* rds) {
+  if (strncmp(t,"AUDIO",5)==0) { *ss=CD_FRAME_SIZE; *hs=0; *rds=CD_MAX_SECTOR_DATA; }
+  else if (strncmp(t,"MODE2",5)==0) { *ss=CD_FRAME_SIZE; *hs=24; *rds=2048; }
+  else { *ss=CD_FRAME_SIZE; *hs=16; *rds=2048; }
+}
+static rc_chd_reader_t* cdreader_alloc_chd_reader(chd_file* chd) {
+  const chd_header* h = chd_get_header(chd);
+  rc_chd_reader_t* r = (rc_chd_reader_t*)calloc(1, sizeof(*r));
+  if (!r) { chd_close(chd); return NULL; }
+  r->chd = chd; r->hunkbytes = h->hunkbytes;
+  r->total_bytes = (int64_t)h->logicalbytes;
+  r->hunk_buffer = (uint8_t*)malloc(h->hunkbytes);
+  r->buffered_hunk = (uint32_t)-1;
+  if (!r->hunk_buffer) { chd_filereader_close(r); return NULL; }
+  return r;
+}
+static void* cdreader_open_chd_track(const char* path, uint32_t track, const rc_hash_iterator_t* iterator) {
+  chd_file* chd = NULL;
+  const chd_header* header;
+  rc_chd_reader_t* rdr;
+  rc_hash_cdrom_track_t* cdrom;
+  chd_error err;
+  char meta[256]; uint32_t mlen;
+  char ttype[16], tsub[16], pgtype[16], pgsub[16];
+  uint32_t tnum, frames, pregap, postgap;
+  uint32_t cum, idx, rb, rp, lf; int rs, rh, rrd, found;
+  int ss, hs, rds;
+  err = chd_open(path, CHD_OPEN_READ, NULL, &chd);
+  if (err != CHDERR_NONE) { rc_hash_iterator_error_formatted(iterator,"Could not open CHD: %s",chd_error_string(err)); return NULL; }
+  header = chd_get_header(chd);
+  rdr = cdreader_alloc_chd_reader(chd);
+  if (!rdr) return NULL;
+  cdrom = (rc_hash_cdrom_track_t*)calloc(1, sizeof(*cdrom));
+  if (!cdrom) { chd_filereader_close(rdr); return NULL; }
+  cdrom->file_reader = &s_chd_filereader;
+  cdrom->file_handle = rdr;
+  cdrom->raw_data_size = 2048;
+  if (track == 0) track = RC_HASH_CDTRACK_LARGEST;
+  found=0; cum=0; rb=0; rp=0; rs=0; rh=0; rrd=2048; lf=0;
+  for (idx=0; ; ++idx) {
+    err = chd_get_metadata(chd,CDROM_TRACK_METADATA2_TAG,idx,meta,sizeof(meta),&mlen,NULL,NULL);
+    if (err==CHDERR_NONE) sscanf(meta,CDROM_TRACK_METADATA2_FORMAT,&tnum,ttype,tsub,&frames,&pregap,pgtype,pgsub,&postgap);
+    else { err=chd_get_metadata(chd,CDROM_TRACK_METADATA_TAG,idx,meta,sizeof(meta),&mlen,NULL,NULL);
+      if (err==CHDERR_NONE) { sscanf(meta,CDROM_TRACK_METADATA_FORMAT,&tnum,ttype,tsub,&frames); pregap=0; postgap=0; }
+      else break; }
+    cdreader_get_chd_sector_info(ttype,&ss,&hs,&rds);
+    if (track==tnum) { rb=cum; rp=pregap; rs=ss; rh=hs; rrd=rds; found=1; break; }
+    if (track==RC_HASH_CDTRACK_FIRST_DATA && strncmp(ttype,"MODE",4)==0) { rb=cum; rp=pregap; rs=ss; rh=hs; rrd=rds; found=1; break; }
+    if (track==RC_HASH_CDTRACK_LARGEST && strncmp(ttype,"MODE",4)==0) { uint32_t df=(frames>pregap)?(frames-pregap):0; if(df>lf){lf=df;rb=cum;rp=pregap;rs=ss;rh=hs;rrd=rds;} }
+    if (track==RC_HASH_CDTRACK_LAST) { rb=cum; rp=pregap; rs=ss; rh=hs; rrd=rds; }
+    cum+=frames;
+  }
+  if (!found && (track==RC_HASH_CDTRACK_LARGEST||track==RC_HASH_CDTRACK_LAST) && rs>0) found=1;
+  if (found) {
+    cdrom->track_first_sector=rb; cdrom->track_pregap_sectors=rp;
+    cdrom->sector_size=rs; cdrom->sector_header_size=rh; cdrom->raw_data_size=rrd;
+    cdrom->file_track_offset=(int64_t)rb*rs;
+    rc_hash_iterator_verbose_formatted(iterator,"Opened CHD CD track (sector size %d, first sector %u, pregap %u)",rs,rb,rp);
+    return cdrom;
+  }
+  if (header->unitbytes==2048 && (track==1||track==RC_HASH_CDTRACK_FIRST_DATA||track==RC_HASH_CDTRACK_LARGEST)) {
+    cdrom->track_first_sector=0; cdrom->track_pregap_sectors=0;
+    cdrom->sector_size=2048; cdrom->sector_header_size=0; cdrom->raw_data_size=2048;
+    cdrom->file_track_offset=0;
+    rc_hash_iterator_verbose_formatted(iterator,"Opened CHD as DVD track (2048-byte sectors, %u total sectors)",(uint32_t)(header->logicalbytes/2048));
+    return cdrom;
+  }
+  rc_hash_iterator_error(iterator,"Could not open track");
+  free(cdrom); chd_filereader_close(rdr); return NULL;
+}
+#endif /* HAVE_CHD */
+
 static void* cdreader_open_track_iterator(const char* path, uint32_t track, const rc_hash_iterator_t* iterator)
 {
   /* backwards compatibility - 0 used to mean largest */
   if (track == 0)
     track = RC_HASH_CDTRACK_LARGEST;
+
+#ifdef HAVE_CHD
+  if (rc_path_compare_extension(path, "chd"))
+    return cdreader_open_chd_track(path, track, iterator);
+#endif
 
   if (rc_path_compare_extension(path, "cue"))
     return cdreader_open_cue_track(path, track, iterator);

--- a/test/Makefile
+++ b/test/Makefile
@@ -157,6 +157,33 @@ else
                $(RC_HASH_SRC)/hash_disc.o \
                rhash/test_cdreader.o \
                rhash/test_hash_disc.o
+        ifeq ($(HAVE_CHD), 1)
+            CHD_SRC=../deps/libchdr
+            CFLAGS += -DHAVE_CHD -I$(CHD_SRC)/include
+            OBJ += $(CHD_SRC)/src/libchdr_bitstream.o \
+                   $(CHD_SRC)/src/libchdr_cdrom.o \
+                   $(CHD_SRC)/src/libchdr_chd.o \
+                   $(CHD_SRC)/src/libchdr_codec_cdfl.o \
+                   $(CHD_SRC)/src/libchdr_codec_cdlz.o \
+                   $(CHD_SRC)/src/libchdr_codec_cdzl.o \
+                   $(CHD_SRC)/src/libchdr_codec_cdzs.o \
+                   $(CHD_SRC)/src/libchdr_codec_flac.o \
+                   $(CHD_SRC)/src/libchdr_codec_huff.o \
+                   $(CHD_SRC)/src/libchdr_codec_lzma.o \
+                   $(CHD_SRC)/src/libchdr_codec_zlib.o \
+                   $(CHD_SRC)/src/libchdr_codec_zstd.o \
+                   $(CHD_SRC)/src/libchdr_flac.o \
+                   $(CHD_SRC)/src/libchdr_huffman.o
+            LZMA_SRC=$(CHD_SRC)/deps/lzma-25.01
+            CFLAGS += -I$(LZMA_SRC)/include
+            OBJ += $(LZMA_SRC)/src/LzmaDec.o
+            MINIZ_SRC=$(CHD_SRC)/deps/miniz-3.1.1
+            OBJ += $(MINIZ_SRC)/miniz.o
+            ZSTD_SRC=$(CHD_SRC)/deps/zstd-1.5.7
+            CFLAGS += -I$(ZSTD_SRC)
+            OBJ += $(ZSTD_SRC)/zstddeclib.o
+            CFLAGS += -DWANT_RAW_DATA_SECTOR=1 -DWANT_SUBCODE=1 -DVERIFY_BLOCK_CRC=1
+        endif
     endif
 
     ifeq ($(HAVE_HASH_ZIP), 0)
@@ -192,6 +219,9 @@ $(RC_HASH_SRC)/%.o: $(RC_HASH_SRC)/%.c
 
 $(RC_API_SRC)/%.o: $(RC_API_SRC)/%.c
 	$(CC) $(CFLAGS) $(SRC_CFLAGS) $(INCLUDES) -c $< -o $@
+
+../deps/%.o: ../deps/%.c
+	$(CC) $(filter-out -std=c89 -std=c99 -pedantic -Wextra -Wshadow, $(CFLAGS)) -std=c99 -Wno-unused-function $(INCLUDES) -c $< -o $@
 
 %.o: %.c
 	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@


### PR DESCRIPTION
## Problem

`cdreader.c` has never had native CHD support. When a `.chd` file is passed to the hasher, `cdreader_open_track_iterator` falls through to `cdreader_open_bin_track`, which attempts to read the CHD as a raw binary. This fails because CHD is a compressed container format. Every console attempt prints `Could not open track` and hash generation fails entirely.

This affects all CHD users but is especially visible with PS2 and PSP games compressed using `chdman createdvd`, which is the format chdman now recommends for DVD-based games. These produce a CHD with **no CD track metadata at all**, causing total failure even in clients that implement their own CHD handler but don't handle the DVD format.

> **Note:** RetroArch PR #18040 fixed this within RetroArch's own internal CHD handler. However, that fix only applies to RetroArch itself. rcheevos' default cdreader has never had any CHD support, meaning every other client that calls `rc_hash_init_default_cdreader()` still fails entirely. This PR fixes the root cause at the library level so all clients benefit.

**Related upstream issues:**
- libretro/RetroArch#18005
- libretro/RetroArch#16145

---

## Solution

Add native CHD reading to `cdreader.c` via [libchdr](https://github.com/rtissera/libchdr), added as a submodule at `deps/libchdr`.

The feature is gated behind a `HAVE_CHD` compile flag so existing clients that supply their own CHD callback (e.g. RetroArch) can opt out and keep their own implementation unchanged.

### Two CHD formats are now supported

**`createcd` CHDs**
Contain `CDROM_TRACK_METADATA` / `CDROM_TRACK_METADATA2` entries. We scan them to locate the requested track and configure sector geometry (size, header offset) correctly per track type (`MODE1`, `MODE2`, `AUDIO`). All track selection modes are supported: exact number, `RC_HASH_CDTRACK_FIRST_DATA`, `RC_HASH_CDTRACK_LARGEST`, `RC_HASH_CDTRACK_LAST`.

**`createdvd` CHDs**
Contain no CD track metadata. Detected by `header->unitbytes == 2048` and `Metadata Tag='DVD '`. Synthesised as a single virtual track covering all raw 2048-byte DVD sectors with no header stripping needed. This is the root cause of issues #18005 and #16145.

---

## Implementation notes

- `rc_chd_reader_t` wraps the open `chd_file*` and presents a `rc_hash_filereader_t` interface, so `cdreader_read_sector` and `cdreader_close_track` work completely unchanged.
- Hunk decompression is cached (`buffered_hunk`) to avoid repeated `chd_read` calls when reading across sector boundaries.
- libchdr supports all CHD compression codecs including **Zstandard (zstd)**, which is what modern `chdman` uses by default. Real-world PS2 CHDs downloaded today typically use zstd. Without this fix they fail even in clients that partially handle CHD.
- No changes to `hash_disc.c` or any console-specific hash logic; the fix is entirely in the CD reader layer.
- Clients that already handle CHD (e.g. RetroArch) are unaffected; they override `open_track_iterator` before our code runs.

---

## Real-world verification

Inspecting a real-world downloaded PS2 CHD with `chdman info` confirms the exact format this fix targets:

<img width="861" height="268" alt="chdman_test" src="https://github.com/user-attachments/assets/b86c362d-f5e1-444a-8174-15c257703d0b" />

Tested against 3 PS2 titles, each hashed from both the original ISO and a `createdvd` CHD. All three produce identical hashes:

| Game | Hash |
|---|---|
| Shrek 2 (USA) | `3d9206a51e2ab540c3c0f344cd30520d` |
| Star Wars: Battlefront II (USA) (v2.01) | `ffb7e6298d9386cc197af821e67e58f9` |
| Spider-Man (USA) (v2.01) | `c7b60699f5e993f3fd89a163eda917b0` |

<img width="882" height="1261" alt="hash_test" src="https://github.com/user-attachments/assets/5a60d21a-de65-4434-8313-e9ab752962a5" />

---

## Build & test
```bash
# Baseline — no CHD, all existing tests pass
make ARCH=x64 BUILD=c89

# With CHD enabled — all existing tests still pass
make ARCH=x64 BUILD=c89 HAVE_CHD=1
```

All 2720 existing tests pass in both configurations.