### PR TITLE
prevent null dereference processing recall chain with no remember

### DIFF
--- a/src/rcheevos/alloc.c
+++ b/src/rcheevos/alloc.c
@@ -213,6 +213,10 @@ static void rc_preparse_sync_operand(rc_operand_t* operand, rc_parse_state_t* pa
 {
   if (rc_operand_is_memref(operand) || rc_operand_is_recall(operand)) {
     const rc_memref_t* src_memref = operand->value.memref;
+    if (!src_memref) {
+      parse->offset = RC_INVALID_MEMORY_OPERAND;
+      return;
+    }
 
     if (src_memref->value.memref_type == RC_MEMREF_TYPE_MODIFIED_MEMREF) {
       const rc_modified_memref_list_t* modified_memref_list = &memrefs->modified_memrefs;

--- a/src/rcheevos/richpresence.c
+++ b/src/rcheevos/richpresence.c
@@ -38,6 +38,11 @@ static void rc_alloc_helper_variable_memref_value(rc_richpresence_display_part_t
   /* ensure new needed memrefs are allocated in the primary buffer */
   rc_preparse_copy_memrefs(parse, &preparse.memrefs);
 
+  if (parse->offset < 0) {
+    rc_destroy_preparse_state(&preparse);
+    return;
+  }
+
   /* parse the value into the scratch buffer so we can look at it */
   rc_reset_parse_state(&preparse.parse, rc_buffer_alloc(&preparse.parse.scratch.buffer, (size_t)size));
   preparse.parse.memrefs = parse->memrefs;

--- a/test/rcheevos/test_richpresence.c
+++ b/test/rcheevos/test_richpresence.c
@@ -1202,6 +1202,13 @@ static void test_macro_mathematic_chain() {
   ASSERT_NUM_EQUALS(lines, 5);
 }
 
+static void test_macro_invalid_recall_chain() {
+  int lines;
+  int result = rc_richpresence_size_lines("Format:Points\nFormatType=VALUE\n\nDisplay:\n@Points(K:{recall}+6_A:{recall}_M:0) Points", &lines);
+  ASSERT_NUM_EQUALS(result, RC_INVALID_MEMORY_OPERAND);
+  ASSERT_NUM_EQUALS(lines, 5);
+}
+
 static void test_builtin_macro(const char* macro, const char* expected) {
   uint8_t ram[] = { 0x39, 0x30 };
   memory_t memory;
@@ -1523,6 +1530,7 @@ void test_richpresence(void) {
   TEST(test_macro_without_parameter_conditional_display);
   TEST(test_macro_non_numeric_parameter);
   TEST(test_macro_mathematic_chain);
+  TEST(test_macro_invalid_recall_chain);
 
   /* builtin macros */
   TEST_PARAMS2(test_builtin_macro, "Number", "12,345");


### PR DESCRIPTION
https://discord.com/channels/310192285306454017/533411674162593812/1494791247850770573

When a `{recall}` does not have a `Remember` to reference in a value expression (such as those used by rich presence), a null reference was occurring. Now `RC_INVALID_MEMORY_OPERAND` will be returned.