### PR TITLE
Prevent popup on MeasuredIf activation

### DIFF
--- a/include/rc_runtime_types.h
+++ b/include/rc_runtime_types.h
@@ -289,6 +289,9 @@ struct rc_trigger_t {
   /* True if the measured value should be displayed as a percentage */
   uint8_t measured_as_percent;
 
+  /* True if all MeasuredIf conditions are true */
+  uint8_t can_measure;
+
   /* True if the trigger has its own rc_memrefs_t */
   uint8_t has_memrefs;
 };

--- a/src/rc_client.c
+++ b/src/rc_client.c
@@ -5834,12 +5834,14 @@ static void rc_client_do_frame_process_achievements(rc_client_t* client, rc_clie
     rc_trigger_t* trigger = achievement->trigger;
     int old_state, new_state;
     uint32_t old_measured_value;
+    uint8_t old_can_measure;
 
     if (!trigger || achievement->public_.state != RC_CLIENT_ACHIEVEMENT_STATE_ACTIVE)
       continue;
 
     old_measured_value = trigger->measured_value;
     old_state = trigger->state;
+    old_can_measure = trigger->can_measure;
     new_state = rc_evaluate_trigger(trigger, client->state.legacy_peek, client, NULL);
 
     /* trigger->state doesn't actually change to RESET - RESET just serves as a notification.
@@ -5872,8 +5874,8 @@ static void rc_client_do_frame_process_achievements(rc_client_t* client, rc_clie
       }
     }
 
-    /* if the state hasn't changed, there won't be any events raised */
-    if (new_state == old_state)
+    /* if the state hasn't changed or it just became measurable, there won't be any events raised */
+    if (new_state == old_state || !old_can_measure)
       continue;
 
     /* raise a CHALLENGE_INDICATOR_HIDE event when changing from PRIMED to anything else */

--- a/src/rcheevos/runtime.c
+++ b/src/rcheevos/runtime.c
@@ -520,6 +520,7 @@ void rc_runtime_do_frame(rc_runtime_t* self, rc_runtime_event_handler_t event_ha
     rc_trigger_t* trigger = self->triggers[i].trigger;
     int old_state, new_state;
     uint32_t old_measured_value;
+    uint8_t old_can_measure = 0;
 
     if (!trigger)
       continue;
@@ -540,6 +541,7 @@ void rc_runtime_do_frame(rc_runtime_t* self, rc_runtime_event_handler_t event_ha
 
     old_measured_value = trigger->measured_value;
     old_state = trigger->state;
+    old_can_measure = trigger->can_measure;
     new_state = rc_evaluate_trigger(trigger, peek, ud, unused_L);
 
     /* trigger->state doesn't actually change to RESET, RESET just serves as a notification.
@@ -578,8 +580,8 @@ void rc_runtime_do_frame(rc_runtime_t* self, rc_runtime_event_handler_t event_ha
       runtime_event.value = 0; /* achievement loop expects this to stay at 0 */
     }
 
-    /* if the state hasn't changed, there won't be any events raised */
-    if (new_state == old_state)
+    /* if the state hasn't changed or it just became measurable, there won't be any events raised */
+    if (new_state == old_state || !old_can_measure)
       continue;
 
     /* raise an UNPRIMED event when changing from PRIMED to anything else */

--- a/src/rcheevos/trigger.c
+++ b/src/rcheevos/trigger.c
@@ -234,6 +234,7 @@ int rc_evaluate_trigger(rc_trigger_t* self, rc_peek_t peek, void* ud, void* unus
     /* if the core is not paused, all alts must be paused to count as a paused trigger */
     is_paused |= sub_paused;
   }
+  self->can_measure = eval_state.can_measure;
 
   if (is_paused) {
     /* if the trigger is fully paused, ignore any updates to the measured value */


### PR DESCRIPTION
This prevent the popup that happens because the value goes from being 0ed out by the measuredif to the actual value when all measuredifs become true.

It would allow a whole bunch of control over the pop ups with the logic and we would be able to do things like make the progress tracker pop up appear only once every 10 increments or even crazyier things that I can't even think of, all that while still having the measured value be readable in the retroacheivement menu of the emulator.

The problem would be if some sets rely on this specific pop up but that sounds a bit weird and I don't think any achievements actually do that.