### PR TITLE
Use _vsnprintf_s() in rc_client_log_message_va()

### DIFF
--- a/src/rc_client.c
+++ b/src/rc_client.c
@@ -240,7 +240,7 @@ static void rc_client_log_message_va(const rc_client_t* client, const char* form
     char buffer[2048];
 
 #ifdef __STDC_SECURE_LIB__
-    vsprintf_s(buffer, sizeof(buffer), format, args);
+    vsnprintf_s(buffer, sizeof(buffer), _TRUNCATE, format, args);
 #elif __STDC_VERSION__ >= 199901L /* vsnprintf requires c99 */
     vsnprintf(buffer, sizeof(buffer), format, args);
 #else /* c89 doesn't have a size-limited vsprintf function - assume the buffer is large enough */


### PR DESCRIPTION
vsprintf_s() will abort the program if the buffer is too small to contain the message, which can happen with long error messages.

Instead, use _vsnprintf_s() with _TRUNCATE, which matches the non-Windows vsnprintf() behavior.