### PR TITLE
hash: content-hash .neo (Geolith Neo Geo cart) files

### DIFF
--- a/src/rhash/hash.c
+++ b/src/rhash/hash.c
@@ -543,6 +543,11 @@ static int rc_hash_from_buffer(char hash[33], uint32_t console_id, const rc_hash
       return rc_hash_buffer(hash, iterator->buffer, iterator->buffer_size, iterator);
 
 #ifndef RC_HASH_NO_ROM
+    case RC_CONSOLE_ARCADE:
+      /* .neo (Geolith Neo Geo cart) files carry the ROM data; other arcade
+       * formats are archives, which aren't hashed from a buffer. */
+      return rc_hash_neogeo_cart(hash, iterator);
+
     case RC_CONSOLE_ARDUBOY:
       return rc_hash_arduboy(hash, iterator);
 

--- a/src/rhash/hash.c
+++ b/src/rhash/hash.c
@@ -1230,6 +1230,7 @@ static const rc_hash_iterator_ext_handler_entry_t rc_hash_iterator_ext_handlers[
   { "n64", rc_hash_initialize_iterator_single, RC_CONSOLE_NINTENDO_64 },
   { "ndd", rc_hash_initialize_iterator_single, RC_CONSOLE_NINTENDO_64 },
   { "nds", rc_hash_initialize_iterator_single, RC_CONSOLE_NINTENDO_DS }, /* handles both DS and DSi */
+  { "neo", rc_hash_initialize_iterator_single, RC_CONSOLE_ARCADE }, /* Geolith Neo Geo cart format */
   { "nes", rc_hash_initialize_iterator_single, RC_CONSOLE_NINTENDO },
   { "ngc", rc_hash_initialize_iterator_single, RC_CONSOLE_NEOGEO_POCKET },
   { "nib", rc_hash_initialize_iterator_nib, 0 },

--- a/src/rhash/hash.c
+++ b/src/rhash/hash.c
@@ -862,6 +862,11 @@ static int rc_hash_from_file(char hash[33], uint32_t console_id, const rc_hash_i
 
 #ifndef RC_HASH_NO_ROM
     case RC_CONSOLE_ARCADE:
+      /* .neo files (Geolith Neo Geo cart format) contain the actual ROM data,
+       * so are content-hashed. Everything else (.zip/.7z) hashes by filename. */
+      if (rc_path_compare_extension(path, "neo"))
+        return rc_hash_neogeo_cart(hash, iterator);
+
       return rc_hash_arcade(hash, iterator);
 
     case RC_CONSOLE_ARDUBOY:

--- a/src/rhash/hash_rom.c
+++ b/src/rhash/hash_rom.c
@@ -359,22 +359,25 @@ int rc_hash_neogeo_cart(char hash[33], const rc_hash_iterator_t* iterator)
   md5_init(&md5);
 
   buffer = (uint8_t*)malloc(chunk_size);
-  if (buffer) {
-    rc_file_seek(iterator, file_handle, (int64_t)header_size, SEEK_SET);
-    while (remaining >= chunk_size) {
-      rc_file_read(iterator, file_handle, buffer, (int)chunk_size);
-      md5_append(&md5, buffer, (int)chunk_size);
-      remaining -= chunk_size;
-    }
-
-    if (remaining > 0) {
-      rc_file_read(iterator, file_handle, buffer, (int)remaining);
-      md5_append(&md5, buffer, (int)remaining);
-    }
-
-    free(buffer);
-    result = rc_hash_finalize(iterator, &md5, hash);
+  if (!buffer) {
+    rc_file_close(iterator, file_handle);
+    return rc_hash_iterator_error(iterator, "Could not allocate temporary buffer");
   }
+
+  rc_file_seek(iterator, file_handle, (int64_t)header_size, SEEK_SET);
+  while (remaining >= chunk_size) {
+    rc_file_read(iterator, file_handle, buffer, (int)chunk_size);
+    md5_append(&md5, buffer, (int)chunk_size);
+    remaining -= chunk_size;
+  }
+
+  if (remaining > 0) {
+    rc_file_read(iterator, file_handle, buffer, (int)remaining);
+    md5_append(&md5, buffer, (int)remaining);
+  }
+
+  free(buffer);
+  result = rc_hash_finalize(iterator, &md5, hash);
 
   rc_file_close(iterator, file_handle);
   return result;

--- a/src/rhash/hash_rom.c
+++ b/src/rhash/hash_rom.c
@@ -297,6 +297,89 @@ int rc_hash_n64(char hash[33], const rc_hash_iterator_t* iterator)
   return rc_hash_finalize(iterator, &md5, hash);
 }
 
+int rc_hash_neogeo_cart(char hash[33], const rc_hash_iterator_t* iterator)
+{
+  /* The first 4096 bytes of a .neo file are a header: a magic number, the
+   * sizes of the ROM sections, and metadata text fields (name, manufacturer,
+   * genre, ...). The text fields can differ between conversion tools, so the
+   * header cannot participate in the hash. The decrypted, concatenated ROM
+   * data starts at byte 4096 and is deterministic for a given romset - hash
+   * only that.
+   * https://github.com/libretro/geolith-libretro (src/geo_neo.c)
+   */
+  const size_t header_size = 4096;
+  const size_t chunk_size = 65536;
+  md5_state_t md5;
+  uint8_t* buffer;
+  uint8_t header[4];
+  int64_t size;
+  void* file_handle;
+  size_t remaining;
+  int result = 0;
+
+  if (iterator->buffer) {
+    if (iterator->buffer_size < header_size ||
+        memcmp(iterator->buffer, "NEO\1", 4) != 0)
+      return rc_hash_iterator_error(iterator, "Not a valid .neo file");
+
+    rc_hash_iterator_verbose(iterator, "Ignoring NEO header");
+    return rc_hash_unheadered_iterator_buffer(hash, iterator, header_size);
+  }
+
+  file_handle = rc_file_open(iterator, iterator->path);
+  if (!file_handle)
+    return rc_hash_iterator_error(iterator, "Could not open file");
+
+  rc_file_seek(iterator, file_handle, 0, SEEK_SET);
+  if (rc_file_read(iterator, file_handle, header, 4) != 4 ||
+      memcmp(header, "NEO\1", 4) != 0) {
+    rc_file_close(iterator, file_handle);
+    return rc_hash_iterator_error(iterator, "Not a valid .neo file");
+  }
+
+  rc_file_seek(iterator, file_handle, 0, SEEK_END);
+  size = rc_file_tell(iterator, file_handle);
+  if (size <= (int64_t)header_size) {
+    rc_file_close(iterator, file_handle);
+    return rc_hash_iterator_error(iterator, "Not a valid .neo file");
+  }
+  size -= (int64_t)header_size;
+
+  if (size > MAX_BUFFER_SIZE) {
+    rc_hash_iterator_verbose_formatted(iterator, "Hashing first %u bytes (of %u bytes) of %s after 4096 byte header",
+      MAX_BUFFER_SIZE, (unsigned)size, rc_path_get_filename(iterator->path));
+    remaining = MAX_BUFFER_SIZE;
+  }
+  else {
+    rc_hash_iterator_verbose_formatted(iterator, "Hashing %s (%u bytes after 4096 byte header)",
+      rc_path_get_filename(iterator->path), (unsigned)size);
+    remaining = (size_t)size;
+  }
+
+  md5_init(&md5);
+
+  buffer = (uint8_t*)malloc(chunk_size);
+  if (buffer) {
+    rc_file_seek(iterator, file_handle, (int64_t)header_size, SEEK_SET);
+    while (remaining >= chunk_size) {
+      rc_file_read(iterator, file_handle, buffer, (int)chunk_size);
+      md5_append(&md5, buffer, (int)chunk_size);
+      remaining -= chunk_size;
+    }
+
+    if (remaining > 0) {
+      rc_file_read(iterator, file_handle, buffer, (int)remaining);
+      md5_append(&md5, buffer, (int)remaining);
+    }
+
+    free(buffer);
+    result = rc_hash_finalize(iterator, &md5, hash);
+  }
+
+  rc_file_close(iterator, file_handle);
+  return result;
+}
+
 int rc_hash_nintendo_ds(char hash[33], const rc_hash_iterator_t* iterator)
 {
   uint8_t header[512];

--- a/src/rhash/rc_hash_internal.h
+++ b/src/rhash/rc_hash_internal.h
@@ -74,6 +74,7 @@ int rc_hash_buffered_file(char hash[33], uint32_t console_id, const rc_hash_iter
   int rc_hash_lynx(char hash[33], const rc_hash_iterator_t* iterator);
   int rc_hash_nes(char hash[33], const rc_hash_iterator_t* iterator);
   int rc_hash_n64(char hash[33], const rc_hash_iterator_t* iterator);
+  int rc_hash_neogeo_cart(char hash[33], const rc_hash_iterator_t* iterator);
   int rc_hash_nintendo_ds(char hash[33], const rc_hash_iterator_t* iterator);
   int rc_hash_pce(char hash[33], const rc_hash_iterator_t* iterator);
   int rc_hash_scv(char hash[33], const rc_hash_iterator_t* iterator);

--- a/test/rhash/test_hash_rom.c
+++ b/test/rhash/test_hash_rom.c
@@ -708,6 +708,7 @@ void test_hash_rom(void) {
   /* Arcade */
   TEST_PARAMS2(test_hash_arcade, "game.zip", "c8d46d341bea4fd5bff866a65ff8aea9");
   TEST_PARAMS2(test_hash_arcade, "game.7z", "c8d46d341bea4fd5bff866a65ff8aea9");
+  TEST_PARAMS2(test_hash_arcade, "game.neo", "c8d46d341bea4fd5bff866a65ff8aea9");
   TEST_PARAMS2(test_hash_arcade, "/game.zip", "c8d46d341bea4fd5bff866a65ff8aea9");
   TEST_PARAMS2(test_hash_arcade, "\\game.zip", "c8d46d341bea4fd5bff866a65ff8aea9");
   TEST_PARAMS2(test_hash_arcade, "roms\\game.zip", "c8d46d341bea4fd5bff866a65ff8aea9");

--- a/test/rhash/test_hash_rom.c
+++ b/test/rhash/test_hash_rom.c
@@ -40,6 +40,112 @@ static void test_hash_arcade(const char* path, const char* expected_md5)
 
 /* ========================================================================= */
 
+/* Builds a synthetic .neo file: 4096-byte header (magic, P ROM size, and
+ * tool-variant text fields) followed by payload_size bytes of ROM data.
+ * fill_image seeds from size, so the payload is byte-identical to
+ * generate_generic_file(payload_size) - tests use that for cross-checking. */
+static uint8_t* generate_neo_file(size_t payload_size, const char* name, const char* manufacturer, size_t* image_size)
+{
+  const size_t header_size = 4096;
+  uint8_t* image;
+
+  *image_size = header_size + payload_size;
+  image = (uint8_t*)calloc(*image_size, 1);
+  if (image) {
+    image[0] = 'N'; image[1] = 'E'; image[2] = 'O'; image[3] = 1;
+    /* P ROM size (little endian) - whole payload for simplicity */
+    image[4] = (uint8_t)(payload_size & 0xFF);
+    image[5] = (uint8_t)((payload_size >> 8) & 0xFF);
+    image[6] = (uint8_t)((payload_size >> 16) & 0xFF);
+    image[7] = (uint8_t)((payload_size >> 24) & 0xFF);
+    /* tool-variant metadata text fields */
+    snprintf((char*)&image[44], 33, "%s", name);
+    snprintf((char*)&image[77], 17, "%s", manufacturer);
+
+    fill_image(&image[header_size], payload_size);
+  }
+
+  return image;
+}
+
+static void test_hash_neo()
+{
+  /* the hash of a .neo file is the hash of its ROM data (everything after
+   * the 4096-byte header), so must match a plain full-buffer hash of the
+   * payload alone */
+  const size_t payload_size = 131072;
+  size_t image_size;
+  uint8_t* image = generate_neo_file(payload_size, "Test Game", "TestCorp", &image_size);
+  uint8_t* payload = generate_generic_file(payload_size);
+  char hash_file[33], hash_iterator[33], hash_payload[33];
+  int result_file, result_iterator, result_payload;
+  struct rc_hash_iterator iterator;
+
+  result_payload = rc_hash_generate_from_buffer(hash_payload, RC_CONSOLE_MEGA_DRIVE, payload, payload_size);
+  free(payload);
+
+  mock_file(0, "game.neo", image, image_size);
+
+  result_file = rc_hash_generate_from_file(hash_file, RC_CONSOLE_ARCADE, "game.neo");
+
+  rc_hash_initialize_iterator(&iterator, "game.neo", NULL, 0);
+  result_iterator = rc_hash_iterate(hash_iterator, &iterator);
+  rc_hash_destroy_iterator(&iterator);
+  free(image);
+
+  ASSERT_NUM_EQUALS(result_payload, 1);
+  ASSERT_NUM_EQUALS(result_file, 1);
+  ASSERT_STR_EQUALS(hash_file, hash_payload);
+
+  ASSERT_NUM_EQUALS(result_iterator, 1);
+  ASSERT_STR_EQUALS(hash_iterator, hash_payload);
+}
+
+static void test_hash_neo_header_variants()
+{
+  /* conversion tools fill the header text fields differently - two .neo
+   * files with the same ROM data but different headers must hash the same */
+  const size_t payload_size = 131072;
+  size_t image_size;
+  uint8_t* image1 = generate_neo_file(payload_size, "Test Game", "TestCorp", &image_size);
+  uint8_t* image2 = generate_neo_file(payload_size, "test game (alt name)", "OtherTool", &image_size);
+  char hash1[33], hash2[33];
+  int result1, result2;
+
+  mock_file(0, "game1.neo", image1, image_size);
+  mock_file(1, "game2.neo", image2, image_size);
+
+  result1 = rc_hash_generate_from_file(hash1, RC_CONSOLE_ARCADE, "game1.neo");
+  result2 = rc_hash_generate_from_file(hash2, RC_CONSOLE_ARCADE, "game2.neo");
+
+  free(image2);
+  free(image1);
+
+  ASSERT_NUM_EQUALS(result1, 1);
+  ASSERT_NUM_EQUALS(result2, 1);
+  ASSERT_STR_EQUALS(hash1, hash2);
+}
+
+static void test_hash_neo_bad_magic()
+{
+  /* a .neo file without the NEO\1 magic must not hash */
+  const size_t payload_size = 131072;
+  size_t image_size;
+  uint8_t* image = generate_neo_file(payload_size, "Test Game", "TestCorp", &image_size);
+  char hash_file[33];
+  int result_file;
+
+  image[3] = 2; /* unsupported version */
+  mock_file(0, "game.neo", image, image_size);
+
+  result_file = rc_hash_generate_from_file(hash_file, RC_CONSOLE_ARCADE, "game.neo");
+  free(image);
+
+  ASSERT_NUM_EQUALS(result_file, 0);
+}
+
+/* ========================================================================= */
+
 static void test_hash_arduboy()
 {
   char hash_file[33], hash_iterator[33];
@@ -708,7 +814,6 @@ void test_hash_rom(void) {
   /* Arcade */
   TEST_PARAMS2(test_hash_arcade, "game.zip", "c8d46d341bea4fd5bff866a65ff8aea9");
   TEST_PARAMS2(test_hash_arcade, "game.7z", "c8d46d341bea4fd5bff866a65ff8aea9");
-  TEST_PARAMS2(test_hash_arcade, "game.neo", "c8d46d341bea4fd5bff866a65ff8aea9");
   TEST_PARAMS2(test_hash_arcade, "/game.zip", "c8d46d341bea4fd5bff866a65ff8aea9");
   TEST_PARAMS2(test_hash_arcade, "\\game.zip", "c8d46d341bea4fd5bff866a65ff8aea9");
   TEST_PARAMS2(test_hash_arcade, "roms\\game.zip", "c8d46d341bea4fd5bff866a65ff8aea9");
@@ -748,6 +853,11 @@ void test_hash_rom(void) {
   TEST_PARAMS2(test_hash_arcade, "/home/user/sg1000/game.zip", "e8f6c711c4371f09537b4f2a7a304d6c");
   TEST_PARAMS2(test_hash_arcade, "/home/user/spectrum/game.zip", "a5f62157b2617bd728c4b1bc885c29e9");
   TEST_PARAMS2(test_hash_arcade, "/home/user/ngp/game.zip", "d4133b74c4e57274ca514e27a370dcb6");
+
+  /* Arcade .neo (Geolith Neo Geo cart) - content hash, not filename hash */
+  TEST(test_hash_neo);
+  TEST(test_hash_neo_header_variants);
+  TEST(test_hash_neo_bad_magic);
 
   /* Arduboy */
   TEST(test_hash_arduboy);


### PR DESCRIPTION
## Summary

Registers the `.neo` file extension in the hash-iterator console table under `RC_CONSOLE_ARCADE`, and adds a dedicated hashing function for it: `.neo` files contain the actual ROM data, so they are content-hashed rather than using the arcade filename hash.

## Hashing

The first 4096 bytes of a `.neo` file are a header — magic number, ROM section sizes, then metadata text fields (name, manufacturer, genre). The text fields vary between conversion tools, so the header can't participate in the hash (confirmed with the Geolith author). The decrypted, concatenated ROM data starts at byte 4096 and is deterministic for a given romset, so the hash covers everything from byte 4096 to EOF (capped at `MAX_BUFFER_SIZE`, consistent with `rc_hash_whole_file`). The `NEO\1` magic is validated before hashing.

Other arcade content (`.zip`, `.7z`) is unaffected and keeps the filename hash.

## Background

The [Geolith](https://github.com/libretro/geolith-libretro) libretro core loads Neo Geo cartridges from a self-contained `.neo` file format (one game per file). Geolith now also validates ROMs internally against a checksum database of the canonical set, and that set can be used to seed RA-side hashes — the Geolith author has offered to supply the list.

## Tests

- `test_hash_neo` — hash of a `.neo` file equals the hash of its ROM payload alone
- `test_hash_neo_header_variants` — two files with identical ROM data but different header text fields produce the same hash
- `test_hash_neo_bad_magic` — files without the `NEO\1` magic do not hash

Full suite passes (2733/2733). Branch rebased on current develop.