### PR TITLE
replace rc_peek_t with rc_read_memory_func_t

### DIFF
--- a/include/rc_runtime.h
+++ b/include/rc_runtime.h
@@ -27,11 +27,9 @@ typedef struct rc_value_t rc_value_t;
 \*****************************************************************************/
 
 /**
- * Callback used to read num_bytes bytes from memory starting at address. If
- * num_bytes is greater than 1, the value is read in little-endian from
- * memory.
+ * Callback used to read num_bytes bytes from memory into buffer starting at address.
  */
-typedef uint32_t(RC_CCONV *rc_runtime_peek_t)(uint32_t address, uint32_t num_bytes, void* ud);
+typedef uint32_t(RC_CCONV *rc_runtime_read_memory_func_t)(uint32_t address, uint8_t* buffer, uint32_t num_bytes, void* ud);
 
 /*****************************************************************************\
 | Runtime                                                                     |
@@ -99,7 +97,7 @@ RC_EXPORT int RC_CCONV rc_runtime_format_lboard_value(char* buffer, int size, in
 
 
 RC_EXPORT int RC_CCONV rc_runtime_activate_richpresence(rc_runtime_t* runtime, const char* script, void* unused_L, int unused_funcs_idx);
-RC_EXPORT int RC_CCONV rc_runtime_get_richpresence(const rc_runtime_t* runtime, char* buffer, size_t buffersize, rc_runtime_peek_t peek, void* peek_ud, void* unused_L);
+RC_EXPORT int RC_CCONV rc_runtime_get_richpresence(const rc_runtime_t* runtime, char* buffer, size_t buffersize, rc_runtime_read_memory_func_t read_memory, void* read_memory_ud, void* unused_L);
 
 enum {
   RC_RUNTIME_EVENT_ACHIEVEMENT_ACTIVATED, /* from WAITING, PAUSED, or PRIMED to ACTIVE */
@@ -126,7 +124,7 @@ rc_runtime_event_t;
 
 typedef void (RC_CCONV *rc_runtime_event_handler_t)(const rc_runtime_event_t* runtime_event);
 
-RC_EXPORT void RC_CCONV rc_runtime_do_frame(rc_runtime_t* runtime, rc_runtime_event_handler_t event_handler, rc_runtime_peek_t peek, void* ud, void* unused_L);
+RC_EXPORT void RC_CCONV rc_runtime_do_frame(rc_runtime_t* runtime, rc_runtime_event_handler_t event_handler, rc_runtime_read_memory_func_t read_memory, void* ud, void* unused_L);
 RC_EXPORT void RC_CCONV rc_runtime_reset(rc_runtime_t* runtime);
 
 typedef int (RC_CCONV *rc_runtime_validate_address_t)(uint32_t address);

--- a/include/rc_runtime_types.h
+++ b/include/rc_runtime_types.h
@@ -23,11 +23,9 @@ typedef struct rc_value_t rc_value_t;
 \*****************************************************************************/
 
 /**
- * Callback used to read num_bytes bytes from memory starting at address. If
- * num_bytes is greater than 1, the value is read in little-endian from
- * memory.
+ * Callback used to read num_bytes bytes from memory into buffer starting at address.
  */
-typedef uint32_t(RC_CCONV* rc_peek_t)(uint32_t address, uint32_t num_bytes, void* ud);
+typedef uint32_t(RC_CCONV* rc_read_memory_func_t)(uint32_t address, uint8_t* buffer, uint32_t num_bytes, void* ud);
 
 /*****************************************************************************\
 | Memory References                                                           |
@@ -295,8 +293,8 @@ struct rc_trigger_t {
 
 RC_EXPORT int RC_CCONV rc_trigger_size(const char* memaddr);
 RC_EXPORT rc_trigger_t* RC_CCONV rc_parse_trigger(void* buffer, const char* memaddr, void* unused_L, int unused_funcs_idx);
-RC_EXPORT int RC_CCONV rc_evaluate_trigger(rc_trigger_t* trigger, rc_peek_t peek, void* ud, void* unused_L);
-RC_EXPORT int RC_CCONV rc_test_trigger(rc_trigger_t* trigger, rc_peek_t peek, void* ud, void* unused_L);
+RC_EXPORT int RC_CCONV rc_evaluate_trigger(rc_trigger_t* trigger, rc_read_memory_func_t read_memory, void* ud, void* unused_L);
+RC_EXPORT int RC_CCONV rc_test_trigger(rc_trigger_t* trigger, rc_read_memory_func_t read_memory, void* ud, void* unused_L);
 RC_EXPORT void RC_CCONV rc_reset_trigger(rc_trigger_t* self);
 
 /*****************************************************************************\
@@ -324,7 +322,7 @@ struct rc_value_t {
 
 RC_EXPORT int RC_CCONV rc_value_size(const char* memaddr);
 RC_EXPORT rc_value_t* RC_CCONV rc_parse_value(void* buffer, const char* memaddr, void* unused_L, int unused_funcs_idx);
-RC_EXPORT int32_t RC_CCONV rc_evaluate_value(rc_value_t* value, rc_peek_t peek, void* ud, void* unused_L);
+RC_EXPORT int32_t RC_CCONV rc_evaluate_value(rc_value_t* value, rc_read_memory_func_t read_memory, void* ud, void* unused_L);
 
 /*****************************************************************************\
 | Leaderboards                                                                |
@@ -354,7 +352,7 @@ struct rc_lboard_t {
 
 RC_EXPORT int RC_CCONV rc_lboard_size(const char* memaddr);
 RC_EXPORT rc_lboard_t* RC_CCONV rc_parse_lboard(void* buffer, const char* memaddr, void* unused_L, int unused_funcs_idx);
-RC_EXPORT int RC_CCONV rc_evaluate_lboard(rc_lboard_t* lboard, int32_t* value, rc_peek_t peek, void* peek_ud, void* unused_L);
+RC_EXPORT int RC_CCONV rc_evaluate_lboard(rc_lboard_t* lboard, int32_t* value, rc_read_memory_func_t read_memory, void* read_memory_ud, void* unused_L);
 RC_EXPORT void RC_CCONV rc_reset_lboard(rc_lboard_t* lboard);
 
 /*****************************************************************************\
@@ -442,9 +440,9 @@ struct rc_richpresence_t {
 RC_EXPORT int RC_CCONV rc_richpresence_size(const char* script);
 RC_EXPORT int RC_CCONV rc_richpresence_size_lines(const char* script, int* lines_read);
 RC_EXPORT rc_richpresence_t* RC_CCONV rc_parse_richpresence(void* buffer, const char* script, void* unused_L, int unused_funcs_idx);
-RC_EXPORT int RC_CCONV rc_evaluate_richpresence(rc_richpresence_t* richpresence, char* buffer, size_t buffersize, rc_peek_t peek, void* peek_ud, void* unused_L);
-RC_EXPORT void RC_CCONV rc_update_richpresence(rc_richpresence_t* richpresence, rc_peek_t peek, void* peek_ud, void* unused_L);
-RC_EXPORT int RC_CCONV rc_get_richpresence_display_string(rc_richpresence_t* richpresence, char* buffer, size_t buffersize, rc_peek_t peek, void* peek_ud, void* unused_L);
+RC_EXPORT int RC_CCONV rc_evaluate_richpresence(rc_richpresence_t* richpresence, char* buffer, size_t buffersize, rc_read_memory_func_t read_memory, void* read_memory_ud, void* unused_L);
+RC_EXPORT void RC_CCONV rc_update_richpresence(rc_richpresence_t* richpresence, rc_read_memory_func_t read_memory, void* read_memory_ud, void* unused_L);
+RC_EXPORT int RC_CCONV rc_get_richpresence_display_string(rc_richpresence_t* richpresence, char* buffer, size_t buffersize, rc_read_memory_func_t read_memory, void* read_memory_ud, void* unused_L);
 RC_EXPORT void RC_CCONV rc_reset_richpresence(rc_richpresence_t* self);
 
 RC_END_C_DECLS

--- a/src/rc_client.c
+++ b/src/rc_client.c
@@ -91,6 +91,7 @@ static void rc_client_reschedule_callback(rc_client_t* client, rc_client_schedul
 static void rc_client_award_achievement_retry(rc_client_scheduled_callback_data_t* callback_data, rc_client_t* client, rc_clock_t now);
 static int rc_client_is_award_achievement_pending(const rc_client_t* client, uint32_t achievement_id);
 static void rc_client_submit_leaderboard_entry_retry(rc_client_scheduled_callback_data_t* callback_data, rc_client_t* client, rc_clock_t now);
+static uint32_t rc_client_read_modified_memory_helper(uint32_t address, uint8_t* buffer, uint32_t num_bytes, void* ud);
 
 /* ===== natvis extensions ===== */
 
@@ -178,7 +179,6 @@ rc_client_t* rc_client_create(rc_client_read_memory_func_t read_memory_function,
   client->callbacks.server_call = server_call_function;
   client->callbacks.event_handler = rc_client_natvis_helper;
   client->callbacks.event_handler = rc_client_dummy_event_handler;
-  rc_client_set_legacy_peek(client, RC_CLIENT_LEGACY_PEEK_AUTO);
   rc_client_set_get_time_millisecs_function(client, NULL);
 
   rc_mutex_init(&client->state.mutex);
@@ -5747,7 +5747,7 @@ static void rc_client_ping(rc_client_scheduled_callback_data_t* callback_data, r
       rc_mutex_lock(&client->state.mutex);
 
       rc_runtime_get_richpresence(&client->game->runtime, buffer, sizeof(buffer),
-          client->state.legacy_peek, client, NULL);
+          rc_client_read_modified_memory_helper, client, NULL);
 
       rc_mutex_unlock(&client->state.mutex);
     }
@@ -5806,7 +5806,7 @@ size_t rc_client_get_rich_presence_message(rc_client_t* client, char buffer[], s
   rc_mutex_lock(&client->state.mutex);
 
   result = rc_runtime_get_richpresence(&client->game->runtime, buffer, (unsigned)buffer_size,
-      client->state.legacy_peek, client, NULL);
+      rc_client_read_modified_memory_helper, client, NULL);
 
   rc_mutex_unlock(&client->state.mutex);
 
@@ -5875,85 +5875,26 @@ static void rc_client_invalidate_processing_memref(rc_client_t* client)
   client->state.processing_memref = NULL;
 }
 
-static uint32_t rc_client_peek_le(uint32_t address, uint32_t num_bytes, void* ud)
+static uint32_t RC_CCONV rc_client_read_memory_validator(uint32_t address, uint8_t* buffer, uint32_t num_bytes, void* ud)
 {
   rc_client_t* client = (rc_client_t*)ud;
-  uint32_t value = 0;
-  uint32_t num_read = 0;
 
-  /* if we know the address is out of range, and it's part of a pointer chain
-   * (processing_memref is null), don't bother processing it. */
-  if (address > client->game->max_valid_address && !client->state.processing_memref)
-    return 0;
-
-  if (num_bytes <= sizeof(value)) {
-    num_read = client->callbacks.read_memory(address, (uint8_t*)&value, num_bytes, client);
-    if (num_read == num_bytes)
-      return value;
-  }
-
+  uint32_t num_read = client->callbacks.read_memory(address, buffer, num_bytes, client);
   if (num_read < num_bytes)
     rc_client_invalidate_processing_memref(client);
 
-  return 0;
+  return num_read;
 }
 
-static uint32_t rc_client_peek(uint32_t address, uint32_t num_bytes, void* ud)
+static uint32_t RC_CCONV rc_client_read_modified_memory_helper(uint32_t address, uint8_t* buffer, uint32_t num_bytes, void* ud)
 {
   rc_client_t* client = (rc_client_t*)ud;
-  uint8_t buffer[4];
-  uint32_t num_read = 0;
 
-  /* if we know the address is out of range, and it's part of a pointer chain
-   * (processing_memref is null), don't bother processing it. */
-  if (address > client->game->max_valid_address && !client->state.processing_memref)
+  /* if the address is out of range, don't bother processing it. */
+  if (address > client->game->max_valid_address)
     return 0;
 
-  switch (num_bytes) {
-    case 1:
-      num_read = client->callbacks.read_memory(address, buffer, 1, client);
-      if (num_read == 1)
-        return buffer[0];
-      break;
-    case 2:
-      num_read = client->callbacks.read_memory(address, buffer, 2, client);
-      if (num_read == 2)
-        return buffer[0] | (buffer[1] << 8);
-      break;
-    case 3:
-      num_read = client->callbacks.read_memory(address, buffer, 3, client);
-      if (num_read == 3)
-        return buffer[0] | (buffer[1] << 8) | (buffer[2] << 16);
-      break;
-    case 4:
-      num_read = client->callbacks.read_memory(address, buffer, 4, client);
-      if (num_read == 4)
-        return buffer[0] | (buffer[1] << 8) | (buffer[2] << 16) | (buffer[3] << 24);
-      break;
-    default:
-      break;
-  }
-
-  if (num_read < num_bytes)
-    rc_client_invalidate_processing_memref(client);
-
-  return 0;
-}
-
-void rc_client_set_legacy_peek(rc_client_t* client, int method)
-{
-  if (method == RC_CLIENT_LEGACY_PEEK_AUTO) {
-    union {
-      uint32_t whole;
-      uint8_t parts[4];
-    } u;
-    u.whole = 1;
-    method = (u.parts[0] == 1) ?
-        RC_CLIENT_LEGACY_PEEK_LITTLE_ENDIAN_READS : RC_CLIENT_LEGACY_PEEK_CONSTRUCTED;
-  }
-
-  client->state.legacy_peek = (method == RC_CLIENT_LEGACY_PEEK_LITTLE_ENDIAN_READS) ?
-      rc_client_peek_le : rc_client_peek;
+  return client->callbacks.read_memory(address, buffer, num_bytes, client);
 }
 
 int rc_client_is_processing_required(rc_client_t* client)
@@ -5994,7 +5935,7 @@ static void rc_client_update_memref_values(rc_client_t* client) {
       /* if processing_memref is set, and the memory read fails, all dependent achievements will be disabled */
       client->state.processing_memref = memref;
 
-      value = rc_peek_value(memref->address, memref->value.size, client->state.legacy_peek, client);
+      value = rc_read_memory(memref->address, memref->value.size, rc_client_read_memory_validator, client);
 
       if (client->state.processing_memref) {
         rc_update_memref_value(&memref->value, value);
@@ -6016,8 +5957,10 @@ static void rc_client_update_memref_values(rc_client_t* client) {
       rc_modified_memref_t* modified_memref = modified_memref_list->items;
       const rc_modified_memref_t* modified_memref_stop = modified_memref + modified_memref_list->count;
 
-      for (; modified_memref < modified_memref_stop; ++modified_memref)
-        rc_update_memref_value(&modified_memref->memref.value, rc_get_modified_memref_value(modified_memref, client->state.legacy_peek, client));
+      for (; modified_memref < modified_memref_stop; ++modified_memref) {
+        rc_update_memref_value(&modified_memref->memref.value,
+            rc_get_modified_memref_value(modified_memref, rc_client_read_modified_memory_helper, client));
+      }
 
       modified_memref_list = modified_memref_list->next;
     } while (modified_memref_list);
@@ -6042,7 +5985,7 @@ static void rc_client_do_frame_process_achievements(rc_client_t* client, rc_clie
 
     old_measured_value = trigger->measured_value;
     old_state = trigger->state;
-    new_state = rc_evaluate_trigger(trigger, client->state.legacy_peek, client, NULL);
+    new_state = rc_evaluate_trigger(trigger, rc_client_read_modified_memory_helper, client, NULL);
 
     /* trigger->state doesn't actually change to RESET - RESET just serves as a notification.
      * we don't care about that particular notification, so look at the actual state. */
@@ -6253,7 +6196,7 @@ static void rc_client_do_frame_process_leaderboards(rc_client_t* client, rc_clie
     }
 
     old_state = lboard->state;
-    new_state = rc_evaluate_lboard(lboard, &leaderboard->value, client->state.legacy_peek, client, NULL);
+    new_state = rc_evaluate_lboard(lboard, &leaderboard->value, rc_client_read_modified_memory_helper, client, NULL);
 
     switch (new_state) {
       case RC_LBOARD_STATE_STARTED: /* leaderboard is running */
@@ -6460,7 +6403,7 @@ void rc_client_do_frame(rc_client_t* client)
 
     richpresence = client->game->runtime.richpresence;
     if (richpresence && richpresence->richpresence)
-      rc_update_richpresence_internal(richpresence->richpresence, client->state.legacy_peek, client);
+      rc_update_richpresence_internal(richpresence->richpresence, rc_client_read_modified_memory_helper, client);
 
     rc_mutex_unlock(&client->state.mutex);
 

--- a/src/rc_client_internal.h
+++ b/src/rc_client_internal.h
@@ -342,8 +342,6 @@ typedef struct rc_client_state_t {
   struct rc_client_load_state_t* load;
   struct rc_client_async_handle_t* async_handles[4];
   rc_memref_t* processing_memref;
-
-  rc_peek_t legacy_peek;
 } rc_client_state_t;
 
 struct rc_client_t {
@@ -392,14 +390,6 @@ struct rc_hash_iterator;
 struct rc_hash_iterator* rc_client_get_load_state_hash_iterator(rc_client_t* client);
 #endif
 /* end helper functions for unit tests */
-
-enum {
-  RC_CLIENT_LEGACY_PEEK_AUTO,
-  RC_CLIENT_LEGACY_PEEK_CONSTRUCTED,
-  RC_CLIENT_LEGACY_PEEK_LITTLE_ENDIAN_READS
-};
-
-void rc_client_set_legacy_peek(rc_client_t* client, int method);
 
 void rc_client_allocate_leaderboard_tracker(rc_client_game_info_t* game, rc_client_leaderboard_info_t* leaderboard);
 void rc_client_release_leaderboard_tracker(rc_client_game_info_t* game, rc_client_leaderboard_info_t* leaderboard);

--- a/src/rcheevos/lboard.c
+++ b/src/rcheevos/lboard.c
@@ -166,25 +166,25 @@ rc_lboard_t* rc_parse_lboard(void* buffer, const char* memaddr, void* unused_L, 
   return (preparse.parse.offset >= 0) ? &lboard->lboard : NULL;
 }
 
-static void rc_update_lboard_memrefs(rc_lboard_t* self, rc_peek_t peek, void* ud) {
+static void rc_update_lboard_memrefs(rc_lboard_t* self, rc_read_memory_func_t read_memory, void* ud) {
   if (self->has_memrefs) {
     rc_lboard_with_memrefs_t* lboard = (rc_lboard_with_memrefs_t*)self;
-    rc_update_memref_values(&lboard->memrefs, peek, ud);
+    rc_update_memref_values(&lboard->memrefs, read_memory, ud);
   }
 }
 
-int rc_evaluate_lboard(rc_lboard_t* self, int32_t* value, rc_peek_t peek, void* peek_ud, void* unused_L) {
+int rc_evaluate_lboard(rc_lboard_t* self, int32_t* value, rc_read_memory_func_t read_memory, void* read_memory_ud, void* unused_L) {
   int start_ok, cancel_ok, submit_ok;
 
-  rc_update_lboard_memrefs(self, peek, peek_ud);
+  rc_update_lboard_memrefs(self, read_memory, read_memory_ud);
 
   if (self->state == RC_LBOARD_STATE_INACTIVE || self->state == RC_LBOARD_STATE_DISABLED)
     return RC_LBOARD_STATE_INACTIVE;
 
   /* these are always tested once every frame, to ensure hit counts work properly */
-  start_ok = rc_test_trigger(&self->start, peek, peek_ud, unused_L);
-  cancel_ok = rc_test_trigger(&self->cancel, peek, peek_ud, unused_L);
-  submit_ok = rc_test_trigger(&self->submit, peek, peek_ud, unused_L);
+  start_ok = rc_test_trigger(&self->start, read_memory, read_memory_ud, unused_L);
+  cancel_ok = rc_test_trigger(&self->cancel, read_memory, read_memory_ud, unused_L);
+  submit_ok = rc_test_trigger(&self->submit, read_memory, read_memory_ud, unused_L);
 
   switch (self->state)
   {
@@ -241,13 +241,13 @@ int rc_evaluate_lboard(rc_lboard_t* self, int32_t* value, rc_peek_t peek, void* 
   switch (self->state) {
     case RC_LBOARD_STATE_STARTED:
       if (self->progress) {
-        *value = rc_evaluate_value(self->progress, peek, peek_ud, unused_L);
+        *value = rc_evaluate_value(self->progress, read_memory, read_memory_ud, unused_L);
         break;
       }
       /* fallthrough */ /* to RC_LBOARD_STATE_TRIGGERED */
 
     case RC_LBOARD_STATE_TRIGGERED:
-      *value = rc_evaluate_value(&self->value, peek, peek_ud, unused_L);
+      *value = rc_evaluate_value(&self->value, read_memory, read_memory_ud, unused_L);
       break;
 
     default:

--- a/src/rcheevos/memref.c
+++ b/src/rcheevos/memref.c
@@ -6,6 +6,13 @@
 
 #define MEMREF_PLACEHOLDER_ADDRESS 0xFFFFFFFF
 
+union rc_bigendian_check_t {
+    uint32_t u32;
+    uint8_t u8[4];
+};
+static const union rc_bigendian_check_t host_bigendian_check = { 0x01000000 };
+static uint8_t rc_is_host_bigendian() { return host_bigendian_check.u8[0]; }
+
 rc_memref_t* rc_alloc_memref(rc_parse_state_t* parse, uint32_t address, uint8_t size) {
   rc_memref_list_t* memref_list = NULL;
   rc_memref_t* memref = NULL;
@@ -570,6 +577,42 @@ void rc_transform_memref_value(rc_typed_value_t* value, uint8_t size) {
   }
 }
 
+static const uint32_t rc_memref_size_bytes[] = {
+  1, /* RC_MEMSIZE_8_BITS     */
+  2, /* RC_MEMSIZE_16_BITS    */
+  3, /* RC_MEMSIZE_24_BITS    */
+  4, /* RC_MEMSIZE_32_BITS    */
+  1, /* RC_MEMSIZE_LOW        */
+  1, /* RC_MEMSIZE_HIGH       */
+  1, /* RC_MEMSIZE_BIT_0      */
+  1, /* RC_MEMSIZE_BIT_1      */
+  1, /* RC_MEMSIZE_BIT_2      */
+  1, /* RC_MEMSIZE_BIT_3      */
+  1, /* RC_MEMSIZE_BIT_4      */
+  1, /* RC_MEMSIZE_BIT_5      */
+  1, /* RC_MEMSIZE_BIT_6      */
+  1, /* RC_MEMSIZE_BIT_7      */
+  1, /* RC_MEMSIZE_BITCOUNT   */
+  2, /* RC_MEMSIZE_16_BITS_BE */
+  3, /* RC_MEMSIZE_24_BITS_BE */
+  4, /* RC_MEMSIZE_32_BITS_BE */
+  4, /* RC_MEMSIZE_FLOAT      */
+  4, /* RC_MEMSIZE_MBF32      */
+  4, /* RC_MEMSIZE_MBF32_LE   */
+  4, /* RC_MEMSIZE_FLOAT_BE   */
+  4, /* RC_MEMSIZE_DOUBLE32   */
+  4, /* RC_MEMSIZE_DOUBLE32_BE*/
+  0, /* RC_MEMSIZE_VARIABLE   */
+};
+
+uint32_t rc_memref_bytes(uint8_t size) {
+  const size_t index = (size_t)size;
+  if (index >= sizeof(rc_memref_size_bytes) / sizeof(rc_memref_size_bytes[0]))
+    return 0;
+
+  return rc_memref_size_bytes[index];
+}
+
 static const uint32_t rc_memref_masks[] = {
   0x000000ff, /* RC_MEMSIZE_8_BITS     */
   0x0000ffff, /* RC_MEMSIZE_16_BITS    */
@@ -645,35 +688,30 @@ uint8_t rc_memref_shared_size(uint8_t size) {
   return rc_memref_shared_sizes[index];
 }
 
-uint32_t rc_peek_value(uint32_t address, uint8_t size, rc_peek_t peek, void* ud) {
-  if (!peek)
+uint32_t rc_read_memory(uint32_t address, uint8_t size, rc_read_memory_func_t read_memory, void* ud) {
+  union buffered_u32 {
+    uint32_t u32;
+    uint8_t u8[4];
+  } value = { 0 };
+
+  uint32_t num_bytes = rc_memref_bytes(size);
+  if (num_bytes == 0) /* abort if size is unknown */
     return 0;
 
-  switch (size)
-  {
-    case RC_MEMSIZE_8_BITS:
-      return peek(address, 1, ud);
+  if (!read_memory)
+    return 0;
 
-    case RC_MEMSIZE_16_BITS:
-      return peek(address, 2, ud);
+  read_memory(address, value.u8, num_bytes, ud);
 
-    case RC_MEMSIZE_32_BITS:
-      return peek(address, 4, ud);
-
-    default:
-    {
-      uint32_t value;
-      const size_t index = (size_t)size;
-      if (index >= sizeof(rc_memref_shared_sizes) / sizeof(rc_memref_shared_sizes[0]))
-        return 0;
-
-      /* fetch the larger value and mask off the bits associated to the specified size
-       * for correct deduction of prior value. non-prior memrefs should already be using
-       * shared size memrefs to minimize the total number of memory reads required. */
-      value = rc_peek_value(address, rc_memref_shared_sizes[index], peek, ud);
-      return value & rc_memref_masks[index];
-    }
+  if (rc_is_host_bigendian()) {
+    value.u32 = value.u8[0] << 24 |
+                value.u8[1] << 16 |
+                value.u8[2] << 8 |
+                value.u8[3];
   }
+
+  value.u32 &= rc_memref_masks[size]; /* rc_memref_bytes ensures this index exists */
+  return value.u32;
 }
 
 void rc_update_memref_value(rc_memref_value_t* memref, uint32_t new_value) {
@@ -720,7 +758,7 @@ void rc_get_memref_value(rc_typed_value_t* value, rc_memref_t* memref, int opera
   value->value.u32 = rc_get_memref_value_value(&memref->value, operand_type);
 }
 
-uint32_t rc_get_modified_memref_value(const rc_modified_memref_t* memref, rc_peek_t peek, void* ud) {
+uint32_t rc_get_modified_memref_value(const rc_modified_memref_t* memref, rc_read_memory_func_t read_memory, void* ud) {
   rc_typed_value_t value, modifier;
 
   rc_evaluate_operand(&value, &memref->parent, NULL);
@@ -730,7 +768,7 @@ uint32_t rc_get_modified_memref_value(const rc_modified_memref_t* memref, rc_pee
     case RC_OPERATOR_INDIRECT_READ:
       rc_typed_value_add(&value, &modifier);
       rc_typed_value_convert(&value, RC_VALUE_TYPE_UNSIGNED);
-      value.value.u32 = rc_peek_value(value.value.u32, memref->memref.value.size, peek, ud);
+      value.value.u32 = rc_read_memory(value.value.u32, memref->memref.value.size, read_memory, ud);
       value.type = memref->memref.value.type;
       break;
 
@@ -773,7 +811,7 @@ uint32_t rc_get_modified_memref_value(const rc_modified_memref_t* memref, rc_pee
   return value.value.u32;
 }
 
-void rc_update_memref_values(rc_memrefs_t* memrefs, rc_peek_t peek, void* ud) {
+void rc_update_memref_values(rc_memrefs_t* memrefs, rc_read_memory_func_t read_memory, void* ud) {
   rc_memref_list_t* memref_list;
   rc_modified_memref_list_t* modified_memref_list;
 
@@ -785,7 +823,7 @@ void rc_update_memref_values(rc_memrefs_t* memrefs, rc_peek_t peek, void* ud) {
 
     for (; memref < memref_stop; ++memref) {
       if (memref->value.type != RC_VALUE_TYPE_NONE)
-        rc_update_memref_value(&memref->value, rc_peek_value(memref->address, memref->value.size, peek, ud));
+        rc_update_memref_value(&memref->value, rc_read_memory(memref->address, memref->value.size, read_memory, ud));
     }
 
     memref_list = memref_list->next;
@@ -798,7 +836,7 @@ void rc_update_memref_values(rc_memrefs_t* memrefs, rc_peek_t peek, void* ud) {
       const rc_modified_memref_t* modified_memref_stop = modified_memref + modified_memref_list->count;
 
       for (; modified_memref < modified_memref_stop; ++modified_memref)
-        rc_update_memref_value(&modified_memref->memref.value, rc_get_modified_memref_value(modified_memref, peek, ud));
+        rc_update_memref_value(&modified_memref->memref.value, rc_get_modified_memref_value(modified_memref, read_memory, ud));
 
       modified_memref_list = modified_memref_list->next;
     } while (modified_memref_list);

--- a/src/rcheevos/rc_internal.h
+++ b/src/rcheevos/rc_internal.h
@@ -193,6 +193,7 @@ typedef struct {
     uint32_t u32;
     int32_t i32;
     float f32;
+    uint8_t u8[4];
   } value;
 
   char type;
@@ -210,8 +211,8 @@ enum {
 
 typedef struct {
   /* memory accessors */
-  rc_peek_t peek;
-  void* peek_userdata;
+  rc_read_memory_func_t read_memory;
+  void* read_memory_userdata;
 
   /* processing state */
   rc_typed_value_t measured_value;     /* captured Measured value */
@@ -284,14 +285,15 @@ rc_memref_t* rc_alloc_memref(rc_parse_state_t* parse, uint32_t address, uint8_t 
 rc_modified_memref_t* rc_alloc_modified_memref(rc_parse_state_t* parse, uint8_t size, const rc_operand_t* parent,
                                                uint8_t modifier_type, const rc_operand_t* modifier);
 int rc_parse_memref(const char** memaddr, uint8_t* size, uint32_t* address);
-void rc_update_memref_values(rc_memrefs_t* memrefs, rc_peek_t peek, void* ud);
+void rc_update_memref_values(rc_memrefs_t* memrefs, rc_read_memory_func_t read_memory, void* ud);
 void rc_update_memref_value(rc_memref_value_t* memref, uint32_t value);
 void rc_get_memref_value(rc_typed_value_t* value, rc_memref_t* memref, int operand_type);
-uint32_t rc_get_modified_memref_value(const rc_modified_memref_t* memref, rc_peek_t peek, void* ud);
+uint32_t rc_get_modified_memref_value(const rc_modified_memref_t* memref, rc_read_memory_func_t read_memory, void* ud);
 uint8_t rc_memref_shared_size(uint8_t size);
 uint32_t rc_memref_mask(uint8_t size);
+uint32_t rc_memref_bytes(uint8_t size);
 void rc_transform_memref_value(rc_typed_value_t* value, uint8_t size);
-uint32_t rc_peek_value(uint32_t address, uint8_t size, rc_peek_t peek, void* ud);
+uint32_t rc_read_memory(uint32_t address, uint8_t size, rc_read_memory_func_t read_memory, void* ud);
 
 void rc_memrefs_init(rc_memrefs_t* memrefs);
 void rc_memrefs_destroy(rc_memrefs_t* memrefs);
@@ -355,12 +357,12 @@ void rc_operand_set_float_const(rc_operand_t* self, double value);
 
 int rc_is_valid_variable_character(char ch, int is_first);
 void rc_parse_value_internal(rc_value_t* self, const char** memaddr, rc_parse_state_t* parse);
-int rc_evaluate_value_typed(rc_value_t* self, rc_typed_value_t* value, rc_peek_t peek, void* ud);
+int rc_evaluate_value_typed(rc_value_t* self, rc_typed_value_t* value, rc_read_memory_func_t read_memory, void* ud);
 void rc_reset_value(rc_value_t* self);
 int rc_value_from_hits(rc_value_t* self);
 rc_value_t* rc_alloc_variable(const char* memaddr, size_t memaddr_len, rc_parse_state_t* parse);
 uint32_t rc_count_values(const rc_value_t* values);
-void rc_update_values(rc_value_t* values, rc_peek_t peek, void* ud);
+void rc_update_values(rc_value_t* values, rc_read_memory_func_t read_memory, void* ud);
 void rc_reset_values(rc_value_t* values);
 
 void rc_typed_value_convert(rc_typed_value_t* value, char new_type);
@@ -381,7 +383,7 @@ int rc_lboard_state_active(int state);
 void rc_parse_richpresence_internal(rc_richpresence_t* self, const char* script, rc_parse_state_t* parse);
 rc_memrefs_t* rc_richpresence_get_memrefs(rc_richpresence_t* self);
 void rc_reset_richpresence_triggers(rc_richpresence_t* self);
-void rc_update_richpresence_internal(rc_richpresence_t* richpresence, rc_peek_t peek, void* peek_ud);
+void rc_update_richpresence_internal(rc_richpresence_t* richpresence, rc_read_memory_func_t read_memory, void* read_memory_ud);
 
 int rc_validate_memrefs_for_console(const rc_memrefs_t* memrefs, char result[], const size_t result_size, uint32_t console_id);
 

--- a/src/rcheevos/rc_internal.h
+++ b/src/rcheevos/rc_internal.h
@@ -193,7 +193,6 @@ typedef struct {
     uint32_t u32;
     int32_t i32;
     float f32;
-    uint8_t u8[4];
   } value;
 
   char type;

--- a/src/rcheevos/richpresence.c
+++ b/src/rcheevos/richpresence.c
@@ -711,10 +711,10 @@ rc_richpresence_t* rc_parse_richpresence(void* buffer, const char* script, void*
   return (preparse.parse.offset >= 0) ? &richpresence->richpresence : NULL;
 }
 
-static void rc_update_richpresence_memrefs(rc_richpresence_t* self, rc_peek_t peek, void* ud) {
+static void rc_update_richpresence_memrefs(rc_richpresence_t* self, rc_read_memory_func_t read_memory, void* ud) {
   if (self->has_memrefs) {
     rc_richpresence_with_memrefs_t* richpresence = (rc_richpresence_with_memrefs_t*)self;
-    rc_update_memref_values(&richpresence->memrefs, peek, ud);
+    rc_update_memref_values(&richpresence->memrefs, read_memory, ud);
   }
 }
 
@@ -727,21 +727,21 @@ rc_memrefs_t* rc_richpresence_get_memrefs(rc_richpresence_t* self) {
   return NULL;
 }
 
-void rc_update_richpresence(rc_richpresence_t* richpresence, rc_peek_t peek, void* peek_ud, void* unused_L) {
+void rc_update_richpresence(rc_richpresence_t* richpresence, rc_read_memory_func_t read_memory, void* read_memory_ud, void* unused_L) {
   (void)unused_L;
 
-  rc_update_richpresence_internal(richpresence, peek, peek_ud);
+  rc_update_richpresence_internal(richpresence, read_memory, read_memory_ud);
 }
 
-void rc_update_richpresence_internal(rc_richpresence_t* richpresence, rc_peek_t peek, void* peek_ud) {
+void rc_update_richpresence_internal(rc_richpresence_t* richpresence, rc_read_memory_func_t read_memory, void* read_memory_ud) {
   rc_richpresence_display_t* display;
 
-  rc_update_richpresence_memrefs(richpresence, peek, peek_ud);
-  rc_update_values(richpresence->values, peek, peek_ud);
+  rc_update_richpresence_memrefs(richpresence, read_memory, read_memory_ud);
+  rc_update_values(richpresence->values, read_memory, read_memory_ud);
 
   for (display = richpresence->first_display; display; display = display->next) {
     if (display->has_required_hits)
-      rc_test_trigger(&display->trigger, peek, peek_ud, NULL);
+      rc_test_trigger(&display->trigger, read_memory, read_memory_ud, NULL);
   }
 }
 
@@ -889,7 +889,7 @@ static int rc_evaluate_richpresence_display(rc_richpresence_display_part_t* part
   return (int)(ptr - buffer);
 }
 
-int rc_get_richpresence_display_string(rc_richpresence_t* richpresence, char* buffer, size_t buffersize, rc_peek_t peek, void* peek_ud, void* unused_L) {
+int rc_get_richpresence_display_string(rc_richpresence_t* richpresence, char* buffer, size_t buffersize, rc_read_memory_func_t read_memory, void* read_memory_ud, void* unused_L) {
   rc_richpresence_display_t* display;
 
   for (display = richpresence->first_display; display; display = display->next) {
@@ -899,7 +899,7 @@ int rc_get_richpresence_display_string(rc_richpresence_t* richpresence, char* bu
 
     /* triggers with required hits will be updated in rc_update_richpresence */
     if (!display->has_required_hits)
-      rc_test_trigger(&display->trigger, peek, peek_ud, unused_L);
+      rc_test_trigger(&display->trigger, read_memory, read_memory_ud, unused_L);
 
     /* if we've found a valid condition, process it */
     if (display->trigger.state == RC_TRIGGER_STATE_TRIGGERED)
@@ -910,9 +910,9 @@ int rc_get_richpresence_display_string(rc_richpresence_t* richpresence, char* bu
   return 0;
 }
 
-int rc_evaluate_richpresence(rc_richpresence_t* richpresence, char* buffer, size_t buffersize, rc_peek_t peek, void* peek_ud, void* unused_L) {
-  rc_update_richpresence(richpresence, peek, peek_ud, unused_L);
-  return rc_get_richpresence_display_string(richpresence, buffer, buffersize, peek, peek_ud, unused_L);
+int rc_evaluate_richpresence(rc_richpresence_t* richpresence, char* buffer, size_t buffersize, rc_read_memory_func_t read_memory, void* read_memory_ud, void* unused_L) {
+  rc_update_richpresence(richpresence, read_memory, read_memory_ud, unused_L);
+  return rc_get_richpresence_display_string(richpresence, buffer, buffersize, read_memory, read_memory_ud, unused_L);
 }
 
 void rc_reset_richpresence_triggers(rc_richpresence_t* self) {

--- a/src/rcheevos/runtime.c
+++ b/src/rcheevos/runtime.c
@@ -500,21 +500,21 @@ int rc_runtime_activate_richpresence(rc_runtime_t* self, const char* script, voi
   return RC_OK;
 }
 
-int rc_runtime_get_richpresence(const rc_runtime_t* self, char* buffer, size_t buffersize, rc_runtime_peek_t peek, void* peek_ud, void* unused_L) {
+int rc_runtime_get_richpresence(const rc_runtime_t* self, char* buffer, size_t buffersize, rc_runtime_read_memory_func_t read_memory, void* read_memory_ud, void* unused_L) {
   if (self->richpresence && self->richpresence->richpresence)
-    return rc_get_richpresence_display_string(self->richpresence->richpresence, buffer, buffersize, peek, peek_ud, unused_L);
+    return rc_get_richpresence_display_string(self->richpresence->richpresence, buffer, buffersize, read_memory, read_memory_ud, unused_L);
 
   *buffer = '\0';
   return 0;
 }
 
-void rc_runtime_do_frame(rc_runtime_t* self, rc_runtime_event_handler_t event_handler, rc_runtime_peek_t peek, void* ud, void* unused_L) {
+void rc_runtime_do_frame(rc_runtime_t* self, rc_runtime_event_handler_t event_handler, rc_runtime_read_memory_func_t read_memory, void* ud, void* unused_L) {
   rc_runtime_event_t runtime_event;
   int32_t i;
 
   runtime_event.value = 0;
 
-  rc_update_memref_values(self->memrefs, peek, ud);
+  rc_update_memref_values(self->memrefs, read_memory, ud);
 
   for (i = self->trigger_count - 1; i >= 0; --i) {
     rc_trigger_t* trigger = self->triggers[i].trigger;
@@ -540,7 +540,7 @@ void rc_runtime_do_frame(rc_runtime_t* self, rc_runtime_event_handler_t event_ha
 
     old_measured_value = trigger->measured_value;
     old_state = trigger->state;
-    new_state = rc_evaluate_trigger(trigger, peek, ud, unused_L);
+    new_state = rc_evaluate_trigger(trigger, read_memory, ud, unused_L);
 
     /* trigger->state doesn't actually change to RESET, RESET just serves as a notification.
      * handle the notification, then look at the actual state */
@@ -642,7 +642,7 @@ void rc_runtime_do_frame(rc_runtime_t* self, rc_runtime_event_handler_t event_ha
     }
 
     lboard_state = lboard->state;
-    switch (rc_evaluate_lboard(lboard, &runtime_event.value, peek, ud, unused_L))
+    switch (rc_evaluate_lboard(lboard, &runtime_event.value, read_memory, ud, unused_L))
     {
       case RC_LBOARD_STATE_STARTED: /* leaderboard is running */
         if (lboard_state != RC_LBOARD_STATE_STARTED) {
@@ -680,7 +680,7 @@ void rc_runtime_do_frame(rc_runtime_t* self, rc_runtime_event_handler_t event_ha
   }
 
   if (self->richpresence && self->richpresence->richpresence)
-    rc_update_richpresence(self->richpresence->richpresence, peek, ud, unused_L);
+    rc_update_richpresence(self->richpresence->richpresence, read_memory, ud, unused_L);
 }
 
 void rc_runtime_reset(rc_runtime_t* self) {

--- a/src/rcheevos/trigger.c
+++ b/src/rcheevos/trigger.c
@@ -133,10 +133,10 @@ static void rc_reset_trigger_hitcounts(rc_trigger_t* self) {
   }
 }
 
-static void rc_update_trigger_memrefs(rc_trigger_t* self, rc_peek_t peek, void* ud) {
+static void rc_update_trigger_memrefs(rc_trigger_t* self, rc_read_memory_func_t read_memory, void* ud) {
   if (self->has_memrefs) {
     rc_trigger_with_memrefs_t* trigger = (rc_trigger_with_memrefs_t*)self;
-    rc_update_memref_values(&trigger->memrefs, peek, ud);
+    rc_update_memref_values(&trigger->memrefs, read_memory, ud);
   }
 }
 
@@ -149,7 +149,7 @@ rc_memrefs_t* rc_trigger_get_memrefs(rc_trigger_t* self) {
   return NULL;
 }
 
-int rc_evaluate_trigger(rc_trigger_t* self, rc_peek_t peek, void* ud, void* unused_L) {
+int rc_evaluate_trigger(rc_trigger_t* self, rc_read_memory_func_t read_memory, void* ud, void* unused_L) {
   rc_eval_state_t eval_state;
   rc_condset_t* condset;
   rc_typed_value_t measured_value;
@@ -172,7 +172,7 @@ int rc_evaluate_trigger(rc_trigger_t* self, rc_peek_t peek, void* ud, void* unus
 
     case RC_TRIGGER_STATE_INACTIVE:
       /* not yet active. update the memrefs so deltas are correct when it becomes active, then return INACTIVE */
-      rc_update_trigger_memrefs(self, peek, ud);
+      rc_update_trigger_memrefs(self, read_memory, ud);
       return RC_TRIGGER_STATE_INACTIVE;
 
     default:
@@ -180,12 +180,12 @@ int rc_evaluate_trigger(rc_trigger_t* self, rc_peek_t peek, void* ud, void* unus
   }
 
   /* update the memory references */
-  rc_update_trigger_memrefs(self, peek, ud);
+  rc_update_trigger_memrefs(self, read_memory, ud);
 
   /* process the trigger */
   memset(&eval_state, 0, sizeof(eval_state));
-  eval_state.peek = peek;
-  eval_state.peek_userdata = ud;
+  eval_state.read_memory = read_memory;
+  eval_state.read_memory_userdata = ud;
 
   measured_value.type = RC_VALUE_TYPE_NONE;
 
@@ -322,11 +322,11 @@ int rc_evaluate_trigger(rc_trigger_t* self, rc_peek_t peek, void* ud, void* unus
   return self->state;
 }
 
-int rc_test_trigger(rc_trigger_t* self, rc_peek_t peek, void* ud, void* unused_L) {
+int rc_test_trigger(rc_trigger_t* self, rc_read_memory_func_t read_memory, void* ud, void* unused_L) {
   /* for backwards compatibilty, rc_test_trigger always assumes the achievement is active */
   self->state = RC_TRIGGER_STATE_ACTIVE;
 
-  return (rc_evaluate_trigger(self, peek, ud, unused_L) == RC_TRIGGER_STATE_TRIGGERED);
+  return (rc_evaluate_trigger(self, read_memory, ud, unused_L) == RC_TRIGGER_STATE_TRIGGERED);
 }
 
 void rc_reset_trigger(rc_trigger_t* self) {

--- a/src/rcheevos/value.c
+++ b/src/rcheevos/value.c
@@ -312,27 +312,27 @@ rc_value_t* rc_parse_value(void* buffer, const char* memaddr, void* unused_L, in
   return (preparse.parse.offset >= 0) ? &value->value : NULL;
 }
 
-static void rc_update_value_memrefs(rc_value_t* self, rc_peek_t peek, void* ud) {
+static void rc_update_value_memrefs(rc_value_t* self, rc_read_memory_func_t read_memory, void* ud) {
   if (self->has_memrefs) {
     rc_value_with_memrefs_t* value = (rc_value_with_memrefs_t*)self;
-    rc_update_memref_values(&value->memrefs, peek, ud);
+    rc_update_memref_values(&value->memrefs, read_memory, ud);
   }
 }
 
-int rc_evaluate_value_typed(rc_value_t* self, rc_typed_value_t* value, rc_peek_t peek, void* ud) {
+int rc_evaluate_value_typed(rc_value_t* self, rc_typed_value_t* value, rc_read_memory_func_t read_memory, void* ud) {
   rc_eval_state_t eval_state;
   rc_condset_t* condset;
   int valid = 0;
 
-  rc_update_value_memrefs(self, peek, ud);
+  rc_update_value_memrefs(self, read_memory, ud);
 
   value->value.i32 = 0;
   value->type = RC_VALUE_TYPE_SIGNED;
 
   for (condset = self->conditions; condset != NULL; condset = condset->next) {
     memset(&eval_state, 0, sizeof(eval_state));
-    eval_state.peek = peek;
-    eval_state.peek_userdata = ud;
+    eval_state.read_memory = read_memory;
+    eval_state.read_memory_userdata = ud;
 
     rc_test_condset(condset, &eval_state);
 
@@ -365,9 +365,9 @@ int rc_evaluate_value_typed(rc_value_t* self, rc_typed_value_t* value, rc_peek_t
   return valid;
 }
 
-int32_t rc_evaluate_value(rc_value_t* self, rc_peek_t peek, void* ud, void* unused_L) {
+int32_t rc_evaluate_value(rc_value_t* self, rc_read_memory_func_t read_memory, void* ud, void* unused_L) {
   rc_typed_value_t result;
-  int valid = rc_evaluate_value_typed(self, &result, peek, ud);
+  int valid = rc_evaluate_value_typed(self, &result, read_memory, ud);
 
   (void)unused_L;
 
@@ -462,12 +462,12 @@ uint32_t rc_count_values(const rc_value_t* values) {
   return count;
 }
 
-void rc_update_values(rc_value_t* values, rc_peek_t peek, void* ud) {
+void rc_update_values(rc_value_t* values, rc_read_memory_func_t read_memory, void* ud) {
   rc_typed_value_t result;
 
   rc_value_t* value = values;
   for (; value; value = value->next) {
-    if (rc_evaluate_value_typed(value, &result, peek, ud)) {
+    if (rc_evaluate_value_typed(value, &result, read_memory, ud)) {
       /* store the raw bytes and type to be restored by rc_typed_value_from_memref_value  */
       rc_update_memref_value(&value->value, result.value.u32);
       value->value.type = result.type;

--- a/test/rcheevos/mock_memory.h
+++ b/test/rcheevos/mock_memory.h
@@ -1,6 +1,8 @@
 #ifndef MOCK_MEMORY_H
 #define MOCK_MEMORY_H
 
+#include <string.h>
+
 typedef struct {
   uint8_t* ram;
   uint32_t size;
@@ -11,22 +13,18 @@ static uint32_t peekb(uint32_t address, memory_t* memory) {
   return address < memory->size ? memory->ram[address] : 0;
 }
 
-static uint32_t peek(uint32_t address, uint32_t num_bytes, void* ud) {
+static uint32_t read_memory(uint32_t address, uint8_t* buffer, uint32_t num_bytes, void* ud) {
   memory_t* memory = (memory_t*)ud;
 
-  switch (num_bytes) {
-    case 1: return peekb(address, memory);
+  if (address >= memory->size)
+    return 0;
 
-    case 2: return peekb(address, memory) |
-      peekb(address + 1, memory) << 8;
+  uint32_t available = memory->size - address;
+  if (available < num_bytes)
+    num_bytes = available;
 
-    case 4: return peekb(address, memory) |
-      peekb(address + 1, memory) << 8 |
-      peekb(address + 2, memory) << 16 |
-      peekb(address + 3, memory) << 24;
-  }
-
-  return 0;
+  memcpy(buffer, &memory->ram[address], num_bytes);
+  return num_bytes;
 }
 
 #endif /* MOCK_MEMORY_H */

--- a/test/rcheevos/mock_memory.h
+++ b/test/rcheevos/mock_memory.h
@@ -1,6 +1,7 @@
 #ifndef MOCK_MEMORY_H
 #define MOCK_MEMORY_H
 
+#include <stdint.h>
 #include <string.h>
 
 typedef struct {
@@ -8,10 +9,6 @@ typedef struct {
   uint32_t size;
 }
 memory_t;
-
-static uint32_t peekb(uint32_t address, memory_t* memory) {
-  return address < memory->size ? memory->ram[address] : 0;
-}
 
 static uint32_t read_memory(uint32_t address, uint8_t* buffer, uint32_t num_bytes, void* ud) {
   memory_t* memory = (memory_t*)ud;

--- a/test/rcheevos/test_condition.c
+++ b/test/rcheevos/test_condition.c
@@ -110,10 +110,10 @@ static int evaluate_condition(rc_condition_t* cond, memory_t* memory, rc_memrefs
   rc_eval_state_t eval_state;
 
   memset(&eval_state, 0, sizeof(eval_state));
-  eval_state.peek = peek;
-  eval_state.peek_userdata = memory;
+  eval_state.read_memory = read_memory;
+  eval_state.read_memory_userdata = memory;
 
-  rc_update_memref_values(memrefs, peek, memory);
+  rc_update_memref_values(memrefs, read_memory, memory);
   return rc_test_condition(cond, &eval_state);
 }
 
@@ -137,7 +137,7 @@ static void test_evaluate_condition(const char* memaddr, uint8_t expected_compar
   ASSERT_NUM_GREATER(parse.offset, 0);
   ASSERT_NUM_EQUALS(*memaddr, 0);
 
-  rc_update_memref_values(&memrefs, peek, &memory); /* capture delta for ram[1] */
+  rc_update_memref_values(&memrefs, read_memory, &memory); /* capture delta for ram[1] */
   ram[1] = 0x12;
 
   ASSERT_NUM_EQUALS(self->optimized_comparator, expected_comparator);

--- a/test/rcheevos/test_condset.c
+++ b/test/rcheevos/test_condset.c
@@ -26,11 +26,11 @@ static void _assert_evaluate_condset(rc_condset_t* condset, rc_memrefs_t* memref
   int result;
   rc_eval_state_t eval_state;
 
-  rc_update_memref_values(memrefs, peek, memory);
+  rc_update_memref_values(memrefs, read_memory, memory);
 
   memset(&eval_state, 0, sizeof(eval_state));
-  eval_state.peek = peek;
-  eval_state.peek_userdata = memory;
+  eval_state.read_memory = read_memory;
+  eval_state.read_memory_userdata = memory;
 
   result = rc_test_condset(condset, &eval_state);
 

--- a/test/rcheevos/test_lboard.c
+++ b/test/rcheevos/test_lboard.c
@@ -24,7 +24,7 @@ static void _assert_parse_lboard(rc_lboard_t** lboard, void* buffer, const char*
 #define assert_parse_lboard(lboard, buffer, memaddr) ASSERT_HELPER(_assert_parse_lboard(lboard, buffer, memaddr), "assert_parse_lboard")
 
 static int evaluate_lboard(rc_lboard_t* lboard, memory_t* memory, int* value) {
-  return rc_evaluate_lboard(lboard, value, peek, memory, NULL);
+  return rc_evaluate_lboard(lboard, value, read_memory, memory, NULL);
 }
 
 static void test_simple_leaderboard() {

--- a/test/rcheevos/test_memref.c
+++ b/test/rcheevos/test_memref.c
@@ -458,7 +458,7 @@ static void test_update_memref_values() {
   memref1 = rc_alloc_memref(&parse, 1, RC_MEMSIZE_8_BITS);
   memref2 = rc_alloc_memref(&parse, 2, RC_MEMSIZE_8_BITS);
 
-  rc_update_memref_values(&memrefs, peek, &memory);
+  rc_update_memref_values(&memrefs, read_memory, &memory);
 
   ASSERT_NUM_EQUALS(memref1->value.value, 0x12);
   ASSERT_NUM_EQUALS(memref1->value.changed, 1);
@@ -468,7 +468,7 @@ static void test_update_memref_values() {
   ASSERT_NUM_EQUALS(memref2->value.prior, 0);
 
   ram[1] = 3;
-  rc_update_memref_values(&memrefs, peek, &memory);
+  rc_update_memref_values(&memrefs, read_memory, &memory);
 
   ASSERT_NUM_EQUALS(memref1->value.value, 3);
   ASSERT_NUM_EQUALS(memref1->value.changed, 1);
@@ -478,7 +478,7 @@ static void test_update_memref_values() {
   ASSERT_NUM_EQUALS(memref2->value.prior, 0);
 
   ram[1] = 5;
-  rc_update_memref_values(&memrefs, peek, &memory);
+  rc_update_memref_values(&memrefs, read_memory, &memory);
 
   ASSERT_NUM_EQUALS(memref1->value.value, 5);
   ASSERT_NUM_EQUALS(memref1->value.changed, 1);
@@ -488,7 +488,7 @@ static void test_update_memref_values() {
   ASSERT_NUM_EQUALS(memref2->value.prior, 0);
 
   ram[2] = 7;
-  rc_update_memref_values(&memrefs, peek, &memory);
+  rc_update_memref_values(&memrefs, read_memory, &memory);
 
   ASSERT_NUM_EQUALS(memref1->value.value, 5);
   ASSERT_NUM_EQUALS(memref1->value.changed, 0);

--- a/test/rcheevos/test_operand.c
+++ b/test/rcheevos/test_operand.c
@@ -80,10 +80,10 @@ static uint32_t evaluate_operand(rc_operand_t* op, memory_t* memory, rc_memrefs_
   rc_typed_value_t value;
 
   memset(&eval_state, 0, sizeof(eval_state));
-  eval_state.peek = peek;
-  eval_state.peek_userdata = memory;
+  eval_state.read_memory = read_memory;
+  eval_state.read_memory_userdata = memory;
 
-  rc_update_memref_values(memrefs, peek, memory);
+  rc_update_memref_values(memrefs, read_memory, memory);
   rc_evaluate_operand(&value, op, &eval_state);
   return value.value.u32;
 }
@@ -109,10 +109,10 @@ static float evaluate_operand_float(rc_operand_t* op, memory_t* memory, rc_memre
   rc_typed_value_t value;
 
   memset(&eval_state, 0, sizeof(eval_state));
-  eval_state.peek = peek;
-  eval_state.peek_userdata = memory;
+  eval_state.read_memory = read_memory;
+  eval_state.read_memory_userdata = memory;
 
-  rc_update_memref_values(memrefs, peek, memory);
+  rc_update_memref_values(memrefs, read_memory, memory);
   rc_evaluate_operand(&value, op, &eval_state);
   return value.value.f32;
 }

--- a/test/rcheevos/test_richpresence.c
+++ b/test/rcheevos/test_richpresence.c
@@ -30,7 +30,7 @@ static void _assert_richpresence_output(rc_richpresence_t* richpresence, memory_
   char output[256];
   int result;
 
-  result = rc_evaluate_richpresence(richpresence, output, sizeof(output), peek, memory, NULL);
+  result = rc_evaluate_richpresence(richpresence, output, sizeof(output), read_memory, memory, NULL);
   ASSERT_STR_EQUALS(output, expected_display_string);
   ASSERT_NUM_EQUALS(result, strlen(expected_display_string));
 }
@@ -62,7 +62,7 @@ static void assert_buffer_boundary(rc_richpresence_t* richpresence, memory_t* me
   unsigned* overflow = (unsigned*)(&output[buffersize]);
   *overflow = 0xCDCDCDCD;
 
-  result = rc_evaluate_richpresence(richpresence, output, buffersize, peek, memory, NULL);
+  result = rc_evaluate_richpresence(richpresence, output, buffersize, read_memory, memory, NULL);
   ASSERT_NUM_EQUALS(result, expected_result);
 
   if (*overflow != 0xCDCDCDCD) {

--- a/test/rcheevos/test_runtime.c
+++ b/test/rcheevos/test_runtime.c
@@ -50,14 +50,14 @@ static void _assert_activate_richpresence(rc_runtime_t* runtime, const char* scr
 static void assert_do_frame(rc_runtime_t* runtime, memory_t* memory)
 {
   event_count = 0;
-  rc_runtime_do_frame(runtime, event_handler, peek, memory, NULL);
+  rc_runtime_do_frame(runtime, event_handler, read_memory, memory, NULL);
 }
 
 static void _assert_richpresence_display_string(rc_runtime_t* runtime, memory_t* memory, const char* expected)
 {
   char buffer[512];
   const int expected_len = (int)strlen(expected);
-  const int result = rc_runtime_get_richpresence(runtime, buffer, sizeof(buffer), peek, memory, NULL);
+  const int result = rc_runtime_get_richpresence(runtime, buffer, sizeof(buffer), read_memory, memory, NULL);
   ASSERT_STR_EQUALS(buffer, expected);
   ASSERT_NUM_EQUALS(result, expected_len);
 }
@@ -591,7 +591,7 @@ static void test_trigger_deactivation(void)
   ram[1] = 10;
   event_count = 0;
   discarding_event_handler_runtime = &runtime;
-  rc_runtime_do_frame(&runtime, discarding_event_handler, peek, &memory, NULL);
+  rc_runtime_do_frame(&runtime, discarding_event_handler, read_memory, &memory, NULL);
   discarding_event_handler_runtime = NULL;
 
   ASSERT_NUM_EQUALS(event_count, 3);
@@ -1429,11 +1429,11 @@ typedef struct {
 }
 memory_invalid_t;
 
-static uint32_t peek_invalid(uint32_t address, uint32_t num_bytes, void* ud)
+static uint32_t read_memory_invalid(uint32_t address, uint8_t* buffer, uint32_t num_bytes, void* ud)
 {
   memory_invalid_t* memory = (memory_invalid_t*)ud;
   if (memory->invalid_address != address)
-    return peek(address, num_bytes, &memory->memory);
+    return read_memory(address, buffer, num_bytes, &memory->memory);
 
   rc_runtime_invalidate_address(memory->runtime, address);
   return 0;
@@ -1444,7 +1444,7 @@ static void assert_do_frame_invalid(rc_runtime_t* runtime, memory_invalid_t* mem
   event_count = 0;
   memory->runtime = runtime;
   memory->invalid_address = invalid_address;
-  rc_runtime_do_frame(runtime, event_handler, peek_invalid, memory, NULL);
+  rc_runtime_do_frame(runtime, event_handler, read_memory_invalid, memory, NULL);
 }
 
 static void test_invalidate_address(void)

--- a/test/rcheevos/test_runtime_progress.c
+++ b/test/rcheevos/test_runtime_progress.c
@@ -30,7 +30,7 @@ static void _assert_richpresence_output(rc_runtime_t* runtime, memory_t* memory,
   char output[256];
   int result;
 
-  result = rc_runtime_get_richpresence(runtime, output, sizeof(output), peek, memory, NULL);
+  result = rc_runtime_get_richpresence(runtime, output, sizeof(output), read_memory, memory, NULL);
   ASSERT_STR_EQUALS(output, expected_display_string);
   ASSERT_NUM_EQUALS(result, strlen(expected_display_string));
 }
@@ -43,7 +43,7 @@ static void event_handler(const rc_runtime_event_t* e)
 
 static void assert_do_frame(rc_runtime_t* runtime, memory_t* memory)
 {
-  rc_runtime_do_frame(runtime, event_handler, peek, memory, NULL);
+  rc_runtime_do_frame(runtime, event_handler, read_memory, memory, NULL);
 }
 
 static void _assert_serialize(rc_runtime_t* runtime, uint8_t* buffer, size_t buffer_size)

--- a/test/rcheevos/test_timing.c
+++ b/test/rcheevos/test_timing.c
@@ -122,7 +122,7 @@ static void do_timing(void)
     ram[0x8C] = (i % 10) + '0';
 
     start = clock();
-    rc_runtime_do_frame(&runtime, event_handler, peek, &memory, NULL);
+    rc_runtime_do_frame(&runtime, event_handler, read_memory, &memory, NULL);
     end = clock();
 
     total_clocks += (end - start);

--- a/test/rcheevos/test_trigger.c
+++ b/test/rcheevos/test_trigger.c
@@ -25,7 +25,7 @@ static void _assert_parse_trigger(rc_trigger_t** trigger, void* buffer, size_t b
 #define assert_parse_trigger(trigger, buffer, memaddr) ASSERT_HELPER(_assert_parse_trigger(trigger, buffer, sizeof(buffer), memaddr), "assert_parse_trigger")
 
 static void _assert_evaluate_trigger(rc_trigger_t* trigger, memory_t* memory, int expected_result) {
-  int result = rc_test_trigger(trigger, peek, memory, NULL);
+  int result = rc_test_trigger(trigger, read_memory, memory, NULL);
   ASSERT_NUM_EQUALS(result, expected_result);
 }
 #define assert_evaluate_trigger(trigger, memory, expected_result) ASSERT_HELPER(_assert_evaluate_trigger(trigger, memory, expected_result), "assert_evaluate_trigger")
@@ -68,7 +68,7 @@ static void _assert_hit_count(rc_trigger_t* trigger, int group_index, int cond_i
 #define assert_hit_count(trigger, group_index, cond_index, expected_hit_count) ASSERT_HELPER(_assert_hit_count(trigger, group_index, cond_index, expected_hit_count), "assert_hit_count")
 
 static int evaluate_trigger(rc_trigger_t* self, memory_t* memory) {
-  return rc_evaluate_trigger(self, peek, memory, NULL);
+  return rc_evaluate_trigger(self, read_memory, memory, NULL);
 }
 
 /* ======================================================== */

--- a/test/rcheevos/test_value.c
+++ b/test/rcheevos/test_value.c
@@ -27,7 +27,7 @@ static void test_evaluate_value(const char* memaddr, int expected_value) {
     ASSERT_FAIL("write past end of buffer");
   }
 
-  ret = rc_evaluate_value(self, peek, &memory, NULL);
+  ret = rc_evaluate_value(self, read_memory, &memory, NULL);
   ASSERT_NUM_EQUALS(ret, expected_value);
 }
 
@@ -75,35 +75,35 @@ static void test_evaluate_measured_value_with_pause() {
   ASSERT_PTR_NOT_NULL(self);
 
   /* should initially be paused, no hits captured */
-  ASSERT_NUM_EQUALS(rc_evaluate_value(self, peek, &memory, NULL), 0);
+  ASSERT_NUM_EQUALS(rc_evaluate_value(self, read_memory, &memory, NULL), 0);
 
   /* pause should prevent hitcount */
   ram[2]++;
-  ASSERT_NUM_EQUALS(rc_evaluate_value(self, peek, &memory, NULL), 0);
+  ASSERT_NUM_EQUALS(rc_evaluate_value(self, read_memory, &memory, NULL), 0);
 
   /* unpause should not report the change that occurred while paused */
   ram[3] = 0;
-  ASSERT_NUM_EQUALS(rc_evaluate_value(self, peek, &memory, NULL), 0);
+  ASSERT_NUM_EQUALS(rc_evaluate_value(self, read_memory, &memory, NULL), 0);
 
   /* hitcount should be captured */
   ram[2]++;
-  ASSERT_NUM_EQUALS(rc_evaluate_value(self, peek, &memory, NULL), 1);
+  ASSERT_NUM_EQUALS(rc_evaluate_value(self, read_memory, &memory, NULL), 1);
 
   /* pause should return current hitcount */
   ram[3] = 0xAB;
-  ASSERT_NUM_EQUALS(rc_evaluate_value(self, peek, &memory, NULL), 1);
+  ASSERT_NUM_EQUALS(rc_evaluate_value(self, read_memory, &memory, NULL), 1);
 
   /* pause should prevent hitcount */
   ram[2]++;
-  ASSERT_NUM_EQUALS(rc_evaluate_value(self, peek, &memory, NULL), 1);
+  ASSERT_NUM_EQUALS(rc_evaluate_value(self, read_memory, &memory, NULL), 1);
 
   /* unpause should not report the change that occurred while paused */
   ram[3] = 0;
-  ASSERT_NUM_EQUALS(rc_evaluate_value(self, peek, &memory, NULL), 1);
+  ASSERT_NUM_EQUALS(rc_evaluate_value(self, read_memory, &memory, NULL), 1);
 
   /* additional hitcount should be captured */
   ram[2]++;
-  ASSERT_NUM_EQUALS(rc_evaluate_value(self, peek, &memory, NULL), 2);
+  ASSERT_NUM_EQUALS(rc_evaluate_value(self, read_memory, &memory, NULL), 2);
 }
 
 static void test_evaluated_and_next_measured_if_value() {
@@ -129,49 +129,49 @@ static void test_evaluated_and_next_measured_if_value() {
   cond4 = cond2->next->next;
 
   /* measured if cannot be true */
-  ASSERT_NUM_EQUALS(rc_evaluate_value(self, peek, &memory, NULL), 0);
+  ASSERT_NUM_EQUALS(rc_evaluate_value(self, read_memory, &memory, NULL), 0);
   ASSERT_NUM_EQUALS(cond2->current_hits, 0);
   ASSERT_NUM_EQUALS(cond4->current_hits, 0);
 
   /* capture first hit, measured_if still not true */
   ram[0] = 1;
-  ASSERT_NUM_EQUALS(rc_evaluate_value(self, peek, &memory, NULL), 0);
+  ASSERT_NUM_EQUALS(rc_evaluate_value(self, read_memory, &memory, NULL), 0);
   ASSERT_NUM_EQUALS(cond2->current_hits, 1);
   ASSERT_NUM_EQUALS(cond4->current_hits, 0);
 
   /* reset */
   ram[4] = 1;
-  ASSERT_NUM_EQUALS(rc_evaluate_value(self, peek, &memory, NULL), 0);
+  ASSERT_NUM_EQUALS(rc_evaluate_value(self, read_memory, &memory, NULL), 0);
   ASSERT_NUM_EQUALS(cond2->current_hits, 0);
   ASSERT_NUM_EQUALS(cond4->current_hits, 0);
 
   /* clear reset */
   ram[4] = 0;
-  ASSERT_NUM_EQUALS(rc_evaluate_value(self, peek, &memory, NULL), 0);
+  ASSERT_NUM_EQUALS(rc_evaluate_value(self, read_memory, &memory, NULL), 0);
   ASSERT_NUM_EQUALS(cond2->current_hits, 1);
   ASSERT_NUM_EQUALS(cond4->current_hits, 0);
 
   /* prime measured_if */
   ram[0] = 9;
-  ASSERT_NUM_EQUALS(rc_evaluate_value(self, peek, &memory, NULL), 0);
+  ASSERT_NUM_EQUALS(rc_evaluate_value(self, read_memory, &memory, NULL), 0);
   ASSERT_NUM_EQUALS(cond2->current_hits, 1);
   ASSERT_NUM_EQUALS(cond4->current_hits, 0);
 
   /* trigger measured if */
   ram[0] = 0;
-  ASSERT_NUM_EQUALS(rc_evaluate_value(self, peek, &memory, NULL), 100);
+  ASSERT_NUM_EQUALS(rc_evaluate_value(self, read_memory, &memory, NULL), 100);
   ASSERT_NUM_EQUALS(cond2->current_hits, 1);
   ASSERT_NUM_EQUALS(cond4->current_hits, 1);
 
   /* measured if should remain triggered */
   ram[0] = 1;
-  ASSERT_NUM_EQUALS(rc_evaluate_value(self, peek, &memory, NULL), 100);
+  ASSERT_NUM_EQUALS(rc_evaluate_value(self, read_memory, &memory, NULL), 100);
   ASSERT_NUM_EQUALS(cond2->current_hits, 1);
   ASSERT_NUM_EQUALS(cond4->current_hits, 1);
 
   /* reset */
   ram[4] = 1;
-  ASSERT_NUM_EQUALS(rc_evaluate_value(self, peek, &memory, NULL), 0);
+  ASSERT_NUM_EQUALS(rc_evaluate_value(self, read_memory, &memory, NULL), 0);
   ASSERT_NUM_EQUALS(cond2->current_hits, 0);
   ASSERT_NUM_EQUALS(cond4->current_hits, 0);
 }
@@ -194,35 +194,35 @@ static void test_evaluate_measured_value_with_reset() {
   ASSERT_PTR_NOT_NULL(self);
 
   /* reset should initially be true, no hits captured */
-  ASSERT_NUM_EQUALS(rc_evaluate_value(self, peek, &memory, NULL), 0);
+  ASSERT_NUM_EQUALS(rc_evaluate_value(self, read_memory, &memory, NULL), 0);
 
   /* reset should prevent hitcount */
   ram[2]++;
-  ASSERT_NUM_EQUALS(rc_evaluate_value(self, peek, &memory, NULL), 0);
+  ASSERT_NUM_EQUALS(rc_evaluate_value(self, read_memory, &memory, NULL), 0);
 
   /* reset no longer true, change while reset shouldn't be captured */
   ram[3] = 0;
-  ASSERT_NUM_EQUALS(rc_evaluate_value(self, peek, &memory, NULL), 0);
+  ASSERT_NUM_EQUALS(rc_evaluate_value(self, read_memory, &memory, NULL), 0);
 
   /* additional hitcount should be captured */
   ram[2]++;
-  ASSERT_NUM_EQUALS(rc_evaluate_value(self, peek, &memory, NULL), 1);
+  ASSERT_NUM_EQUALS(rc_evaluate_value(self, read_memory, &memory, NULL), 1);
 
   /* reset should clear hit count */
   ram[3] = 0xAB;
-  ASSERT_NUM_EQUALS(rc_evaluate_value(self, peek, &memory, NULL), 0);
+  ASSERT_NUM_EQUALS(rc_evaluate_value(self, read_memory, &memory, NULL), 0);
 
   /* reset should prevent hitcount */
   ram[2]++;
-  ASSERT_NUM_EQUALS(rc_evaluate_value(self, peek, &memory, NULL), 0);
+  ASSERT_NUM_EQUALS(rc_evaluate_value(self, read_memory, &memory, NULL), 0);
 
   /* reset no longer true, change while reset shouldn't be captured */
   ram[3] = 0;
-  ASSERT_NUM_EQUALS(rc_evaluate_value(self, peek, &memory, NULL), 0);
+  ASSERT_NUM_EQUALS(rc_evaluate_value(self, read_memory, &memory, NULL), 0);
 
   /* additional hitcount should be captured */
   ram[2]++;
-  ASSERT_NUM_EQUALS(rc_evaluate_value(self, peek, &memory, NULL), 1);
+  ASSERT_NUM_EQUALS(rc_evaluate_value(self, read_memory, &memory, NULL), 1);
 }
 
 static void init_typed_value(rc_typed_value_t* value, uint8_t type, uint32_t u32, double f32) {
@@ -632,19 +632,19 @@ static void test_addhits_float_coercion() {
    */
 
   /* float(4) = 1.5, prev(float(4)) = 0.0. 0+15-0=1 is false => 0 */
-  ASSERT_NUM_EQUALS(rc_evaluate_value(self, peek, &memory, NULL), 0);
+  ASSERT_NUM_EQUALS(rc_evaluate_value(self, read_memory, &memory, NULL), 0);
 
   /* float(4) = 1.75, prev(float(4)) = 1.5. 0+17-15 => 2 => 2=1 is false => 0 */
   ram[7] = 0x3f; ram[6] = 0xe0;
-  ASSERT_NUM_EQUALS(rc_evaluate_value(self, peek, &memory, NULL), 0);
+  ASSERT_NUM_EQUALS(rc_evaluate_value(self, read_memory, &memory, NULL), 0);
 
   /* float(4) = 1.82, prev(float(4)) = 1.75. 0+18-17 => 1 => 1=1 is true => 1 */
   ram[6] = 0xe8; ram[5] = 0xf5; ram[4] = 0xc3;
-  ASSERT_NUM_EQUALS(rc_evaluate_value(self, peek, &memory, NULL), 1);
+  ASSERT_NUM_EQUALS(rc_evaluate_value(self, read_memory, &memory, NULL), 1);
 
   /* float(4) = 2.06, prev(float(4)) = 1.82. 0+20-18 => 2 => 2=1 is false => 1 */
   ram[7] = 0x40; ram[6] = 0x03; ram[5] = 0xd7; ram[4] = 0x0a;
-  ASSERT_NUM_EQUALS(rc_evaluate_value(self, peek, &memory, NULL), 1);
+  ASSERT_NUM_EQUALS(rc_evaluate_value(self, read_memory, &memory, NULL), 1);
 }
 
 static void test_addhits_float_coercion_remembered() {
@@ -669,19 +669,19 @@ static void test_addhits_float_coercion_remembered() {
    * performing the subtraction. */
 
   /* float(4) = 1.5, prev(float(4)) = 0.0. 15-0 => 15=1 is false => 0 */
-  ASSERT_NUM_EQUALS(rc_evaluate_value(self, peek, &memory, NULL), 0);
+  ASSERT_NUM_EQUALS(rc_evaluate_value(self, read_memory, &memory, NULL), 0);
 
   /* float(4) = 1.75, prev(float(4)) = 1.5. 17-15 => 2=1 is false => 0 */
   ram[7] = 0x3f; ram[6] = 0xe0;
-  ASSERT_NUM_EQUALS(rc_evaluate_value(self, peek, &memory, NULL), 0);
+  ASSERT_NUM_EQUALS(rc_evaluate_value(self, read_memory, &memory, NULL), 0);
 
   /* float(4) = 1.82, prev(float(4)) = 1.75. 18-17 => 1=1 is true => 1 */
   ram[6] = 0xe8; ram[5] = 0xf5; ram[4] = 0xc3;
-  ASSERT_NUM_EQUALS(rc_evaluate_value(self, peek, &memory, NULL), 1);
+  ASSERT_NUM_EQUALS(rc_evaluate_value(self, read_memory, &memory, NULL), 1);
 
   /* float(4) = 2.06, prev(float(4)) = 1.82. 20-18 => 2=1 is false => 1 */
   ram[7] = 0x40; ram[6] = 0x03; ram[5] = 0xd7; ram[4] = 0x0a;
-  ASSERT_NUM_EQUALS(rc_evaluate_value(self, peek, &memory, NULL), 1);
+  ASSERT_NUM_EQUALS(rc_evaluate_value(self, read_memory, &memory, NULL), 1);
 }
 
 void test_value(void) {


### PR DESCRIPTION
Replaces the legacy peek function that returned a memory read as a 32-bit value with the newer memory_read function introduced with rc_client, which supports reading arbitrary lengths of memory.

This eliminates an extra layer of translation occurring between rc_client and the processing functions and opens up the possibility for larger reads in the future.

This is a breaking change for anything calling the rc_runtime or rcheevos code directly. There is no impact to integrations using rc_client.