### PR TITLE
Support the current libctru 3DS define

### DIFF
--- a/src/rc_compat.c
+++ b/src/rc_compat.c
@@ -1,4 +1,4 @@
-#if !defined(RC_NO_THREADS) && !defined(_WIN32) && !defined(GEKKO) && !defined(_3DS) && (!defined(_XOPEN_SOURCE) || (_XOPEN_SOURCE - 0) < 500)
+#if !defined(RC_NO_THREADS) && !defined(_WIN32) && !defined(GEKKO) && !defined(__3DS__) && !defined(_3DS) && (!defined(_XOPEN_SOURCE) || (_XOPEN_SOURCE - 0) < 500)
 /* We'll want to use pthread_mutexattr_settype/PTHREAD_MUTEX_RECURSIVE, but glibc only conditionally exposes pthread_mutexattr_settype and PTHREAD_MUTEX_RECURSIVE depending on feature flags
  * Defining _XOPEN_SOURCE must be done at the top of the source file, before including any headers
  * pthread_mutexattr_settype/PTHREAD_MUTEX_RECURSIVE are specified the Single UNIX Specification (Version 2, 1997), along with POSIX later on (IEEE Standard 1003.1-2008), so should cover practically any pthread implementation
@@ -197,7 +197,7 @@ void rc_mutex_unlock(rc_mutex_t* mutex)
   LWP_MutexUnlock(mutex->handle);
 }
 
-#elif defined(_3DS)
+#elif defined(__3DS__) || defined(_3DS)
 
 void rc_mutex_init(rc_mutex_t* mutex)
 {

--- a/src/rc_compat.h
+++ b/src/rc_compat.h
@@ -102,7 +102,7 @@ RC_BEGIN_C_DECLS
   typedef struct rc_mutex_t {
     mutex_t handle;
   } rc_mutex_t;
- #elif defined(_3DS)
+ #elif defined(__3DS__) || defined(_3DS)
   #include <3ds/synchronization.h>
   typedef RecursiveLock rc_mutex_t;
  #else


### PR DESCRIPTION
Add `__3DS__` to the RecursiveLock platform check, while keeping `_3DS` for compatibility.