### PR TITLE
allow {recall} of const to match across alts

### DIFF
--- a/src/rcheevos/condset.c
+++ b/src/rcheevos/condset.c
@@ -363,7 +363,8 @@ rc_condset_t* rc_parse_condset(const char** memaddr, rc_parse_state_t* parse) {
 
         classification = combining_classification;
       }
-      else {
+      else if (classification != RC_CONDITION_CLASSIFICATION_INDIRECT) {
+        /* if it's not COMBINING or INDIRECT, reset so it will get recalculated for the next clause */
         combining_classification = RC_CONDITION_CLASSIFICATION_COMBINING;
       }
 

--- a/src/rcheevos/operand.c
+++ b/src/rcheevos/operand.c
@@ -319,13 +319,30 @@ int rc_operands_are_equal(const rc_operand_t* left, const rc_operand_t* right) {
     case RC_OPERAND_FP:
       return (left->value.dbl == right->value.dbl);
     case RC_OPERAND_RECALL:
-      return (left->value.memref == right->value.memref);
+      if (left->memref_access_type != right->memref_access_type)
+        return 0;
+      switch (left->memref_access_type) {
+        case RC_OPERAND_CONST:
+          return (left->value.num == right->value.num);
+        case RC_OPERAND_FP:
+          return (left->value.dbl == right->value.dbl);
+        default:
+          if (!left->value.memref || !right->value.memref) /* could not find remember */
+            return 0;
+          break; /* fallthrough to memref comparison */
+      }
     default:
       break;
   }
 
   /* comparing two memrefs - look for exact matches on type and size */
-  if (left->size != right->size || left->value.memref->value.memref_type != right->value.memref->value.memref_type)
+  if (left->size != right->size)
+    return 0;
+
+  if (left->value.memref == right->value.memref) /* quick match if pointing to same memref */
+    return 1;
+
+  if (left->value.memref->value.memref_type != right->value.memref->value.memref_type)
     return 0;
 
   switch (left->value.memref->value.memref_type) {
@@ -336,8 +353,7 @@ int rc_operands_are_equal(const rc_operand_t* left, const rc_operand_t* right) {
       return (left_memref->modifier_type == right_memref->modifier_type &&
               left_memref->depth == right_memref->depth &&
               rc_operands_are_equal(&left_memref->modifier, &right_memref->modifier) &&
-              rc_operands_are_equal(&left_memref->parent, &right_memref->parent) &&
-              1 == 1
+              rc_operands_are_equal(&left_memref->parent, &right_memref->parent)
         );
     }
 

--- a/test/rcheevos/test_operand.c
+++ b/test/rcheevos/test_operand.c
@@ -667,6 +667,172 @@ static void test_evaluate_delta_memory_reference_float() {
   ASSERT_NUM_EQUALS(evaluate_operand_float(&op, &memory, &memrefs), 256.0);
 }
 
+void test_operands_are_equal_const() {
+  rc_operand_t one, two, one_b, two_b, one_float;
+
+  rc_operand_set_const(&one, 1);
+  rc_operand_set_const(&two, 2);
+  rc_operand_set_const(&one_b, 1);
+  rc_operand_set_const(&two_b, 2);
+  rc_operand_set_float_const(&one_float, 1.0);
+
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&one, &one), 1);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&one, &one_b), 1);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&one, &two), 0);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&one, &two_b), 0);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&one, &one_float), 0);
+
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&two, &two), 1);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&two, &two_b), 1);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&two, &one), 0);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&two, &one_b), 0);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&two, &one_float), 0);
+}
+
+void test_operands_are_equal_float_const() {
+  rc_operand_t one, two, one_b, two_b, one_neg, one_num;
+
+  rc_operand_set_float_const(&one, 1.0);
+  rc_operand_set_float_const(&two, 2.16);
+  rc_operand_set_float_const(&one_b, 1.0);
+  rc_operand_set_float_const(&two_b, 2.16);
+  rc_operand_set_float_const(&one_neg, -1.0);
+  rc_operand_set_const(&one_num, 1);
+
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&one, &one), 1);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&one, &one_b), 1);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&one, &two), 0);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&one, &two_b), 0);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&one, &one_neg), 0);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&one, &one_num), 0);
+
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&two, &two), 1);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&two, &two_b), 1);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&two, &one), 0);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&two, &one_b), 0);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&two, &one_neg), 0);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&two, &one_num), 0);
+}
+
+void test_operands_are_equal_memref() {
+  rc_memrefs_t memrefs;
+  rc_parse_state_t parse;
+  rc_operand_t one, two, one_b, two_b, one_large, one_const;
+  const char* memaddr;
+
+  rc_init_parse_state(&parse, NULL);
+  rc_init_parse_state_memrefs(&parse, &memrefs);
+
+  memaddr = "0xH0001";
+  rc_parse_operand(&one, &memaddr, &parse);
+  memaddr = "0xH0002";
+  rc_parse_operand(&two, &memaddr, &parse);
+  memaddr = "0xH0001";
+  rc_parse_operand(&one_b, &memaddr, &parse);
+  memaddr = "0xH0002";
+  rc_parse_operand(&two_b, &memaddr, &parse);
+  memaddr = "0xX0001";
+  rc_parse_operand(&one_large, &memaddr, &parse);
+  rc_operand_set_const(&one_const, 1);
+
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&one, &one), 1);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&one, &one_b), 1);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&one, &two), 0);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&one, &two_b), 0);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&one, &one_large), 0);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&one, &one_const), 0);
+
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&two, &two), 1);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&two, &two_b), 1);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&two, &one), 0);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&two, &one_b), 0);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&two, &one_large), 0);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&two, &one_const), 0);
+
+  rc_destroy_parse_state(&parse);
+}
+
+void test_operands_are_equal_recall() {
+  rc_memrefs_t memrefs;
+  rc_parse_state_t parse;
+  rc_operand_t one_const, two_const, one_const_b, one_float, one_memref, two_memref, none, none_b;
+  const char* memaddr;
+
+  rc_init_parse_state(&parse, NULL);
+  rc_init_parse_state_memrefs(&parse, &memrefs);
+
+  memaddr = "{recall}";
+  rc_parse_operand(&none, &memaddr, &parse);
+
+  memaddr = "{recall}";
+  rc_parse_operand(&none_b, &memaddr, &parse);
+
+  memaddr = "1";
+  rc_parse_operand(&parse.remember, &memaddr, &parse);
+  memaddr = "{recall}";
+  rc_parse_operand(&one_const, &memaddr, &parse);
+
+  memaddr = "2";
+  rc_parse_operand(&parse.remember, &memaddr, &parse);
+  memaddr = "{recall}";
+  rc_parse_operand(&two_const, &memaddr, &parse);
+
+  memaddr = "1";
+  rc_parse_operand(&parse.remember, &memaddr, &parse);
+  memaddr = "{recall}";
+  rc_parse_operand(&one_const_b, &memaddr, &parse);
+
+  memaddr = "f1.0";
+  rc_parse_operand(&parse.remember, &memaddr, &parse);
+  memaddr = "{recall}";
+  rc_parse_operand(&one_float, &memaddr, &parse);
+
+  memaddr = "0xH0001";
+  rc_parse_operand(&parse.remember, &memaddr, &parse);
+  memaddr = "{recall}";
+  rc_parse_operand(&one_memref, &memaddr, &parse);
+
+  memaddr = "0xH0002";
+  rc_parse_operand(&parse.remember, &memaddr, &parse);
+  memaddr = "{recall}";
+  rc_parse_operand(&two_memref, &memaddr, &parse);
+
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&one_const, &one_const), 1);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&one_const, &one_const_b), 1);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&one_const, &two_const), 0);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&one_const, &one_float), 0);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&one_const, &one_memref), 0);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&one_const, &two_memref), 0);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&one_const, &none), 0);
+
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&one_float, &one_const), 0);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&one_float, &one_const_b), 0);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&one_float, &two_const), 0);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&one_float, &one_float), 1);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&one_float, &one_memref), 0);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&one_float, &two_memref), 0);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&one_float, &none), 0);
+
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&one_memref, &one_const), 0);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&one_memref, &one_const_b), 0);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&one_memref, &two_const), 0);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&one_memref, &one_float), 0);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&one_memref, &one_memref), 1);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&one_memref, &two_memref), 0);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&one_memref, &none), 0);
+
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&none, &one_const), 0);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&none, &one_const_b), 0);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&none, &two_const), 0);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&none, &one_float), 0);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&none, &one_memref), 0);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&none, &two_memref), 0);
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&none, &none_b), 0); /* don't match unknown remembers */
+  ASSERT_NUM_EQUALS(rc_operands_are_equal(&none, &none), 1); /* unless it's the same pointer */
+
+  rc_destroy_parse_state(&parse);
+}
+
 void test_operand(void) {
   TEST_SUITE_BEGIN();
 
@@ -687,6 +853,11 @@ void test_operand(void) {
 
   test_evaluate_memory_references_float();
   TEST(test_evaluate_delta_memory_reference_float);
+
+  TEST(test_operands_are_equal_const);
+  TEST(test_operands_are_equal_float_const);
+  TEST(test_operands_are_equal_memref);
+  TEST(test_operands_are_equal_recall);
 
   TEST_SUITE_END();
 }


### PR DESCRIPTION
Fixes an issue where the parse would overflow the buffer when using "Remember {constant}" in multiple alts.

https://discord.com/channels/310192285306454017/310195377993416714/1542379959941734461

Because the preparse reuses the same data structures for analysis, the comparison that "Remember {constant}" equals "Remember {constant}" was true, but the regular parse thought they different instances and therefore didn't share them, resulting in a second allocation that was not accounted for when calculating the buffer size. Then, anything chaining off the new root node also resulted in an extra allocation as the parents differed.

Given the amount of stuff chaining off the first "Remeber {constant}" in the affected achievement, the write exceeded the buffer size significantly, leading to the crash.

