### PR TITLE
fix subsource chain starting with a constant

### DIFF
--- a/src/rcheevos/condition.c
+++ b/src/rcheevos/condition.c
@@ -411,10 +411,13 @@ void rc_condition_update_parse_state(rc_condition_t* condition, rc_parse_state_t
           negate = rc_alloc_modified_memref(parse, new_size, &parse->addsource_parent, RC_OPERATOR_SUB_PARENT, &zero);
           parse->addsource_parent.value.memref = (rc_memref_t*)negate;
           parse->addsource_parent.size = zero.size;
+
+          if (parse->addsource_parent.type == RC_OPERAND_CONST)
+            parse->addsource_parent.value.num = rc_get_modified_memref_value(negate, NULL, NULL);
         }
 
         /* subtract the condition from the chain */
-        parse->addsource_oper = rc_operand_is_memref(&parse->addsource_parent) ? RC_OPERATOR_SUB_ACCUMULATOR : RC_OPERATOR_SUB_PARENT;
+        parse->addsource_oper = RC_OPERATOR_SUB_ACCUMULATOR;
         rc_condition_convert_to_operand(condition, &cond_operand, parse);
         rc_operand_addsource(&cond_operand, parse, new_size);
         memcpy(&parse->addsource_parent, &cond_operand, sizeof(cond_operand));

--- a/src/rcheevos/memref.c
+++ b/src/rcheevos/memref.c
@@ -742,6 +742,7 @@ uint32_t rc_get_modified_memref_value(const rc_modified_memref_t* memref, rc_pee
       break;
 
     case RC_OPERATOR_SUB_ACCUMULATOR:
+      /* sub accumulator is "parent - modifier" */
       rc_typed_value_negate(&modifier);
       /* fallthrough */ /* to case RC_OPERATOR_SUB_ACCUMULATOR */
 

--- a/src/rcheevos/rc_runtime_types.natvis
+++ b/src/rcheevos/rc_runtime_types.natvis
@@ -221,6 +221,8 @@
         <DisplayString Condition="value==RC_OPERATOR_ADD">{RC_OPERATOR_ADD}</DisplayString>
         <DisplayString Condition="value==RC_OPERATOR_SUB">{RC_OPERATOR_SUB}</DisplayString>
         <DisplayString Condition="value==RC_OPERATOR_SUB_PARENT">{RC_OPERATOR_SUB_PARENT}</DisplayString>
+        <DisplayString Condition="value==RC_OPERATOR_ADD_ACCUMULATOR">{RC_OPERATOR_ADD_ACCUMULATOR}</DisplayString>
+        <DisplayString Condition="value==RC_OPERATOR_SUB_ACCUMULATOR">{RC_OPERATOR_SUB_ACCUMULATOR}</DisplayString>
         <DisplayString Condition="value==RC_OPERATOR_INDIRECT_READ">{RC_OPERATOR_INDIRECT_READ}</DisplayString>
         <DisplayString>unknown ({value})</DisplayString>
     </Type>
@@ -281,6 +283,8 @@
     <Type Name="rc_modified_memref_t">
         <DisplayString Condition="modifier_type==RC_OPERATOR_INDIRECT_READ">$({parent} + {modifier})</DisplayString>
         <DisplayString Condition="modifier_type==RC_OPERATOR_SUB_PARENT">({modifier} - {parent})</DisplayString>
+        <DisplayString Condition="modifier_type==RC_OPERATOR_ADD_ACCUMULATOR">({parent} + {modifier})</DisplayString>
+        <DisplayString Condition="modifier_type==RC_OPERATOR_SUB_ACCUMULATOR">({parent} - {modifier})</DisplayString>
         <DisplayString>({parent} {*((__rc_operator_enum_str_t*)&amp;modifier_type)} {modifier})</DisplayString>
         <Expand>
             <Item Name="value">memref.value</Item>

--- a/test/rcheevos/test_condset.c
+++ b/test/rcheevos/test_condset.c
@@ -2935,6 +2935,27 @@ static void test_addsource_long_chain() {
   free(buffer);
 }
 
+static void test_subsource_constant() {
+  uint8_t ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  memory_t memory;
+  rc_condset_t* condset;
+  rc_memrefs_t memrefs;
+  char buffer[2048];
+
+  memory.ram = ram;
+  memory.size = sizeof(ram);
+
+  /* -1 - byte(0) + byte(1) = 10 */
+  assert_parse_condset(&condset, &memrefs, buffer, "B:1_B:0xH0000_0xH0001=10");
+
+  /* -1 - 0 + 18 = 10 */
+  assert_evaluate_condset(condset, memrefs, &memory, 0);
+
+  /* -1 - 7 + 18 = 10 */
+  ram[0] = 7;
+  assert_evaluate_condset(condset, memrefs, &memory, 1);
+}
+
 static void test_addhits() {
   uint8_t ram[] = {0x00, 0x12, 0x34, 0xAB, 0x56};
   memory_t memory;
@@ -5098,6 +5119,7 @@ void test_condset(void) {
   TEST(test_addsource_float_division);
   TEST(test_addsource_recall_float_division);
   TEST(test_addsource_long_chain);
+  TEST(test_subsource_constant);
 
   /* addhits/subhits */
   TEST(test_addhits);

--- a/test/rcheevos/test_condset.c
+++ b/test/rcheevos/test_condset.c
@@ -2945,6 +2945,27 @@ static void test_subsource_constant() {
   memory.ram = ram;
   memory.size = sizeof(ram);
 
+  /* -1 + byte(1) = 10 */
+  assert_parse_condset(&condset, &memrefs, buffer, "B:1_0xH0001=10");
+
+  /* -1 + 18 = 10 */
+  assert_evaluate_condset(condset, memrefs, &memory, 0);
+
+  /* -1 + 11 = 10 */
+  ram[1] = 11;
+  assert_evaluate_condset(condset, memrefs, &memory, 1);
+}
+
+static void test_subsource_constant_and_memref() {
+  uint8_t ram[] = { 0x00, 0x12, 0x34, 0xAB, 0x56 };
+  memory_t memory;
+  rc_condset_t* condset;
+  rc_memrefs_t memrefs;
+  char buffer[2048];
+
+  memory.ram = ram;
+  memory.size = sizeof(ram);
+
   /* -1 - byte(0) + byte(1) = 10 */
   assert_parse_condset(&condset, &memrefs, buffer, "B:1_B:0xH0000_0xH0001=10");
 
@@ -5120,6 +5141,7 @@ void test_condset(void) {
   TEST(test_addsource_recall_float_division);
   TEST(test_addsource_long_chain);
   TEST(test_subsource_constant);
+  TEST(test_subsource_constant_and_memref);
 
   /* addhits/subhits */
   TEST(test_addhits);


### PR DESCRIPTION
fixes #525 

When a SubSource follows another SubSource, a constant is injected so it becomes (0 - A - B). When A is a constant, the (0 - A) modified_memref was correctly flagged as a constant, but the value was not initialized, breaking the remaining logic of the chain.