### PR TITLE
fallback to file hashing for buffered cd-related files

### DIFF
--- a/src/rhash/hash.c
+++ b/src/rhash/hash.c
@@ -503,6 +503,19 @@ static int rc_hash_from_buffer(char hash[33], uint32_t console_id, const rc_hash
 {
   switch (console_id) {
     default:
+      if (iterator->path) {
+        const char* ext = rc_path_get_extension(iterator->path);
+        if (strcasecmp(ext, "cue") == 0 ||
+          strcasecmp(ext, "m3u") == 0 ||
+          strcasecmp(ext, "iso") == 0 ||
+          strcasecmp(ext, "chd") == 0) {
+          /* These extensions are associated to CD media. If buffered data
+           * was provided, ignore it and try to open the media directly. */
+          if (rc_hash_from_file(hash, console_id, iterator))
+            return 1;
+        }
+      }
+
       return rc_hash_iterator_error_formatted(iterator, "Unsupported console for buffer hash: %d", console_id);
 
     case RC_CONSOLE_AMSTRAD_PC:

--- a/test/rhash/test_hash_disc.c
+++ b/test/rhash/test_hash_disc.c
@@ -589,9 +589,7 @@ static void test_hash_dreamcast_split_bin()
   ASSERT_STR_EQUALS(hash_iterator, expected_md5);
 }
 
-static void test_hash_dreamcast_cue()
-{
-  const char* cue_file =
+static const char* dreamcast_cue_file =
       "FILE \"track01.bin\" BINARY\n"
       "  TRACK 01 MODE1/2352\n"
       "    INDEX 01 00:00:00\n"
@@ -610,12 +608,15 @@ static void test_hash_dreamcast_cue()
       "  TRACK 05 MODE1/2352\n"
       "    INDEX 00 00:00:00\n"
       "    INDEX 01 00:03:00\n";
+
+static void test_hash_dreamcast_cue()
+{
   size_t image_size;
   uint8_t* image = convert_to_2352(generate_dreamcast_bin(45000, 1697028, &image_size), &image_size, 45000);
   char hash_file[33], hash_iterator[33];
   const char* expected_md5 = "c952864c3364591d2a8793ce2cfbf3a0";
 
-  mock_file(0, "game.cue", (uint8_t*)cue_file, strlen(cue_file));
+  mock_file(0, "game.cue", (uint8_t*)dreamcast_cue_file, strlen(dreamcast_cue_file));
   mock_file(1, "track01.bin", image, 1425312);    /* 606 sectors */
   mock_file(2, "track02.bin", image, 1589952);    /* 676 sectors */
   mock_file(3, "track03.bin", image, image_size); /* 737 sectors */
@@ -632,6 +633,45 @@ static void test_hash_dreamcast_cue()
   struct rc_hash_iterator iterator;
 
   rc_hash_initialize_iterator(&iterator, "game.cue", NULL, 0);
+  result_iterator = rc_hash_iterate(hash_iterator, &iterator);
+  rc_hash_destroy_iterator(&iterator);
+
+  /* cleanup */
+  free(image);
+  init_mock_cdreader();
+
+  /* validation */
+  ASSERT_NUM_EQUALS(result_file, 1);
+  ASSERT_STR_EQUALS(hash_file, expected_md5);
+
+  ASSERT_NUM_EQUALS(result_iterator, 1);
+  ASSERT_STR_EQUALS(hash_iterator, expected_md5);
+}
+
+static void test_hash_dreamcast_cue_buffered()
+{
+  size_t image_size;
+  uint8_t* image = convert_to_2352(generate_dreamcast_bin(45000, 1697028, &image_size), &image_size, 45000);
+  char hash_file[33], hash_iterator[33];
+  const char* expected_md5 = "c952864c3364591d2a8793ce2cfbf3a0";
+
+  mock_file(0, "game.cue", (uint8_t*)dreamcast_cue_file, strlen(dreamcast_cue_file));
+  mock_file(1, "track01.bin", image, 1425312);    /* 606 sectors */
+  mock_file(2, "track02.bin", image, 1589952);    /* 676 sectors */
+  mock_file(3, "track03.bin", image, image_size); /* 737 sectors */
+  mock_file(4, "track04.bin", image, 1237152);    /* 526 sectors */
+  mock_file(5, "track05.bin", image, image_size);
+
+  rc_hash_init_default_cdreader(); /* want to test actual first_track_sector calculation */
+
+  /* test file hash */
+  int result_file = rc_hash_generate_from_file(hash_file, RC_CONSOLE_DREAMCAST, "game.cue");
+
+  /* test file identification from iterator with buffered cue file */
+  int result_iterator;
+  struct rc_hash_iterator iterator;
+
+  rc_hash_initialize_iterator(&iterator, "game.cue", dreamcast_cue_file, strlen(dreamcast_cue_file));
   result_iterator = rc_hash_iterate(hash_iterator, &iterator);
   rc_hash_destroy_iterator(&iterator);
 
@@ -1289,6 +1329,40 @@ static void test_hash_sega_cd()
   ASSERT_STR_EQUALS(hash_iterator, expected_md5);
 }
 
+static void test_hash_sega_cd_buffered()
+{
+  /* the first 512 bytes of sector 0 are a volume header and ROM header.
+   * generate a generic block and add the Sega CD marker */
+  size_t image_size = 512;
+  uint8_t* image = generate_generic_file(image_size);
+  char hash_file[33], hash_iterator[33];
+  const char* expected_md5 = "574498e1453cb8934df60c4ab906e783";
+  memcpy(image, "SEGADISCSYSTEM  ", 16);
+
+  mock_file(0, "game.iso", image, image_size);
+
+  /* test file hash */
+  int result_file = rc_hash_generate_from_file(hash_file, RC_CONSOLE_SEGA_CD, "game.iso");
+
+  /* test file identification from iterator */
+  int result_iterator;
+  struct rc_hash_iterator iterator;
+
+  rc_hash_initialize_iterator(&iterator, "game.iso", image, image_size);
+  result_iterator = rc_hash_iterate(hash_iterator, &iterator);
+  rc_hash_destroy_iterator(&iterator);
+
+  /* cleanup */
+  free(image);
+
+  /* validation */
+  ASSERT_NUM_EQUALS(result_file, 1);
+  ASSERT_STR_EQUALS(hash_file, expected_md5);
+
+  ASSERT_NUM_EQUALS(result_iterator, 1);
+  ASSERT_STR_EQUALS(hash_iterator, expected_md5);
+}
+
 static void test_hash_sega_cd_invalid_header()
 {
   size_t image_size = 512;
@@ -1393,6 +1467,7 @@ void test_hash_disc(void) {
   TEST(test_hash_dreamcast_single_bin);
   TEST(test_hash_dreamcast_split_bin);
   TEST(test_hash_dreamcast_cue);
+  TEST(test_hash_dreamcast_cue_buffered);
 
   /* Gamecube */
   TEST(test_hash_gamecube);
@@ -1436,6 +1511,7 @@ void test_hash_disc(void) {
 
   /* Sega CD */
   TEST(test_hash_sega_cd);
+  TEST(test_hash_sega_cd_buffered);
   TEST(test_hash_sega_cd_invalid_header);
 
   /* Sega Saturn */

--- a/test/rhash/test_hash_disc.c
+++ b/test/rhash/test_hash_disc.c
@@ -671,7 +671,7 @@ static void test_hash_dreamcast_cue_buffered()
   int result_iterator;
   struct rc_hash_iterator iterator;
 
-  rc_hash_initialize_iterator(&iterator, "game.cue", dreamcast_cue_file, strlen(dreamcast_cue_file));
+  rc_hash_initialize_iterator(&iterator, "game.cue", (uint8_t*)dreamcast_cue_file, strlen(dreamcast_cue_file));
   result_iterator = rc_hash_iterate(hash_iterator, &iterator);
   rc_hash_destroy_iterator(&iterator);
 


### PR DESCRIPTION
Related to https://github.com/RetroAchievements/RALibretro/pull/474

If a buffered m3u/cue/iso makes it into the hashing code for a system that doesn't support hashing, automatically try the file-based hashing code.