### PR TITLE
ensure richpresence owned memrefs get updated

### DIFF
--- a/src/rc_client.c
+++ b/src/rc_client.c
@@ -5810,9 +5810,6 @@ static void rc_client_update_memref_values(rc_client_t* client) {
     } while (modified_memref_list);
   }
 
-  if (client->game->runtime.richpresence && client->game->runtime.richpresence->richpresence)
-    rc_update_values(client->game->runtime.richpresence->richpresence->values, client->state.legacy_peek, client);
-
   if (invalidated_memref)
     rc_client_update_active_achievements(client->game);
 }

--- a/src/rcheevos/richpresence.c
+++ b/src/rcheevos/richpresence.c
@@ -725,13 +725,14 @@ rc_memrefs_t* rc_richpresence_get_memrefs(rc_richpresence_t* self) {
 void rc_update_richpresence(rc_richpresence_t* richpresence, rc_peek_t peek, void* peek_ud, void* unused_L) {
   (void)unused_L;
 
-  rc_update_richpresence_memrefs(richpresence, peek, peek_ud);
-  rc_update_values(richpresence->values, peek, peek_ud);
   rc_update_richpresence_internal(richpresence, peek, peek_ud);
 }
 
 void rc_update_richpresence_internal(rc_richpresence_t* richpresence, rc_peek_t peek, void* peek_ud) {
   rc_richpresence_display_t* display;
+
+  rc_update_richpresence_memrefs(richpresence, peek, peek_ud);
+  rc_update_values(richpresence->values, peek, peek_ud);
 
   for (display = richpresence->first_display; display; display = display->next) {
     if (display->has_required_hits)


### PR DESCRIPTION
Alternate fix for #470 that ensures a richpresence that owns memrefs still updates the memrefs each frame (and only once per frame).

Prerequisite for changes I want to make in the DLL to relocate the ownership of memory associated to local rich presence scripts.