### PR TITLE
Replace usage of sscanf() in rc_json_get_datetime()

### DIFF
--- a/src/rapi/rc_api_common.c
+++ b/src/rapi/rc_api_common.c
@@ -990,6 +990,116 @@ int rc_json_get_required_float(float* out, rc_api_response_t* response, const rc
   return rc_json_missing_field(response, field);
 }
 
+/* Parses exactly count decimal digits without reading beyond end. */
+static int rc_json_parse_datetime_digits(const char** input, const char* end, int count, int* value) {
+  int result = 0;
+
+  while (count > 0) {
+    if (*input >= end || **input < '0' || **input > '9')
+      return 0;
+
+    result *= 10;
+    result += (**input - '0');
+    (*input)++;
+    count--;
+  }
+
+  *value = result;
+  return 1;
+}
+
+/* Consumes an expected separator without reading beyond end. */
+static int rc_json_match_datetime_char(const char** input, const char* end, char expected) {
+  if (*input >= end || **input != expected)
+    return 0;
+
+  (*input)++;
+  return 1;
+}
+
+/* Valid suffixes are Z, fractional seconds, and numeric timezone offsets. */
+static int rc_json_validate_datetime_suffix(const char* input, const char* end) {
+  int offset_hour;
+  int offset_minute;
+
+  if (input == end)
+    return 1;
+
+  if (*input == '.') {
+    input++;
+    if (input == end || *input < '0' || *input > '9')
+      return 0;
+
+    do {
+      input++;
+    } while (input < end && *input >= '0' && *input <= '9');
+
+    if (input == end)
+      return 1;
+  }
+
+  if (*input == 'Z')
+    return (++input == end);
+
+  if (*input != '+' && *input != '-')
+    return 0;
+
+  ++input;
+  if (!rc_json_parse_datetime_digits(&input, end, 2, &offset_hour) ||
+      !rc_json_match_datetime_char(&input, end, ':') ||
+      !rc_json_parse_datetime_digits(&input, end, 2, &offset_minute) ||
+      input != end) {
+    return 0;
+  }
+
+  return (offset_hour <= 23 && offset_minute <= 59);
+}
+
+/* Parses YYYY-MM-DD[ T]HH:MM:SS and only updates tm after the complete
+ * bounded value, including any suffix, has been validated. */
+static int rc_json_parse_datetime(const char* input, const char* end, struct tm* tm) {
+  static const unsigned char days_per_month[] = { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
+  int year, month, day, hour, minute, second;
+  int days_in_month;
+
+  if (!rc_json_parse_datetime_digits(&input, end, 4, &year) ||
+      !rc_json_match_datetime_char(&input, end, '-') ||
+      !rc_json_parse_datetime_digits(&input, end, 2, &month) ||
+      !rc_json_match_datetime_char(&input, end, '-') ||
+      !rc_json_parse_datetime_digits(&input, end, 2, &day) ||
+      input >= end || (*input != ' ' && *input != 'T')) {
+    return 0;
+  }
+
+  input++;
+  if (!rc_json_parse_datetime_digits(&input, end, 2, &hour) ||
+      !rc_json_match_datetime_char(&input, end, ':') ||
+      !rc_json_parse_datetime_digits(&input, end, 2, &minute) ||
+      !rc_json_match_datetime_char(&input, end, ':') ||
+      !rc_json_parse_datetime_digits(&input, end, 2, &second) ||
+      !rc_json_validate_datetime_suffix(input, end)) {
+    return 0;
+  }
+
+  if (month < 1 || month > 12 || hour > 23 || minute > 59 || second > 59)
+    return 0;
+
+  days_in_month = days_per_month[month - 1];
+  if (month == 2 && (year % 4 == 0) && (year % 100 != 0 || year % 400 == 0))
+    days_in_month++;
+  if (day < 1 || day > days_in_month)
+    return 0;
+
+  memset(tm, 0, sizeof(*tm));
+  tm->tm_year = year - 1900;
+  tm->tm_mon = month - 1;
+  tm->tm_mday = day;
+  tm->tm_hour = hour;
+  tm->tm_min = minute;
+  tm->tm_sec = second;
+  return 1;
+}
+
 int rc_json_get_datetime(time_t* out, const rc_json_field_t* field, const char* field_name) {
   struct tm tm;
 
@@ -1000,32 +1110,25 @@ int rc_json_get_datetime(time_t* out, const rc_json_field_t* field, const char* 
   (void)field_name;
 #endif
 
-  if (field->value_start && *field->value_start == '\"') {
-    memset(&tm, 0, sizeof(tm));
-    if (sscanf_s(field->value_start + 1, "%d-%d-%d %d:%d:%d", /* DB format "2013-10-20 22:12:21" */
-                 &tm.tm_year, &tm.tm_mon, &tm.tm_mday, &tm.tm_hour, &tm.tm_min, &tm.tm_sec) == 6 ||
-        /* NOTE: relies on sscanf stopping when it sees a non-digit after the seconds. could be 'Z', '.', '+', or '-' */
-        sscanf_s(field->value_start + 1, "%d-%d-%dT%d:%d:%d", /* ISO format "2013-10-20T22:12:21.000000Z */
-                 &tm.tm_year, &tm.tm_mon, &tm.tm_mday, &tm.tm_hour, &tm.tm_min, &tm.tm_sec) == 6) {
-      tm.tm_mon--; /* 0-based */
-      tm.tm_year -= 1900; /* 1900 based */
+  if (field->value_start && field->value_end > field->value_start &&
+      *field->value_start == '\"' && field->value_end[-1] == '\"' &&
+      rc_json_parse_datetime(field->value_start + 1, field->value_end - 1, &tm)) {
 
-      /* mktime converts a struct tm to a time_t using the local timezone.
-       * the input string is UTC. since timegm is not universally cross-platform,
-       * figure out the offset between UTC and local time by applying the
-       * timezone conversion twice and manually removing the difference */
-      {
-         time_t local_timet = mktime(&tm);
-         time_t skewed_timet, tz_offset;
-         struct tm gmt_tm;
-         gmtime_s(&gmt_tm, &local_timet);
-         skewed_timet = mktime(&gmt_tm); /* applies local time adjustment second time */
-         tz_offset = skewed_timet - local_timet;
-         *out = local_timet - tz_offset;
-      }
-
-      return 1;
+    /* mktime converts a struct tm to a time_t using the local timezone.
+     * the input string is UTC. since timegm is not universally cross-platform,
+     * figure out the offset between UTC and local time by applying the
+     * timezone conversion twice and manually removing the difference */
+    {
+       time_t local_timet = mktime(&tm);
+       time_t skewed_timet, tz_offset;
+       struct tm gmt_tm;
+       gmtime_s(&gmt_tm, &local_timet);
+       skewed_timet = mktime(&gmt_tm); /* applies local time adjustment second time */
+       tz_offset = skewed_timet - local_timet;
+       *out = local_timet - tz_offset;
     }
+
+    return 1;
   }
 
   *out = 0;

--- a/test/rapi/test_rc_api_common.c
+++ b/test/rapi/test_rc_api_common.c
@@ -572,6 +572,88 @@ static void test_json_get_datetime(const char* input, time_t expected) {
   }
 }
 
+static void test_json_get_datetime_truncated() {
+  const char* datetime = "2013-10-20T22:12:21";
+  rc_json_field_t field = RC_JSON_NEW_FIELD("Test");
+  char buffer[21];
+  size_t length;
+  time_t value;
+
+  buffer[0] = '"';
+  for (length = 0; length < 19; ++length) {
+    memcpy(&buffer[1], datetime, length);
+    buffer[length + 1] = '"';
+    field.value_start = buffer;
+    field.value_end = &buffer[length + 2];
+    value = 2;
+
+    ASSERT_FALSE(rc_json_get_datetime(&value, &field, "Test"));
+    ASSERT_TIMET_EQUALS(value, 0);
+  }
+}
+
+static void test_json_get_datetime_non_digits() {
+  rc_json_field_t field = RC_JSON_NEW_FIELD("Test");
+  char datetime[] = "\"2013-10-20T22:12:21\"";
+  size_t index;
+  time_t value;
+
+  field.value_start = datetime;
+  field.value_end = datetime + sizeof(datetime) - 1;
+
+  for (index = 1; index < sizeof(datetime) - 2; ++index) {
+    char digit = datetime[index];
+    if (digit < '0' || digit > '9')
+      continue;
+
+    datetime[index] = 'x';
+    value = 2;
+    ASSERT_FALSE(rc_json_get_datetime(&value, &field, "Test"));
+    ASSERT_TIMET_EQUALS(value, 0);
+    datetime[index] = digit;
+  }
+}
+
+static void test_json_get_datetime_invalid_field() {
+  rc_json_field_t field = RC_JSON_NEW_FIELD("Test");
+  const char non_string[] = "2013-10-20T22:12:21";
+  const char missing_quote[] = "\"2013-10-20T22:12:21";
+  time_t value = 2;
+
+  ASSERT_FALSE(rc_json_get_datetime(&value, &field, "Test"));
+  ASSERT_TIMET_EQUALS(value, 0);
+
+  field.value_start = non_string;
+  field.value_end = non_string + sizeof(non_string) - 1;
+  value = 2;
+  ASSERT_FALSE(rc_json_get_datetime(&value, &field, "Test"));
+  ASSERT_TIMET_EQUALS(value, 0);
+
+  field.value_start = missing_quote;
+  field.value_end = missing_quote + sizeof(missing_quote) - 1;
+  value = 2;
+  ASSERT_FALSE(rc_json_get_datetime(&value, &field, "Test"));
+  ASSERT_TIMET_EQUALS(value, 0);
+}
+
+static void test_json_get_datetime_exact_buffer(const char* datetime) {
+  rc_json_field_t field = RC_JSON_NEW_FIELD("Test");
+  const size_t datetime_length = strlen(datetime);
+  char* buffer = (char*)malloc(datetime_length + 2);
+  time_t value = 2;
+
+  ASSERT_PTR_NOT_NULL(buffer);
+  buffer[0] = '"';
+  memcpy(&buffer[1], datetime, datetime_length);
+  buffer[datetime_length + 1] = '"';
+  field.value_start = buffer;
+  field.value_end = buffer + datetime_length + 2;
+
+  ASSERT_TRUE(rc_json_get_datetime(&value, &field, "Test"));
+  ASSERT_TIMET_EQUALS(value, (time_t)1382307141LL);
+  free(buffer);
+}
+
 static void test_json_get_unum_array(const char* input, uint32_t expected_count, int expected_result) {
   rc_api_response_t response;
   rc_json_field_t field;
@@ -964,8 +1046,35 @@ void test_rapi_common(void) {
 
   /* rc_json_get_datetime */
   TEST_PARAMS2(test_json_get_datetime, "", -1);
+  TEST_PARAMS2(test_json_get_datetime, "2013-10-20 22:12:21", (time_t)1382307141LL);
+  TEST_PARAMS2(test_json_get_datetime, "2013-10-20T22:12:21", (time_t)1382307141LL);
+  TEST_PARAMS2(test_json_get_datetime, "2013-10-20T22:12:21Z", (time_t)1382307141LL);
+  TEST_PARAMS2(test_json_get_datetime, "2013-10-20T22:12:21.000000Z", (time_t)1382307141LL);
+  TEST_PARAMS2(test_json_get_datetime, "2013-10-20T22:12:21+00:00", (time_t)1382307141LL);
+  TEST_PARAMS2(test_json_get_datetime, "2013-10-20T22:12:21-04:00", (time_t)1382307141LL);
   TEST_PARAMS2(test_json_get_datetime, "2015-01-01 08:15:00", (time_t)1420100100LL);
   TEST_PARAMS2(test_json_get_datetime, "2016-02-29 20:01:47", (time_t)1456776107LL);
+  TEST_PARAMS2(test_json_get_datetime, "2015-02-29 20:01:47", -1);
+  TEST_PARAMS2(test_json_get_datetime, "2015-00-01 08:15:00", -1);
+  TEST_PARAMS2(test_json_get_datetime, "2015-13-01 08:15:00", -1);
+  TEST_PARAMS2(test_json_get_datetime, "2015-01-00 08:15:00", -1);
+  TEST_PARAMS2(test_json_get_datetime, "2015-01-32 08:15:00", -1);
+  TEST_PARAMS2(test_json_get_datetime, "2015-01-01 24:15:00", -1);
+  TEST_PARAMS2(test_json_get_datetime, "2015-01-01 08:60:00", -1);
+  TEST_PARAMS2(test_json_get_datetime, "2015-01-01 08:15:60", -1);
+  TEST_PARAMS2(test_json_get_datetime, "2015/01/01 08:15:00", -1);
+  TEST_PARAMS2(test_json_get_datetime, "2015-01-01X08:15:00", -1);
+  TEST_PARAMS2(test_json_get_datetime, "2015-01-01 08-15:00", -1);
+  TEST_PARAMS2(test_json_get_datetime, "2015-01-01 08:15-00", -1);
+  TEST_PARAMS2(test_json_get_datetime, "2015-01-01 08:15:00.", -1);
+  TEST_PARAMS2(test_json_get_datetime, "2015-01-01 08:15:00Zextra", -1);
+  TEST_PARAMS2(test_json_get_datetime, "2015-01-01 08:15:00+24:00", -1);
+  TEST_PARAMS2(test_json_get_datetime, "2015-01-01 08:15:00+00:60", -1);
+  TEST(test_json_get_datetime_truncated);
+  TEST(test_json_get_datetime_non_digits);
+  TEST(test_json_get_datetime_invalid_field);
+  TEST_PARAMS1(test_json_get_datetime_exact_buffer, "2013-10-20 22:12:21");
+  TEST_PARAMS1(test_json_get_datetime_exact_buffer, "2013-10-20T22:12:21");
 
   /* rc_json_get_unum_array */
   TEST_PARAMS3(test_json_get_unum_array, "[]", 0, RC_OK);


### PR DESCRIPTION
sscanf() requires that the input string be null terminated, as it can scan ahead. We end up calling rc_json_get_datetime() on a server-provided response, which may not be null terminated as this typically comes straight from the HTTP response.

Replace sscanf-based datetime decoding with a parser bounded by the JSON field's value_end. Validate fixed-width date/time components and supported suffixes, and add success, malformed-input, truncation, and exact-length buffer coverage.