### PR TITLE
Rebranding: softcore -> casual

### DIFF
--- a/include/rc_api_runtime.h
+++ b/include/rc_api_runtime.h
@@ -330,10 +330,10 @@ rc_api_award_achievement_request_t;
 typedef struct rc_api_award_achievement_response_t {
   /* The unique identifier of the achievement that was awarded */
   uint32_t awarded_achievement_id;
-  /* The updated player score */
+  /* The updated player hardcore score */
   uint32_t new_player_score;
-  /* The updated player softcore score */
-  uint32_t new_player_score_softcore;
+  /* The updated player casual score */
+  uint32_t new_player_score_casual;
   /* The number of achievements the user has not yet unlocked for this game
    * (in hardcore/non-hardcore per hardcore flag in request) */
   uint32_t achievements_remaining;

--- a/include/rc_api_user.h
+++ b/include/rc_api_user.h
@@ -32,10 +32,10 @@ typedef struct rc_api_login_response_t {
   const char* username;
   /* The API token to use for all future requests */
   const char* api_token;
-  /* The current score of the player */
+  /* The current hardcore score of the player */
   uint32_t score;
-  /* The current softcore score of the player */
-  uint32_t score_softcore;
+  /* The current casual score of the player */
+  uint32_t score_casual;
   /* The number of unread messages waiting for the player on the web site */
   uint32_t num_unread_messages;
   /* The preferred name to display for the player */
@@ -237,7 +237,7 @@ typedef struct rc_api_all_user_progress_entry_t {
   uint32_t game_id;
   /* The total number of achievements for this game */
   uint32_t num_achievements;
-  /* The total number of unlocked achievements for this game in softcore mode */
+  /* The total number of unlocked achievements for this game in casual mode */
   uint32_t num_unlocked_achievements;
   /* The total number of unlocked achievements for this game in hardcore mode */
   uint32_t num_unlocked_achievements_hardcore;

--- a/include/rc_client.h
+++ b/include/rc_client.h
@@ -186,7 +186,7 @@ typedef struct rc_client_user_t {
   const char* username;
   const char* token;
   uint32_t score;
-  uint32_t score_softcore;
+  uint32_t score_casual;
   uint32_t num_unread_messages;
   /* minimum version: 12.0 */
   const char* avatar_url;
@@ -247,7 +247,7 @@ typedef void(RC_CCONV* rc_client_fetch_all_user_progress_callback_t)(int result,
 /**
  * Starts an asynchronous request for all progress for the given console.
  * This query returns the total number of achievements for all games tracked by this console, as well as
- * the user's achievement unlock count for both softcore and hardcore modes.
+ * the user's achievement unlock count for both casual and hardcore modes.
  */
 RC_EXPORT rc_client_async_handle_t* RC_CCONV
 rc_client_begin_fetch_all_user_progress(rc_client_t* client, uint32_t console_id,
@@ -548,9 +548,9 @@ enum {
 
 enum {
   RC_CLIENT_ACHIEVEMENT_UNLOCKED_NONE = 0,
-  RC_CLIENT_ACHIEVEMENT_UNLOCKED_SOFTCORE = (1 << 0),
+  RC_CLIENT_ACHIEVEMENT_UNLOCKED_CASUAL = (1 << 0),
   RC_CLIENT_ACHIEVEMENT_UNLOCKED_HARDCORE = (1 << 1),
-  RC_CLIENT_ACHIEVEMENT_UNLOCKED_BOTH = RC_CLIENT_ACHIEVEMENT_UNLOCKED_SOFTCORE | RC_CLIENT_ACHIEVEMENT_UNLOCKED_HARDCORE
+  RC_CLIENT_ACHIEVEMENT_UNLOCKED_BOTH = RC_CLIENT_ACHIEVEMENT_UNLOCKED_CASUAL | RC_CLIENT_ACHIEVEMENT_UNLOCKED_HARDCORE
 };
 
 typedef struct rc_client_achievement_t {

--- a/src/rapi/rc_api_runtime.c
+++ b/src/rapi/rc_api_runtime.c
@@ -717,7 +717,7 @@ int rc_api_process_award_achievement_server_response(rc_api_award_achievement_re
   }
 
   rc_json_get_optional_unum(&response->new_player_score, &fields[2], "Score", 0);
-  rc_json_get_optional_unum(&response->new_player_score_softcore, &fields[3], "SoftcoreScore", 0);
+  rc_json_get_optional_unum(&response->new_player_score_casual, &fields[3], "SoftcoreScore", 0);
   rc_json_get_optional_unum(&response->awarded_achievement_id, &fields[4], "AchievementID", 0);
   rc_json_get_optional_unum(&response->achievements_remaining, &fields[5], "AchievementsRemaining", (unsigned)-1);
 

--- a/src/rapi/rc_api_user.c
+++ b/src/rapi/rc_api_user.c
@@ -79,7 +79,7 @@ int rc_api_process_login_server_response(rc_api_login_response_t* response, cons
     return RC_MISSING_VALUE;
 
   rc_json_get_optional_unum(&response->score, &fields[5], "Score", 0);
-  rc_json_get_optional_unum(&response->score_softcore, &fields[6], "SoftcoreScore", 0);
+  rc_json_get_optional_unum(&response->score_casual, &fields[6], "SoftcoreScore", 0);
   rc_json_get_optional_unum(&response->num_unread_messages, &fields[7], "Messages", 0);
 
   /* For the highest level of backwards compatibility, we have decided to just send the

--- a/src/rc_client.c
+++ b/src/rc_client.c
@@ -722,7 +722,7 @@ static void rc_client_login_callback(const rc_api_server_response_t* server_resp
     client->user.avatar_last_updated = login_response.avatar_last_updated;
     client->user.token = rc_buffer_strcpy(&client->state.buffer, login_response.api_token);
     client->user.score = login_response.score;
-    client->user.score_softcore = login_response.score_softcore;
+    client->user.score_casual = login_response.score_casual;
     client->user.num_unread_messages = login_response.num_unread_messages;
 
     rc_mutex_lock(&client->state.mutex);
@@ -944,7 +944,7 @@ static void rc_client_subset_get_user_game_summary(const rc_client_t* client,
   int num_win_achievements = 0;
   int num_unlocked_progression_achievements = 0;
   const uint8_t unlock_bit = (client->state.hardcore) ?
-    RC_CLIENT_ACHIEVEMENT_UNLOCKED_HARDCORE : RC_CLIENT_ACHIEVEMENT_UNLOCKED_SOFTCORE;
+    RC_CLIENT_ACHIEVEMENT_UNLOCKED_HARDCORE : RC_CLIENT_ACHIEVEMENT_UNLOCKED_CASUAL;
 
   rc_mutex_lock((rc_mutex_t*)&client->state.mutex); /* remove const cast for mutex access */
 
@@ -1471,7 +1471,7 @@ static uint32_t rc_client_subset_toggle_hardcore_achievements(rc_client_subset_i
     }
     else {
       achievement->public_.unlock_time = (active_bit == RC_CLIENT_ACHIEVEMENT_UNLOCKED_HARDCORE) ?
-          achievement->unlock_time_hardcore : achievement->unlock_time_softcore;
+          achievement->unlock_time_hardcore : achievement->unlock_time_casual;
 
       if (achievement->public_.state == RC_CLIENT_ACHIEVEMENT_STATE_ACTIVE ||
           achievement->public_.state == RC_CLIENT_ACHIEVEMENT_STATE_INACTIVE) {
@@ -1519,7 +1519,7 @@ static void rc_client_activate_achievements(rc_client_game_info_t* game, rc_clie
 {
   const uint8_t active_bit = (client->state.encore_mode) ?
       RC_CLIENT_ACHIEVEMENT_UNLOCKED_NONE : (client->state.hardcore) ?
-      RC_CLIENT_ACHIEVEMENT_UNLOCKED_HARDCORE : RC_CLIENT_ACHIEVEMENT_UNLOCKED_SOFTCORE;
+      RC_CLIENT_ACHIEVEMENT_UNLOCKED_HARDCORE : RC_CLIENT_ACHIEVEMENT_UNLOCKED_CASUAL;
 
   rc_client_toggle_hardcore_achievements(game, client, active_bit);
 }
@@ -1606,7 +1606,7 @@ static void rc_client_activate_leaderboards(rc_client_game_info_t* game, rc_clie
   rc_client_leaderboard_info_t* leaderboard;
   rc_client_leaderboard_info_t* stop;
   const uint8_t leaderboards_allowed =
-      client->state.hardcore || client->state.allow_leaderboards_in_softcore;
+      client->state.hardcore || client->state.allow_leaderboards_in_casual;
 
   uint32_t active_count = 0;
   rc_client_subset_info_t* subset = game->subsets;
@@ -1690,8 +1690,8 @@ static void rc_client_apply_unlocks(rc_client_subset_info_t* subset, rc_api_unlo
 
         if (mode & RC_CLIENT_ACHIEVEMENT_UNLOCKED_HARDCORE)
           scan->unlock_time_hardcore = unlock->when;
-        if (mode & RC_CLIENT_ACHIEVEMENT_UNLOCKED_SOFTCORE)
-          scan->unlock_time_softcore = unlock->when;
+        if (mode & RC_CLIENT_ACHIEVEMENT_UNLOCKED_CASUAL)
+          scan->unlock_time_casual = unlock->when;
 
         if (scan == start)
           ++start;
@@ -1808,7 +1808,7 @@ static void rc_client_activate_game(rc_client_load_state_t* load_state, rc_api_s
       rc_client_apply_unlocks(load_state->subset, start_session_response->hardcore_unlocks,
           start_session_response->num_hardcore_unlocks, RC_CLIENT_ACHIEVEMENT_UNLOCKED_BOTH);
       rc_client_apply_unlocks(load_state->subset, start_session_response->unlocks,
-          start_session_response->num_unlocks, RC_CLIENT_ACHIEVEMENT_UNLOCKED_SOFTCORE);
+          start_session_response->num_unlocks, RC_CLIENT_ACHIEVEMENT_UNLOCKED_CASUAL);
     }
 
     /* make the loaded game active if another game is not aleady being loaded. */
@@ -4707,7 +4707,7 @@ static void rc_client_award_achievement_callback(const rc_api_server_response_t*
   }
   else {
     ach_data->client->user.score = award_achievement_response.new_player_score;
-    ach_data->client->user.score_softcore = award_achievement_response.new_player_score_softcore;
+    ach_data->client->user.score_casual = award_achievement_response.new_player_score_casual;
 
     if (award_achievement_response.awarded_achievement_id != ach_data->id) {
       RC_CLIENT_LOG_ERR_FORMATTED(ach_data->client, "Awarded achievement %u instead of %u", award_achievement_response.awarded_achievement_id, error_message);
@@ -4720,12 +4720,12 @@ static void rc_client_award_achievement_callback(const rc_api_server_response_t*
       else if (ach_data->retry_count) {
         RC_CLIENT_LOG_INFO_FORMATTED(ach_data->client, "Achievement %u awarded after %u attempts, new score: %u",
             ach_data->id, ach_data->retry_count + 1,
-            ach_data->hardcore ? award_achievement_response.new_player_score : award_achievement_response.new_player_score_softcore);
+            ach_data->hardcore ? award_achievement_response.new_player_score : award_achievement_response.new_player_score_casual);
       }
       else {
         RC_CLIENT_LOG_INFO_FORMATTED(ach_data->client, "Achievement %u awarded, new score: %u",
             ach_data->id,
-            ach_data->hardcore ? award_achievement_response.new_player_score : award_achievement_response.new_player_score_softcore);
+            ach_data->hardcore ? award_achievement_response.new_player_score : award_achievement_response.new_player_score_casual);
       }
 
       if (award_achievement_response.achievements_remaining == 0) {
@@ -4796,22 +4796,22 @@ static void rc_client_award_achievement(rc_client_t* client, rc_client_achieveme
 
   if (client->state.hardcore) {
     achievement->public_.unlock_time = achievement->unlock_time_hardcore = time(NULL);
-    if (achievement->unlock_time_softcore == 0)
-      achievement->unlock_time_softcore = achievement->unlock_time_hardcore;
+    if (achievement->unlock_time_casual == 0)
+      achievement->unlock_time_casual = achievement->unlock_time_hardcore;
 
     /* adjust score now - will get accurate score back from server */
     client->user.score += achievement->public_.points;
   }
   else {
-    achievement->public_.unlock_time = achievement->unlock_time_softcore = time(NULL);
+    achievement->public_.unlock_time = achievement->unlock_time_casual = time(NULL);
 
     /* adjust score now - will get accurate score back from server */
-    client->user.score_softcore += achievement->public_.points;
+    client->user.score_casual += achievement->public_.points;
   }
 
   achievement->public_.state = RC_CLIENT_ACHIEVEMENT_STATE_UNLOCKED;
   achievement->public_.unlocked |= (client->state.hardcore) ?
-    RC_CLIENT_ACHIEVEMENT_UNLOCKED_BOTH : RC_CLIENT_ACHIEVEMENT_UNLOCKED_SOFTCORE;
+    RC_CLIENT_ACHIEVEMENT_UNLOCKED_BOTH : RC_CLIENT_ACHIEVEMENT_UNLOCKED_CASUAL;
 
   rc_mutex_unlock(&client->state.mutex);
 
@@ -5462,7 +5462,7 @@ static void rc_client_submit_leaderboard_entry(rc_client_t* client, rc_client_le
   rc_client_submit_leaderboard_entry_callback_data_t* callback_data;
 
   if (!client->state.hardcore) {
-    RC_CLIENT_LOG_INFO_FORMATTED(client, "Leaderboard %u entry submission not allowed in softcore", leaderboard->public_.id);
+    RC_CLIENT_LOG_INFO_FORMATTED(client, "Leaderboard %u entry submission not allowed in casual mode", leaderboard->public_.id);
     return;
   }
 
@@ -6451,7 +6451,7 @@ void rc_client_do_frame(rc_client_t* client)
     if (client->game->pending_events & RC_CLIENT_GAME_PENDING_EVENT_PROGRESS_TRACKER)
       rc_client_do_frame_update_progress_tracker(client, client->game);
 
-    if (client->state.hardcore || client->state.allow_leaderboards_in_softcore) {
+    if (client->state.hardcore || client->state.allow_leaderboards_in_casual) {
       for (subset = client->game->subsets; subset; subset = subset->next) {
         if (subset->active)
           rc_client_do_frame_process_leaderboards(client, subset);
@@ -6680,7 +6680,7 @@ int rc_client_can_pause(rc_client_t* client, uint32_t* frames_remaining)
   if (frames_remaining)
     *frames_remaining = 0;
 
-  /* pause is always allowed in softcore */
+  /* pause is always allowed in casual mode */
   if (!rc_client_get_hardcore_enabled(client))
     return 1;
 
@@ -6931,9 +6931,9 @@ static void rc_client_disable_hardcore(rc_client_t* client)
   RC_CLIENT_LOG_INFO(client, "Hardcore disabled");
 
   if (client->game) {
-    rc_client_toggle_hardcore_achievements(client->game, client, RC_CLIENT_ACHIEVEMENT_UNLOCKED_SOFTCORE);
+    rc_client_toggle_hardcore_achievements(client->game, client, RC_CLIENT_ACHIEVEMENT_UNLOCKED_CASUAL);
 
-    if (!client->state.allow_leaderboards_in_softcore)
+    if (!client->state.allow_leaderboards_in_casual)
       rc_client_deactivate_leaderboards(client->game, client);
   }
 }

--- a/src/rc_client_external_versions.h
+++ b/src/rc_client_external_versions.h
@@ -12,7 +12,7 @@ typedef struct v1_rc_client_user_t {
   const char* username;
   const char* token;
   uint32_t score;
-  uint32_t score_softcore;
+  uint32_t score_casual;
   uint32_t num_unread_messages;
 } v1_rc_client_user_t;
 
@@ -21,7 +21,7 @@ typedef struct v3_rc_client_user_t {
   const char* username;
   const char* token;
   uint32_t score;
-  uint32_t score_softcore;
+  uint32_t score_casual;
   uint32_t num_unread_messages;
   const char* avatar_url;
 } v3_rc_client_user_t;

--- a/src/rc_client_internal.h
+++ b/src/rc_client_internal.h
@@ -90,7 +90,7 @@ typedef struct rc_client_achievement_info_t {
   uint8_t md5[16];
 
   time_t unlock_time_hardcore;
-  time_t unlock_time_softcore;
+  time_t unlock_time_casual;
 
   uint8_t pending_events;
 
@@ -336,7 +336,7 @@ typedef struct rc_client_state_t {
   uint8_t log_level;
   uint8_t user;
   uint8_t disconnect;
-  uint8_t allow_leaderboards_in_softcore;
+  uint8_t allow_leaderboards_in_casual;
   uint8_t allow_background_memory_reads;
 
   struct rc_client_load_state_t* load;

--- a/src/rc_client_types.natvis
+++ b/src/rc_client_types.natvis
@@ -46,7 +46,7 @@
     </Type>
     <Type Name="__rc_client_achievement_unlocked_enum_t">
         <DisplayString Condition="value==RC_CLIENT_ACHIEVEMENT_UNLOCKED_NONE">{RC_CLIENT_ACHIEVEMENT_UNLOCKED_NONE}</DisplayString>
-        <DisplayString Condition="value==RC_CLIENT_ACHIEVEMENT_UNLOCKED_SOFTCORE">{RC_CLIENT_ACHIEVEMENT_UNLOCKED_SOFTCORE}</DisplayString>
+        <DisplayString Condition="value==RC_CLIENT_ACHIEVEMENT_UNLOCKED_CASUAL">{RC_CLIENT_ACHIEVEMENT_UNLOCKED_CASUAL}</DisplayString>
         <DisplayString Condition="value==RC_CLIENT_ACHIEVEMENT_UNLOCKED_HARDCORE">{RC_CLIENT_ACHIEVEMENT_UNLOCKED_HARDCORE}</DisplayString>
         <DisplayString Condition="value==RC_CLIENT_ACHIEVEMENT_UNLOCKED_BOTH">{RC_CLIENT_ACHIEVEMENT_UNLOCKED_BOTH}</DisplayString>
         <DisplayString>unknown ({value})</DisplayString>

--- a/test/rapi/test_rc_api_runtime.c
+++ b/test/rapi/test_rc_api_runtime.c
@@ -1557,7 +1557,7 @@ static void test_init_ping_request_rich_presence_empty() {
   rc_api_destroy_request(&request);
 }
 
-static void test_init_ping_request_game_hash_softcore() {
+static void test_init_ping_request_game_hash_casual() {
   rc_api_ping_request_t ping_request;
   rc_api_request_t request;
 
@@ -1710,7 +1710,7 @@ static void test_process_award_achievement_response_success() {
   ASSERT_NUM_EQUALS(award_achievement_response.response.succeeded, 1);
   ASSERT_PTR_NULL(award_achievement_response.response.error_message);
   ASSERT_UNUM_EQUALS(award_achievement_response.new_player_score, 119102);
-  ASSERT_UNUM_EQUALS(award_achievement_response.new_player_score_softcore, 777);
+  ASSERT_UNUM_EQUALS(award_achievement_response.new_player_score_casual, 777);
   ASSERT_UNUM_EQUALS(award_achievement_response.awarded_achievement_id, 56481);
   ASSERT_UNUM_EQUALS(award_achievement_response.achievements_remaining, 11);
 
@@ -1727,7 +1727,7 @@ static void test_process_award_achievement_response_hardcore_already_unlocked() 
   ASSERT_NUM_EQUALS(award_achievement_response.response.succeeded, 1);
   ASSERT_STR_EQUALS(award_achievement_response.response.error_message, "User already has hardcore and regular achievements awarded.");
   ASSERT_UNUM_EQUALS(award_achievement_response.new_player_score, 119210);
-  ASSERT_UNUM_EQUALS(award_achievement_response.new_player_score_softcore, 777);
+  ASSERT_UNUM_EQUALS(award_achievement_response.new_player_score_casual, 777);
   ASSERT_UNUM_EQUALS(award_achievement_response.awarded_achievement_id, 56494);
   ASSERT_UNUM_EQUALS(award_achievement_response.achievements_remaining, 17);
 
@@ -1744,7 +1744,7 @@ static void test_process_award_achievement_response_non_hardcore_already_unlocke
   ASSERT_NUM_EQUALS(award_achievement_response.response.succeeded, 1);
   ASSERT_STR_EQUALS(award_achievement_response.response.error_message, "User already has this achievement awarded.");
   ASSERT_UNUM_EQUALS(award_achievement_response.new_player_score, 119210);
-  ASSERT_UNUM_EQUALS(award_achievement_response.new_player_score_softcore, 777);
+  ASSERT_UNUM_EQUALS(award_achievement_response.new_player_score_casual, 777);
   ASSERT_UNUM_EQUALS(award_achievement_response.awarded_achievement_id, 56494);
   ASSERT_UNUM_EQUALS(award_achievement_response.achievements_remaining, 0xFFFFFFFF);
 
@@ -1761,7 +1761,7 @@ static void test_process_award_achievement_response_generic_failure() {
   ASSERT_NUM_EQUALS(award_achievement_response.response.succeeded, 0);
   ASSERT_PTR_NULL(award_achievement_response.response.error_message);
   ASSERT_UNUM_EQUALS(award_achievement_response.new_player_score, 0);
-  ASSERT_UNUM_EQUALS(award_achievement_response.new_player_score_softcore, 0);
+  ASSERT_UNUM_EQUALS(award_achievement_response.new_player_score_casual, 0);
   ASSERT_UNUM_EQUALS(award_achievement_response.awarded_achievement_id, 0);
   ASSERT_UNUM_EQUALS(award_achievement_response.achievements_remaining, 0);
 
@@ -1778,7 +1778,7 @@ static void test_process_award_achievement_response_empty() {
   ASSERT_NUM_EQUALS(award_achievement_response.response.succeeded, 0);
   ASSERT_PTR_NULL(award_achievement_response.response.error_message);
   ASSERT_UNUM_EQUALS(award_achievement_response.new_player_score, 0);
-  ASSERT_UNUM_EQUALS(award_achievement_response.new_player_score_softcore, 0);
+  ASSERT_UNUM_EQUALS(award_achievement_response.new_player_score_casual, 0);
   ASSERT_UNUM_EQUALS(award_achievement_response.awarded_achievement_id, 0);
   ASSERT_UNUM_EQUALS(award_achievement_response.achievements_remaining, 0);
 
@@ -1795,7 +1795,7 @@ static void test_process_award_achievement_response_invalid_credentials() {
   ASSERT_NUM_EQUALS(award_achievement_response.response.succeeded, 0);
   ASSERT_STR_EQUALS(award_achievement_response.response.error_message, "Credentials invalid (0)");
   ASSERT_UNUM_EQUALS(award_achievement_response.new_player_score, 0);
-  ASSERT_UNUM_EQUALS(award_achievement_response.new_player_score_softcore, 0);
+  ASSERT_UNUM_EQUALS(award_achievement_response.new_player_score_casual, 0);
   ASSERT_UNUM_EQUALS(award_achievement_response.awarded_achievement_id, 0);
   ASSERT_UNUM_EQUALS(award_achievement_response.achievements_remaining, 0);
 
@@ -1812,7 +1812,7 @@ static void test_process_award_achievement_response_text() {
   ASSERT_NUM_EQUALS(award_achievement_response.response.succeeded, 0);
   ASSERT_STR_EQUALS(award_achievement_response.response.error_message, "You do not have access to that resource");
   ASSERT_UNUM_EQUALS(award_achievement_response.new_player_score, 0);
-  ASSERT_UNUM_EQUALS(award_achievement_response.new_player_score_softcore, 0);
+  ASSERT_UNUM_EQUALS(award_achievement_response.new_player_score_casual, 0);
   ASSERT_UNUM_EQUALS(award_achievement_response.awarded_achievement_id, 0);
   ASSERT_UNUM_EQUALS(award_achievement_response.achievements_remaining, 0);
 
@@ -1829,7 +1829,7 @@ static void test_process_award_achievement_response_no_fields() {
   ASSERT_NUM_EQUALS(award_achievement_response.response.succeeded, 1);
   ASSERT_PTR_NULL(award_achievement_response.response.error_message);
   ASSERT_UNUM_EQUALS(award_achievement_response.new_player_score, 0);
-  ASSERT_UNUM_EQUALS(award_achievement_response.new_player_score_softcore, 0);
+  ASSERT_UNUM_EQUALS(award_achievement_response.new_player_score_casual, 0);
   ASSERT_UNUM_EQUALS(award_achievement_response.awarded_achievement_id, 0);
   ASSERT_UNUM_EQUALS(award_achievement_response.achievements_remaining, 0xFFFFFFFF);
 
@@ -1853,7 +1853,7 @@ static void test_process_award_achievement_response_429() {
   ASSERT_NUM_EQUALS(award_achievement_response.response.succeeded, 0);
   ASSERT_STR_EQUALS(award_achievement_response.response.error_message, "429 Too Many Requests");
   ASSERT_UNUM_EQUALS(award_achievement_response.new_player_score, 0);
-  ASSERT_UNUM_EQUALS(award_achievement_response.new_player_score_softcore, 0);
+  ASSERT_UNUM_EQUALS(award_achievement_response.new_player_score_casual, 0);
   ASSERT_UNUM_EQUALS(award_achievement_response.awarded_achievement_id, 0);
   ASSERT_UNUM_EQUALS(award_achievement_response.achievements_remaining, 0);
 
@@ -1928,7 +1928,7 @@ static void test_process_award_achievement_response_503_fancy() {
   ASSERT_NUM_EQUALS(award_achievement_response.response.succeeded, 0);
   ASSERT_STR_EQUALS(award_achievement_response.response.error_message, "503 Service Temporarily Unavailable");
   ASSERT_UNUM_EQUALS(award_achievement_response.new_player_score, 0);
-  ASSERT_UNUM_EQUALS(award_achievement_response.new_player_score_softcore, 0);
+  ASSERT_UNUM_EQUALS(award_achievement_response.new_player_score_casual, 0);
   ASSERT_UNUM_EQUALS(award_achievement_response.awarded_achievement_id, 0);
   ASSERT_UNUM_EQUALS(award_achievement_response.achievements_remaining, 0);
 
@@ -1945,7 +1945,7 @@ static void test_process_award_achievement_response_522_simple() {
   ASSERT_NUM_EQUALS(award_achievement_response.response.succeeded, 0);
   ASSERT_STR_EQUALS(award_achievement_response.response.error_message, "error code: 522");
   ASSERT_UNUM_EQUALS(award_achievement_response.new_player_score, 0);
-  ASSERT_UNUM_EQUALS(award_achievement_response.new_player_score_softcore, 0);
+  ASSERT_UNUM_EQUALS(award_achievement_response.new_player_score_casual, 0);
   ASSERT_UNUM_EQUALS(award_achievement_response.awarded_achievement_id, 0);
   ASSERT_UNUM_EQUALS(award_achievement_response.achievements_remaining, 0);
 
@@ -2188,7 +2188,7 @@ void test_rapi_runtime(void) {
   TEST(test_init_ping_request_rich_presence);
   TEST(test_init_ping_request_rich_presence_unicode);
   TEST(test_init_ping_request_rich_presence_empty);
-  TEST(test_init_ping_request_game_hash_softcore);
+  TEST(test_init_ping_request_game_hash_casual);
   TEST(test_init_ping_request_game_hash_hardcore);
 
   TEST(test_process_ping_response);

--- a/test/rapi/test_rc_api_user.c
+++ b/test/rapi/test_rc_api_user.c
@@ -39,7 +39,7 @@ static void test_init_start_session_request_no_game()
   rc_api_destroy_request(&request);
 }
 
-static void test_init_start_session_request_game_hash_softcore()
+static void test_init_start_session_request_game_hash_casual()
 {
   rc_api_start_session_request_t start_session_request;
   rc_api_request_t request;
@@ -99,8 +99,8 @@ static void test_process_start_session_response()
 {
   rc_api_start_session_response_t start_session_response;
   /* startsession API only returns HardcoreUnlocks if an achievement has been earned in hardcore,
-   * even if the softcore unlock has a different timestamp. Unlocks are only returned for things
-   * only unlocked in softcore. */
+   * even if the casual unlock has a different timestamp. Unlocks are only returned for things
+   * only unlocked in casual mode. */
   const char* server_response = "{\"Success\":true,\"HardcoreUnlocks\":["
       "{\"ID\":111,\"When\":1234567890},"
       "{\"ID\":112,\"When\":1234567891},"
@@ -265,7 +265,7 @@ static void test_process_login_response_success()
   ASSERT_STR_EQUALS(login_response.username, "USER");
   ASSERT_STR_EQUALS(login_response.api_token, "ApiTOKEN");
   ASSERT_NUM_EQUALS(login_response.score, 1234);
-  ASSERT_NUM_EQUALS(login_response.score_softcore, 789);
+  ASSERT_NUM_EQUALS(login_response.score_casual, 789);
   ASSERT_NUM_EQUALS(login_response.num_unread_messages, 2);
   ASSERT_STR_EQUALS(login_response.display_name, "USER");
 
@@ -284,7 +284,7 @@ static void test_process_login_response_success()
   ASSERT_STR_EQUALS(login_response.username, "USER");
   ASSERT_STR_EQUALS(login_response.api_token, "ApiTOKEN");
   ASSERT_NUM_EQUALS(login_response.score, 1234);
-  ASSERT_NUM_EQUALS(login_response.score_softcore, 789);
+  ASSERT_NUM_EQUALS(login_response.score_casual, 789);
   ASSERT_NUM_EQUALS(login_response.num_unread_messages, 2);
   ASSERT_STR_EQUALS(login_response.display_name, "USER");
 
@@ -304,7 +304,7 @@ static void test_process_login_response_avatar_updated()
   ASSERT_STR_EQUALS(login_response.username, "USER");
   ASSERT_STR_EQUALS(login_response.api_token, "ApiTOKEN");
   ASSERT_NUM_EQUALS(login_response.score, 1234);
-  ASSERT_NUM_EQUALS(login_response.score_softcore, 789);
+  ASSERT_NUM_EQUALS(login_response.score_casual, 789);
   ASSERT_NUM_EQUALS(login_response.num_unread_messages, 2);
   ASSERT_STR_EQUALS(login_response.display_name, "USER");
   ASSERT_STR_EQUALS(login_response.avatar_url, "host/UserPic/USER.png");
@@ -326,7 +326,7 @@ static void test_process_login_response_unique_display_name()
   ASSERT_STR_EQUALS(login_response.username, "GamingHero");
   ASSERT_STR_EQUALS(login_response.api_token, "ApiTOKEN");
   ASSERT_NUM_EQUALS(login_response.score, 1234);
-  ASSERT_NUM_EQUALS(login_response.score_softcore, 789);
+  ASSERT_NUM_EQUALS(login_response.score_casual, 789);
   ASSERT_NUM_EQUALS(login_response.num_unread_messages, 2);
   ASSERT_STR_EQUALS(login_response.display_name, "GamingHero");
   ASSERT_STR_EQUALS(login_response.avatar_url, "http://host/UserPic/USER.png");
@@ -349,7 +349,7 @@ static void test_process_login_response_invalid_credentials()
   ASSERT_PTR_NULL(login_response.username);
   ASSERT_PTR_NULL(login_response.api_token);
   ASSERT_NUM_EQUALS(login_response.score, 0);
-  ASSERT_NUM_EQUALS(login_response.score_softcore, 0);
+  ASSERT_NUM_EQUALS(login_response.score_casual, 0);
   ASSERT_NUM_EQUALS(login_response.num_unread_messages, 0);
   ASSERT_PTR_NULL(login_response.display_name);
   ASSERT_PTR_NULL(login_response.avatar_url);
@@ -370,7 +370,7 @@ static void test_process_login_response_invalid_credentials()
   ASSERT_PTR_NULL(login_response.username);
   ASSERT_PTR_NULL(login_response.api_token);
   ASSERT_NUM_EQUALS(login_response.score, 0);
-  ASSERT_NUM_EQUALS(login_response.score_softcore, 0);
+  ASSERT_NUM_EQUALS(login_response.score_casual, 0);
   ASSERT_NUM_EQUALS(login_response.num_unread_messages, 0);
   ASSERT_PTR_NULL(login_response.display_name);
   ASSERT_PTR_NULL(login_response.avatar_url);
@@ -393,7 +393,7 @@ static void test_process_login_response_access_denied()
   ASSERT_PTR_NULL(login_response.username);
   ASSERT_PTR_NULL(login_response.api_token);
   ASSERT_NUM_EQUALS(login_response.score, 0);
-  ASSERT_NUM_EQUALS(login_response.score_softcore, 0);
+  ASSERT_NUM_EQUALS(login_response.score_casual, 0);
   ASSERT_NUM_EQUALS(login_response.num_unread_messages, 0);
   ASSERT_PTR_NULL(login_response.display_name);
 
@@ -412,7 +412,7 @@ static void test_process_login_response_access_denied()
   ASSERT_PTR_NULL(login_response.username);
   ASSERT_PTR_NULL(login_response.api_token);
   ASSERT_NUM_EQUALS(login_response.score, 0);
-  ASSERT_NUM_EQUALS(login_response.score_softcore, 0);
+  ASSERT_NUM_EQUALS(login_response.score_casual, 0);
   ASSERT_NUM_EQUALS(login_response.num_unread_messages, 0);
   ASSERT_PTR_NULL(login_response.display_name);
 
@@ -433,7 +433,7 @@ static void test_process_login_response_expired_token()
   ASSERT_PTR_NULL(login_response.username);
   ASSERT_PTR_NULL(login_response.api_token);
   ASSERT_NUM_EQUALS(login_response.score, 0);
-  ASSERT_NUM_EQUALS(login_response.score_softcore, 0);
+  ASSERT_NUM_EQUALS(login_response.score_casual, 0);
   ASSERT_NUM_EQUALS(login_response.num_unread_messages, 0);
   ASSERT_PTR_NULL(login_response.display_name);
 
@@ -452,7 +452,7 @@ static void test_process_login_response_expired_token()
   ASSERT_PTR_NULL(login_response.username);
   ASSERT_PTR_NULL(login_response.api_token);
   ASSERT_NUM_EQUALS(login_response.score, 0);
-  ASSERT_NUM_EQUALS(login_response.score_softcore, 0);
+  ASSERT_NUM_EQUALS(login_response.score_casual, 0);
   ASSERT_NUM_EQUALS(login_response.num_unread_messages, 0);
   ASSERT_PTR_NULL(login_response.display_name);
 
@@ -472,7 +472,7 @@ static void test_process_login_response_generic_failure()
   ASSERT_PTR_NULL(login_response.username);
   ASSERT_PTR_NULL(login_response.api_token);
   ASSERT_NUM_EQUALS(login_response.score, 0);
-  ASSERT_NUM_EQUALS(login_response.score_softcore, 0);
+  ASSERT_NUM_EQUALS(login_response.score_casual, 0);
   ASSERT_NUM_EQUALS(login_response.num_unread_messages, 0);
   ASSERT_PTR_NULL(login_response.display_name);
 
@@ -492,7 +492,7 @@ static void test_process_login_response_empty()
   ASSERT_PTR_NULL(login_response.username);
   ASSERT_PTR_NULL(login_response.api_token);
   ASSERT_NUM_EQUALS(login_response.score, 0);
-  ASSERT_NUM_EQUALS(login_response.score_softcore, 0);
+  ASSERT_NUM_EQUALS(login_response.score_casual, 0);
   ASSERT_NUM_EQUALS(login_response.num_unread_messages, 0);
   ASSERT_PTR_NULL(login_response.display_name);
 
@@ -512,7 +512,7 @@ static void test_process_login_response_text()
   ASSERT_PTR_NULL(login_response.username);
   ASSERT_PTR_NULL(login_response.api_token);
   ASSERT_NUM_EQUALS(login_response.score, 0);
-  ASSERT_NUM_EQUALS(login_response.score_softcore, 0);
+  ASSERT_NUM_EQUALS(login_response.score_casual, 0);
   ASSERT_NUM_EQUALS(login_response.num_unread_messages, 0);
   ASSERT_PTR_NULL(login_response.display_name);
 
@@ -532,7 +532,7 @@ static void test_process_login_response_html()
   ASSERT_PTR_NULL(login_response.username);
   ASSERT_PTR_NULL(login_response.api_token);
   ASSERT_NUM_EQUALS(login_response.score, 0);
-  ASSERT_NUM_EQUALS(login_response.score_softcore, 0);
+  ASSERT_NUM_EQUALS(login_response.score_casual, 0);
   ASSERT_NUM_EQUALS(login_response.num_unread_messages, 0);
   ASSERT_PTR_NULL(login_response.display_name);
 
@@ -552,7 +552,7 @@ static void test_process_login_response_no_required_fields()
   ASSERT_PTR_NULL(login_response.username);
   ASSERT_PTR_NULL(login_response.api_token);
   ASSERT_NUM_EQUALS(login_response.score, 0);
-  ASSERT_NUM_EQUALS(login_response.score_softcore, 0);
+  ASSERT_NUM_EQUALS(login_response.score_casual, 0);
   ASSERT_NUM_EQUALS(login_response.num_unread_messages, 0);
   ASSERT_PTR_NULL(login_response.display_name);
 
@@ -572,7 +572,7 @@ static void test_process_login_response_no_token()
   ASSERT_STR_EQUALS(login_response.username, "Username");
   ASSERT_PTR_NULL(login_response.api_token);
   ASSERT_NUM_EQUALS(login_response.score, 0);
-  ASSERT_NUM_EQUALS(login_response.score_softcore, 0);
+  ASSERT_NUM_EQUALS(login_response.score_casual, 0);
   ASSERT_NUM_EQUALS(login_response.num_unread_messages, 0);
   ASSERT_PTR_NULL(login_response.display_name);
 
@@ -592,7 +592,7 @@ static void test_process_login_response_no_optional_fields()
   ASSERT_STR_EQUALS(login_response.username, "USER");
   ASSERT_STR_EQUALS(login_response.api_token, "ApiTOKEN");
   ASSERT_NUM_EQUALS(login_response.score, 0);
-  ASSERT_NUM_EQUALS(login_response.score_softcore, 0);
+  ASSERT_NUM_EQUALS(login_response.score_casual, 0);
   ASSERT_NUM_EQUALS(login_response.num_unread_messages, 0);
   ASSERT_STR_EQUALS(login_response.display_name, "USER");
 
@@ -612,7 +612,7 @@ static void test_process_login_response_null_score()
   ASSERT_STR_EQUALS(login_response.username, "USER");
   ASSERT_STR_EQUALS(login_response.api_token, "ApiTOKEN");
   ASSERT_NUM_EQUALS(login_response.score, 0);
-  ASSERT_NUM_EQUALS(login_response.score_softcore, 0);
+  ASSERT_NUM_EQUALS(login_response.score_casual, 0);
   ASSERT_NUM_EQUALS(login_response.num_unread_messages, 0);
   ASSERT_STR_EQUALS(login_response.display_name, "USER");
 
@@ -1015,7 +1015,7 @@ void test_rapi_user(void) {
   /* start session */
   TEST(test_init_start_session_request);
   TEST(test_init_start_session_request_no_game);
-  TEST(test_init_start_session_request_game_hash_softcore);
+  TEST(test_init_start_session_request_game_hash_casual);
   TEST(test_init_start_session_request_game_hash_hardcore);
 
   TEST(test_process_start_session_response_legacy);

--- a/test/test_rc_client.c
+++ b/test/test_rc_client.c
@@ -394,7 +394,7 @@ static const char* patchdata_not_found = "{\"Success\":false,\"Error\":\"Unknown
 static const char* no_unlocks = "{\"Success\":true,\"Unlocks\":[],\"HardcoreUnlocks\":[]}";
 
 /* startsession API only returns HardcoreUnlocks if an achievement has been earned in hardcore,
- * even if the softcore unlock has a different timestamp */
+ * even if the casual unlock has a different timestamp */
 static const char* unlock_5501h_and_5502 = "{\"Success\":true,\"Unlocks\":["
       "{\"ID\":5502,\"When\":1234567899}"
     "],\"HardcoreUnlocks\":["
@@ -806,7 +806,7 @@ static void mock_client_load_game(const char* patchdata, const char* unlocks)
     ASSERT_MESSAGE("client->game is NULL");
 }
 
-static void mock_client_load_game_softcore(const char* patchdata, const char* unlocks)
+static void mock_client_load_game_casual(const char* patchdata, const char* unlocks)
 {
   reset_mock_api_handlers();
   event_count = 0;
@@ -847,7 +847,7 @@ static void test_login_with_password(void)
   ASSERT_STR_EQUALS(user->display_name, "User");
   ASSERT_STR_EQUALS(user->token, "ApiToken");
   ASSERT_NUM_EQUALS(user->score, 12345);
-  ASSERT_NUM_EQUALS(user->score_softcore, 123);
+  ASSERT_NUM_EQUALS(user->score_casual, 123);
   ASSERT_NUM_EQUALS(user->num_unread_messages, 2);
 
   rc_client_destroy(g_client);
@@ -1285,7 +1285,7 @@ static void test_get_user_game_summary(void)
   rc_client_destroy(g_client);
 }
 
-static void test_get_user_game_summary_softcore(void)
+static void test_get_user_game_summary_casual(void)
 {
   rc_client_user_game_summary_t summary;
 
@@ -4308,7 +4308,7 @@ static void test_achievement_list_simple_with_unlocks(void)
     iter = list->buckets[0].achievements;
     achievement = *iter++;
     ASSERT_NUM_EQUALS(achievement->id, 5502);
-    ASSERT_NUM_EQUALS(achievement->unlocked, RC_CLIENT_ACHIEVEMENT_UNLOCKED_SOFTCORE);
+    ASSERT_NUM_EQUALS(achievement->unlocked, RC_CLIENT_ACHIEVEMENT_UNLOCKED_CASUAL);
     iter = list->buckets[1].achievements;
     achievement = *iter++;
     ASSERT_NUM_EQUALS(achievement->id, 5501);
@@ -4322,7 +4322,7 @@ static void test_achievement_list_simple_with_unlocks(void)
   list = rc_client_create_achievement_list(g_client, RC_CLIENT_ACHIEVEMENT_CATEGORY_CORE, RC_CLIENT_ACHIEVEMENT_LIST_GROUPING_LOCK_STATE);
   ASSERT_PTR_NOT_NULL(list);
   if (list) {
-    /* in softcore mode, both should be unlocked */
+    /* in casual mode, both should be unlocked */
     ASSERT_NUM_EQUALS(list->num_buckets, 1);
     ASSERT_NUM_EQUALS(list->buckets[0].bucket_type, RC_CLIENT_ACHIEVEMENT_BUCKET_UNLOCKED);
     ASSERT_NUM_EQUALS(list->buckets[0].subset_id, 0);
@@ -4335,7 +4335,7 @@ static void test_achievement_list_simple_with_unlocks(void)
     ASSERT_NUM_EQUALS(achievement->unlocked, RC_CLIENT_ACHIEVEMENT_UNLOCKED_BOTH);
     achievement = *iter++;
     ASSERT_NUM_EQUALS(achievement->id, 5502);
-    ASSERT_NUM_EQUALS(achievement->unlocked, RC_CLIENT_ACHIEVEMENT_UNLOCKED_SOFTCORE);
+    ASSERT_NUM_EQUALS(achievement->unlocked, RC_CLIENT_ACHIEVEMENT_UNLOCKED_CASUAL);
 
     rc_client_destroy_achievement_list(list);
   }
@@ -4372,7 +4372,7 @@ static void test_achievement_list_simple_with_unlocks_encore_mode(void)
     ASSERT_NUM_EQUALS(achievement->unlocked, RC_CLIENT_ACHIEVEMENT_UNLOCKED_BOTH);
     achievement = *iter++;
     ASSERT_NUM_EQUALS(achievement->id, 5502);
-    ASSERT_NUM_EQUALS(achievement->unlocked, RC_CLIENT_ACHIEVEMENT_UNLOCKED_SOFTCORE);
+    ASSERT_NUM_EQUALS(achievement->unlocked, RC_CLIENT_ACHIEVEMENT_UNLOCKED_CASUAL);
 
     rc_client_destroy_achievement_list(list);
   }
@@ -4383,7 +4383,7 @@ static void test_achievement_list_simple_with_unlocks_encore_mode(void)
   list = rc_client_create_achievement_list(g_client, RC_CLIENT_ACHIEVEMENT_CATEGORY_CORE, RC_CLIENT_ACHIEVEMENT_LIST_GROUPING_LOCK_STATE);
   ASSERT_PTR_NOT_NULL(list);
   if (list) {
-    /* in softcore mode, both should be unlocked, but will appear locked due to encore mode */
+    /* in casual mode, both should be unlocked, but will appear locked due to encore mode */
     ASSERT_NUM_EQUALS(list->num_buckets, 1);
     ASSERT_NUM_EQUALS(list->buckets[0].bucket_type, RC_CLIENT_ACHIEVEMENT_BUCKET_LOCKED);
     ASSERT_NUM_EQUALS(list->buckets[0].subset_id, 0);
@@ -4396,7 +4396,7 @@ static void test_achievement_list_simple_with_unlocks_encore_mode(void)
     ASSERT_NUM_EQUALS(achievement->unlocked, RC_CLIENT_ACHIEVEMENT_UNLOCKED_BOTH);
     achievement = *iter++;
     ASSERT_NUM_EQUALS(achievement->id, 5502);
-    ASSERT_NUM_EQUALS(achievement->unlocked, RC_CLIENT_ACHIEVEMENT_UNLOCKED_SOFTCORE);
+    ASSERT_NUM_EQUALS(achievement->unlocked, RC_CLIENT_ACHIEVEMENT_UNLOCKED_CASUAL);
 
     rc_client_destroy_achievement_list(list);
   }
@@ -4425,7 +4425,7 @@ static void test_achievement_list_simple_with_unlocks_encore_mode(void)
 
     achievement = list->buckets[0].achievements[0];
     ASSERT_NUM_EQUALS(achievement->id, 5502);
-    ASSERT_NUM_EQUALS(achievement->unlocked, RC_CLIENT_ACHIEVEMENT_UNLOCKED_SOFTCORE);
+    ASSERT_NUM_EQUALS(achievement->unlocked, RC_CLIENT_ACHIEVEMENT_UNLOCKED_CASUAL);
 
     ASSERT_NUM_EQUALS(list->buckets[1].bucket_type, RC_CLIENT_ACHIEVEMENT_BUCKET_UNLOCKED);
     ASSERT_NUM_EQUALS(list->buckets[1].subset_id, 0);
@@ -4459,7 +4459,7 @@ static void test_achievement_list_simple_with_unlocks_encore_mode(void)
 
     achievement = list->buckets[1].achievements[0];
     ASSERT_NUM_EQUALS(achievement->id, 5502);
-    ASSERT_NUM_EQUALS(achievement->unlocked, RC_CLIENT_ACHIEVEMENT_UNLOCKED_SOFTCORE);
+    ASSERT_NUM_EQUALS(achievement->unlocked, RC_CLIENT_ACHIEVEMENT_UNLOCKED_CASUAL);
 
     rc_client_destroy_achievement_list(list);
   }
@@ -5361,7 +5361,7 @@ static void test_get_next_achievement_first(void)
 
   achievement = rc_client_get_next_achievement_info(g_client, NULL, RC_CLIENT_ACHIEVEMENT_BUCKET_UNLOCKED);
   ASSERT_PTR_NOT_NULL(achievement);
-  ASSERT_NUM_EQUALS(achievement->id, 8); /* 8 is the first unlocked achievement since 6 only has a softcore unlock */
+  ASSERT_NUM_EQUALS(achievement->id, 8); /* 8 is the first unlocked achievement since 6 only has a casual unlock */
 
   achievement = rc_client_get_next_achievement_info(g_client, NULL, RC_CLIENT_ACHIEVEMENT_BUCKET_UNSUPPORTED);
   ASSERT_PTR_NULL(achievement); /* all achievements in this set should be supported */
@@ -6512,7 +6512,7 @@ static void test_do_frame_achievement_trigger(void)
 
     ASSERT_NUM_EQUALS(g_client->game->runtime.trigger_count, num_active - 1);
     ASSERT_NUM_EQUALS(g_client->user.score, 5432);
-    ASSERT_NUM_EQUALS(g_client->user.score_softcore, 777);
+    ASSERT_NUM_EQUALS(g_client->user.score_casual, 777);
 
     event_count = 0;
     rc_client_do_frame(g_client);
@@ -6556,7 +6556,7 @@ static void test_do_frame_achievement_trigger_already_awarded(void)
 
     ASSERT_NUM_EQUALS(g_client->game->runtime.trigger_count, num_active - 1);
     ASSERT_NUM_EQUALS(g_client->user.score, 5432);
-    ASSERT_NUM_EQUALS(g_client->user.score_softcore, 777);
+    ASSERT_NUM_EQUALS(g_client->user.score_casual, 777);
 
     event_count = 0;
     rc_client_do_frame(g_client);
@@ -6721,7 +6721,7 @@ static void test_do_frame_achievement_trigger_blocked(void)
 
   ASSERT_NUM_EQUALS(g_client->game->runtime.trigger_count, num_active - 1);
   ASSERT_NUM_EQUALS(g_client->user.score, 12350); /* 12345+5 - not updated by server response that didn't happen */
-  ASSERT_NUM_EQUALS(g_client->user.score_softcore, 0);
+  ASSERT_NUM_EQUALS(g_client->user.score_casual, 0);
 
   event_count = 0;
   rc_client_do_frame(g_client);
@@ -6745,7 +6745,7 @@ static void test_do_frame_achievement_trigger_blocked(void)
 
   ASSERT_NUM_EQUALS(g_client->game->runtime.trigger_count, num_active - 2);
   ASSERT_NUM_EQUALS(g_client->user.score, 5432);
-  ASSERT_NUM_EQUALS(g_client->user.score_softcore, 777);
+  ASSERT_NUM_EQUALS(g_client->user.score_casual, 777);
 
   assert_api_called(api_call9);
 
@@ -6781,7 +6781,7 @@ static void test_do_frame_achievement_trigger_warning(void)
 
     ASSERT_NUM_EQUALS(g_client->game->runtime.trigger_count, num_active - 1);
     ASSERT_NUM_EQUALS(g_client->user.score, 12345);
-    ASSERT_NUM_EQUALS(g_client->user.score_softcore, 0);
+    ASSERT_NUM_EQUALS(g_client->user.score_casual, 0);
 
     assert_api_not_called("r=awardachievement&u=Username&t=ApiToken&a=101000001&h=1&m=0123456789ABCDEF&v=589baefac51bd5931234fa9ade42460f");
 
@@ -6877,7 +6877,7 @@ static void test_do_frame_achievement_trigger_automatic_retry(const char* respon
     ASSERT_PTR_NULL(g_client->state.scheduled_callbacks);
 
     ASSERT_NUM_EQUALS(g_client->user.score, 5432);
-    ASSERT_NUM_EQUALS(g_client->user.score_softcore, 777);
+    ASSERT_NUM_EQUALS(g_client->user.score_casual, 777);
 
     /* reconnected event should be pending, watch for it */
     ASSERT_NUM_EQUALS(event_count, 0);
@@ -6953,7 +6953,7 @@ static void test_do_frame_achievement_trigger_subset(void)
 
     ASSERT_NUM_EQUALS(g_client->game->runtime.trigger_count, num_active - 1);
     ASSERT_NUM_EQUALS(g_client->user.score, 5432);
-    ASSERT_NUM_EQUALS(g_client->user.score_softcore, 777);
+    ASSERT_NUM_EQUALS(g_client->user.score_casual, 777);
 
     event_count = 0;
     rc_client_do_frame(g_client);
@@ -6976,7 +6976,7 @@ static void test_do_frame_achievement_trigger_subset(void)
 
     ASSERT_NUM_EQUALS(g_client->game->runtime.trigger_count, num_active - 2);
     ASSERT_NUM_EQUALS(g_client->user.score, 5437);
-    ASSERT_NUM_EQUALS(g_client->user.score_softcore, 777);
+    ASSERT_NUM_EQUALS(g_client->user.score_casual, 777);
   }
 
   rc_client_destroy(g_client);
@@ -7027,7 +7027,7 @@ static void test_do_frame_achievement_trigger_base_and_subset(void)
 
     ASSERT_NUM_EQUALS(g_client->game->runtime.trigger_count, num_active - 2);
     ASSERT_NUM_EQUALS(g_client->user.score, 5437);
-    ASSERT_NUM_EQUALS(g_client->user.score_softcore, 777);
+    ASSERT_NUM_EQUALS(g_client->user.score_casual, 777);
   }
 
   rc_client_destroy(g_client);
@@ -7071,7 +7071,7 @@ static void test_do_frame_achievement_trigger_rarity(void)
 
     ASSERT_NUM_EQUALS(g_client->game->runtime.trigger_count, num_active - 1);
     ASSERT_NUM_EQUALS(g_client->user.score, 5432);
-    ASSERT_NUM_EQUALS(g_client->user.score_softcore, 777);
+    ASSERT_NUM_EQUALS(g_client->user.score_casual, 777);
 
     event_count = 0;
     rc_client_do_frame(g_client);
@@ -7668,7 +7668,7 @@ static void test_do_frame_mastery(void)
 
     ASSERT_NUM_EQUALS(g_client->game->runtime.trigger_count, num_active - 1);
     ASSERT_NUM_EQUALS(g_client->user.score, 12345+5);
-    ASSERT_NUM_EQUALS(g_client->user.score_softcore, 0);
+    ASSERT_NUM_EQUALS(g_client->user.score_casual, 0);
 
     event_count = 0;
     rc_client_do_frame(g_client);
@@ -7679,7 +7679,7 @@ static void test_do_frame_mastery(void)
 
     ASSERT_NUM_EQUALS(event_count, 0);
     ASSERT_NUM_EQUALS(g_client->user.score, 5432);
-    ASSERT_NUM_EQUALS(g_client->user.score_softcore, 777);
+    ASSERT_NUM_EQUALS(g_client->user.score_casual, 777);
 
     event_count = 0;
     rc_client_do_frame(g_client);
@@ -7703,7 +7703,7 @@ static void test_do_frame_mastery(void)
 
     ASSERT_NUM_EQUALS(g_client->game->runtime.trigger_count, num_active - 2);
     ASSERT_NUM_EQUALS(g_client->user.score, 5432+5);
-    ASSERT_NUM_EQUALS(g_client->user.score_softcore, 777);
+    ASSERT_NUM_EQUALS(g_client->user.score_casual, 777);
 
     event_count = 0;
     rc_client_do_frame(g_client);
@@ -7714,7 +7714,7 @@ static void test_do_frame_mastery(void)
 
     ASSERT_NUM_EQUALS(event_count, 0);
     ASSERT_NUM_EQUALS(g_client->user.score, 5432);
-    ASSERT_NUM_EQUALS(g_client->user.score_softcore, 777);
+    ASSERT_NUM_EQUALS(g_client->user.score_casual, 777);
 
     rc_client_do_frame(g_client);
     ASSERT_NUM_EQUALS(event_count, 0);
@@ -7755,7 +7755,7 @@ static void test_do_frame_mastery_encore(void)
 
     ASSERT_NUM_EQUALS(g_client->game->runtime.trigger_count, num_active - 1);
     ASSERT_NUM_EQUALS(g_client->user.score, 12345+5);
-    ASSERT_NUM_EQUALS(g_client->user.score_softcore, 0);
+    ASSERT_NUM_EQUALS(g_client->user.score_casual, 0);
 
     event_count = 0;
     rc_client_do_frame(g_client);
@@ -7766,7 +7766,7 @@ static void test_do_frame_mastery_encore(void)
 
     ASSERT_NUM_EQUALS(event_count, 0);
     ASSERT_NUM_EQUALS(g_client->user.score, 5432);
-    ASSERT_NUM_EQUALS(g_client->user.score_softcore, 777);
+    ASSERT_NUM_EQUALS(g_client->user.score_casual, 777);
 
     event_count = 0;
     rc_client_do_frame(g_client);
@@ -7790,7 +7790,7 @@ static void test_do_frame_mastery_encore(void)
 
     ASSERT_NUM_EQUALS(g_client->game->runtime.trigger_count, num_active - 2);
     ASSERT_NUM_EQUALS(g_client->user.score, 5432+5);
-    ASSERT_NUM_EQUALS(g_client->user.score_softcore, 777);
+    ASSERT_NUM_EQUALS(g_client->user.score_casual, 777);
 
     event_count = 0;
     rc_client_do_frame(g_client);
@@ -7801,7 +7801,7 @@ static void test_do_frame_mastery_encore(void)
 
     ASSERT_NUM_EQUALS(event_count, 0);
     ASSERT_NUM_EQUALS(g_client->user.score, 5432);
-    ASSERT_NUM_EQUALS(g_client->user.score_softcore, 777);
+    ASSERT_NUM_EQUALS(g_client->user.score_casual, 777);
 
     rc_client_do_frame(g_client);
     ASSERT_NUM_EQUALS(event_count, 0);
@@ -7843,7 +7843,7 @@ static void test_do_frame_mastery_subset(void)
 
     ASSERT_NUM_EQUALS(g_client->game->runtime.trigger_count, num_active - 1);
     ASSERT_NUM_EQUALS(g_client->user.score, 12345 + 5);
-    ASSERT_NUM_EQUALS(g_client->user.score_softcore, 0);
+    ASSERT_NUM_EQUALS(g_client->user.score_casual, 0);
 
     event_count = 0;
     rc_client_do_frame(g_client);
@@ -7854,7 +7854,7 @@ static void test_do_frame_mastery_subset(void)
 
     ASSERT_NUM_EQUALS(event_count, 0);
     ASSERT_NUM_EQUALS(g_client->user.score, 5432);
-    ASSERT_NUM_EQUALS(g_client->user.score_softcore, 777);
+    ASSERT_NUM_EQUALS(g_client->user.score_casual, 777);
 
     event_count = 0;
     rc_client_do_frame(g_client);
@@ -8420,7 +8420,7 @@ static void test_do_frame_leaderboard_submit_blocked(void)
   rc_client_destroy(g_client);
 }
 
-static void test_do_frame_leaderboard_submit_softcore(void)
+static void test_do_frame_leaderboard_submit_casual(void)
 {
   rc_client_leaderboard_info_t* leaderboard;
   rc_client_event_t* event;
@@ -8443,14 +8443,14 @@ static void test_do_frame_leaderboard_submit_softcore(void)
   rc_client_do_frame(g_client);
   ASSERT_NUM_EQUALS(event_count, 0);
 
-  /* start the leaderboard - will be ignored in softcore */
+  /* start the leaderboard - will be ignored in casual mode */
   memory[0x0B] = 1;
   memory[0x0E] = 17;
   rc_client_do_frame(g_client);
   ASSERT_NUM_EQUALS(event_count, 0);
 
-  /* allow leaderboards to be processed in softcore. have to manually activate as it wasn't activated on game load */
-  g_client->state.allow_leaderboards_in_softcore = 1;
+  /* allow leaderboards to be processed in casual mode. have to manually activate as it wasn't activated on game load */
+  g_client->state.allow_leaderboards_in_casual = 1;
   leaderboard = (rc_client_leaderboard_info_t*)rc_client_get_leaderboard_info(g_client, 44);
   leaderboard->public_.state = RC_CLIENT_LEADERBOARD_BUCKET_ACTIVE;
   leaderboard->lboard->state = RC_LBOARD_STATE_ACTIVE;
@@ -10097,7 +10097,7 @@ static void test_set_hardcore_disable(void)
   achievement = rc_client_get_achievement_info(g_client, 5502);
   ASSERT_PTR_NOT_NULL(achievement);
   trigger = ((rc_client_achievement_info_t*)achievement)->trigger;
-  ASSERT_NUM_EQUALS(achievement->unlocked, RC_CLIENT_ACHIEVEMENT_UNLOCKED_SOFTCORE);
+  ASSERT_NUM_EQUALS(achievement->unlocked, RC_CLIENT_ACHIEVEMENT_UNLOCKED_CASUAL);
   ASSERT_NUM_EQUALS(achievement->state, RC_CLIENT_ACHIEVEMENT_STATE_ACTIVE);
   ASSERT_NUM_EQUALS(trigger->state, RC_TRIGGER_STATE_WAITING);
 
@@ -10116,7 +10116,7 @@ static void test_set_hardcore_disable(void)
   ASSERT_PTR_NOT_NULL(achievement);
   trigger = ((rc_client_achievement_info_t*)achievement)->trigger;
 
-  ASSERT_NUM_EQUALS(achievement->unlocked, RC_CLIENT_ACHIEVEMENT_UNLOCKED_SOFTCORE);
+  ASSERT_NUM_EQUALS(achievement->unlocked, RC_CLIENT_ACHIEVEMENT_UNLOCKED_CASUAL);
   ASSERT_NUM_EQUALS(achievement->state, RC_CLIENT_ACHIEVEMENT_STATE_UNLOCKED);
   ASSERT_NUM_EQUALS(trigger->state, RC_TRIGGER_STATE_TRIGGERED);
   ASSERT_NUM_EQUALS(g_client->game->runtime.trigger_count, 0); /* 5502 should not be active*/
@@ -10184,14 +10184,14 @@ static void test_set_hardcore_enable(void)
 
   g_client = mock_client_logged_in();
   rc_client_set_hardcore_enabled(g_client, 0);
-  mock_client_load_game_softcore(patchdata_2ach_1lbd, unlock_5501h_and_5502);
+  mock_client_load_game_casual(patchdata_2ach_1lbd, unlock_5501h_and_5502);
 
   ASSERT_NUM_EQUALS(rc_client_get_hardcore_enabled(g_client), 0);
 
   achievement = rc_client_get_achievement_info(g_client, 5502);
   ASSERT_PTR_NOT_NULL(achievement);
   if (achievement) {
-    ASSERT_NUM_EQUALS(achievement->unlocked, RC_CLIENT_ACHIEVEMENT_UNLOCKED_SOFTCORE);
+    ASSERT_NUM_EQUALS(achievement->unlocked, RC_CLIENT_ACHIEVEMENT_UNLOCKED_CASUAL);
     ASSERT_NUM_EQUALS(achievement->state, RC_CLIENT_ACHIEVEMENT_STATE_UNLOCKED);
     ASSERT_NUM_EQUALS(g_client->game->runtime.trigger_count, 0); /* 5502 should not be active*/
   }
@@ -10213,7 +10213,7 @@ static void test_set_hardcore_enable(void)
   achievement = rc_client_get_achievement_info(g_client, 5502);
   ASSERT_PTR_NOT_NULL(achievement);
   if (achievement) {
-    ASSERT_NUM_EQUALS(achievement->unlocked, RC_CLIENT_ACHIEVEMENT_UNLOCKED_SOFTCORE);
+    ASSERT_NUM_EQUALS(achievement->unlocked, RC_CLIENT_ACHIEVEMENT_UNLOCKED_CASUAL);
     ASSERT_NUM_EQUALS(achievement->state, RC_CLIENT_ACHIEVEMENT_STATE_ACTIVE);
     ASSERT_NUM_EQUALS(g_client->game->runtime.trigger_count, 1); /* 5502 should be active*/
   }
@@ -10278,7 +10278,7 @@ static void test_set_hardcore_enable_encore_mode(void)
   achievement = rc_client_get_achievement_info(g_client, 5502);
   ASSERT_PTR_NOT_NULL(achievement);
   if (achievement) {
-    ASSERT_NUM_EQUALS(achievement->unlocked, RC_CLIENT_ACHIEVEMENT_UNLOCKED_SOFTCORE);
+    ASSERT_NUM_EQUALS(achievement->unlocked, RC_CLIENT_ACHIEVEMENT_UNLOCKED_CASUAL);
     ASSERT_NUM_EQUALS(achievement->state, RC_CLIENT_ACHIEVEMENT_STATE_ACTIVE);
     ASSERT_NUM_EQUALS(g_client->game->runtime.triggers[1].trigger->state, RC_TRIGGER_STATE_ACTIVE);
   }
@@ -10299,7 +10299,7 @@ static void test_set_hardcore_enable_encore_mode(void)
   achievement = rc_client_get_achievement_info(g_client, 5502);
   ASSERT_PTR_NOT_NULL(achievement);
   if (achievement) {
-    ASSERT_NUM_EQUALS(achievement->unlocked, RC_CLIENT_ACHIEVEMENT_UNLOCKED_SOFTCORE);
+    ASSERT_NUM_EQUALS(achievement->unlocked, RC_CLIENT_ACHIEVEMENT_UNLOCKED_CASUAL);
     ASSERT_NUM_EQUALS(achievement->state, RC_CLIENT_ACHIEVEMENT_STATE_ACTIVE);
     ASSERT_NUM_EQUALS(g_client->game->runtime.triggers[1].trigger->state, RC_TRIGGER_STATE_ACTIVE);
   }
@@ -10330,7 +10330,7 @@ static void test_set_hardcore_enable_encore_mode(void)
   achievement = rc_client_get_achievement_info(g_client, 5502);
   ASSERT_PTR_NOT_NULL(achievement);
   if (achievement) {
-    ASSERT_NUM_EQUALS(achievement->unlocked, RC_CLIENT_ACHIEVEMENT_UNLOCKED_SOFTCORE);
+    ASSERT_NUM_EQUALS(achievement->unlocked, RC_CLIENT_ACHIEVEMENT_UNLOCKED_CASUAL);
     ASSERT_NUM_EQUALS(achievement->state, RC_CLIENT_ACHIEVEMENT_STATE_ACTIVE);
     ASSERT_NUM_EQUALS(g_client->game->runtime.triggers[0].trigger->state, RC_TRIGGER_STATE_ACTIVE);
     ASSERT_PTR_EQUALS(((rc_client_achievement_info_t*)achievement)->trigger, g_client->game->runtime.triggers[0].trigger);
@@ -10364,7 +10364,7 @@ static void test_set_encore_mode_enable(void)
   achievement = rc_client_get_achievement_info(g_client, 5502);
   ASSERT_PTR_NOT_NULL(achievement);
   if (achievement) {
-    ASSERT_NUM_EQUALS(achievement->unlocked, RC_CLIENT_ACHIEVEMENT_UNLOCKED_SOFTCORE);
+    ASSERT_NUM_EQUALS(achievement->unlocked, RC_CLIENT_ACHIEVEMENT_UNLOCKED_CASUAL);
     ASSERT_NUM_EQUALS(achievement->state, RC_CLIENT_ACHIEVEMENT_STATE_ACTIVE);
   }
 
@@ -10381,7 +10381,7 @@ static void test_set_encore_mode_enable(void)
   achievement = rc_client_get_achievement_info(g_client, 5502);
   ASSERT_PTR_NOT_NULL(achievement);
   if (achievement) {
-    ASSERT_NUM_EQUALS(achievement->unlocked, RC_CLIENT_ACHIEVEMENT_UNLOCKED_SOFTCORE);
+    ASSERT_NUM_EQUALS(achievement->unlocked, RC_CLIENT_ACHIEVEMENT_UNLOCKED_CASUAL);
     ASSERT_NUM_EQUALS(achievement->state, RC_CLIENT_ACHIEVEMENT_STATE_ACTIVE);
   }
 
@@ -10408,7 +10408,7 @@ static void test_set_encore_mode_disable(void)
   achievement = rc_client_get_achievement_info(g_client, 5502);
   ASSERT_PTR_NOT_NULL(achievement);
   if (achievement) {
-    ASSERT_NUM_EQUALS(achievement->unlocked, RC_CLIENT_ACHIEVEMENT_UNLOCKED_SOFTCORE);
+    ASSERT_NUM_EQUALS(achievement->unlocked, RC_CLIENT_ACHIEVEMENT_UNLOCKED_CASUAL);
     ASSERT_NUM_EQUALS(achievement->state, RC_CLIENT_ACHIEVEMENT_STATE_ACTIVE);
   }
 
@@ -10425,7 +10425,7 @@ static void test_set_encore_mode_disable(void)
   achievement = rc_client_get_achievement_info(g_client, 5502);
   ASSERT_PTR_NOT_NULL(achievement);
   if (achievement) {
-    ASSERT_NUM_EQUALS(achievement->unlocked, RC_CLIENT_ACHIEVEMENT_UNLOCKED_SOFTCORE);
+    ASSERT_NUM_EQUALS(achievement->unlocked, RC_CLIENT_ACHIEVEMENT_UNLOCKED_CASUAL);
     ASSERT_NUM_EQUALS(achievement->state, RC_CLIENT_ACHIEVEMENT_STATE_ACTIVE);
   }
 
@@ -10485,7 +10485,7 @@ void test_client(void) {
   TEST(test_user_get_image_url);
 
   TEST(test_get_user_game_summary);
-  TEST(test_get_user_game_summary_softcore);
+  TEST(test_get_user_game_summary_casual);
   TEST(test_get_user_game_summary_encore_mode);
   TEST(test_get_user_game_summary_with_unsupported_and_unofficial);
   TEST(test_get_user_game_summary_with_unsupported_unlocks);
@@ -10675,7 +10675,7 @@ void test_client(void) {
   TEST(test_do_frame_leaderboard_submit_immediate);
   TEST(test_do_frame_leaderboard_submit_hidden);
   TEST(test_do_frame_leaderboard_submit_blocked);
-  TEST(test_do_frame_leaderboard_submit_softcore);
+  TEST(test_do_frame_leaderboard_submit_casual);
   TEST(test_do_frame_leaderboard_tracker_sharing);
   TEST(test_do_frame_leaderboard_tracker_sharing_hits);
   TEST(test_do_frame_leaderboard_submit_automatic_retry);

--- a/test/test_rc_client_external.c
+++ b/test/test_rc_client_external.c
@@ -360,7 +360,7 @@ static void test_v1_user_field_offsets(void)
   ASSERT_FIELD_OFFSET(rc_client_user_t, v1_rc_client_user_t, username);
   ASSERT_FIELD_OFFSET(rc_client_user_t, v1_rc_client_user_t, token);
   ASSERT_FIELD_OFFSET(rc_client_user_t, v1_rc_client_user_t, score);
-  ASSERT_FIELD_OFFSET(rc_client_user_t, v1_rc_client_user_t, score_softcore);
+  ASSERT_FIELD_OFFSET(rc_client_user_t, v1_rc_client_user_t, score_casual);
   ASSERT_FIELD_OFFSET(rc_client_user_t, v1_rc_client_user_t, num_unread_messages);
 }
 
@@ -370,7 +370,7 @@ static void test_v3_user_field_offsets(void)
   ASSERT_FIELD_OFFSET(rc_client_user_t, v3_rc_client_user_t, username);
   ASSERT_FIELD_OFFSET(rc_client_user_t, v3_rc_client_user_t, token);
   ASSERT_FIELD_OFFSET(rc_client_user_t, v3_rc_client_user_t, score);
-  ASSERT_FIELD_OFFSET(rc_client_user_t, v3_rc_client_user_t, score_softcore);
+  ASSERT_FIELD_OFFSET(rc_client_user_t, v3_rc_client_user_t, score_casual);
   ASSERT_FIELD_OFFSET(rc_client_user_t, v3_rc_client_user_t, num_unread_messages);
   ASSERT_FIELD_OFFSET(rc_client_user_t, v3_rc_client_user_t, avatar_url);
 }
@@ -404,7 +404,7 @@ static const rc_client_user_t* rc_client_external_get_user_info_v1(void)
   user->username = "User";
   user->token = "ApiToken";
   user->score = 12345;
-  user->score_softcore = 123;
+  user->score_casual = 123;
   user->num_unread_messages = 2;
 
   return (rc_client_user_t*)user;
@@ -420,7 +420,7 @@ static const rc_client_user_t* rc_client_external_get_user_info_v3(void)
   user->username = "User";
   user->token = "ApiToken";
   user->score = 12345;
-  user->score_softcore = 123;
+  user->score_casual = 123;
   user->num_unread_messages = 2;
   user->avatar_url = "/UserPic/User.png";
 
@@ -447,7 +447,7 @@ static void test_login_with_password(void)
   ASSERT_STR_EQUALS(user->display_name, "User");
   ASSERT_STR_EQUALS(user->token, "ApiToken");
   ASSERT_NUM_EQUALS(user->score, 12345);
-  ASSERT_NUM_EQUALS(user->score_softcore, 123);
+  ASSERT_NUM_EQUALS(user->score_casual, 123);
   ASSERT_NUM_EQUALS(user->num_unread_messages, 2);
   ASSERT_STR_EQUALS(user->avatar_url, "/UserPic/User.png");
 
@@ -495,7 +495,7 @@ static void test_login_with_token_v1(void)
   ASSERT_STR_EQUALS(user->display_name, "User");
   ASSERT_STR_EQUALS(user->token, "ApiToken");
   ASSERT_NUM_EQUALS(user->score, 12345);
-  ASSERT_NUM_EQUALS(user->score_softcore, 123);
+  ASSERT_NUM_EQUALS(user->score_casual, 123);
   ASSERT_NUM_EQUALS(user->num_unread_messages, 2);
   ASSERT_STR_EQUALS(user->avatar_url, "https://media.retroachievements.org/UserPic/User.png");
 
@@ -515,7 +515,7 @@ static const rc_client_user_t* rc_client_external_get_user_info_v1_long_name(voi
   user->username = "TwentyCharUserNameXX";
   user->token = "ApiToken";
   user->score = 12345;
-  user->score_softcore = 123;
+  user->score_casual = 123;
   user->num_unread_messages = 2;
 
   return (rc_client_user_t*)user;
@@ -549,7 +549,7 @@ static void test_login_with_token_v1_long_username(void)
   ASSERT_STR_EQUALS(user->display_name, "TwentyCharUserNameXX");
   ASSERT_STR_EQUALS(user->token, "ApiToken");
   ASSERT_NUM_EQUALS(user->score, 12345);
-  ASSERT_NUM_EQUALS(user->score_softcore, 123);
+  ASSERT_NUM_EQUALS(user->score_casual, 123);
   ASSERT_NUM_EQUALS(user->num_unread_messages, 2);
   ASSERT_STR_EQUALS(user->avatar_url, "https://media.retroachievements.org/UserPic/TwentyCharUserNameXX.png");
 
@@ -569,7 +569,7 @@ static const rc_client_user_t* rc_client_external_get_user_info_v1_too_long_name
   user->username = "ThisUserNameIsTooLongToFitIntoTheUserAvatarBufferWithoutOverflowing";
   user->token = "ApiToken";
   user->score = 12345;
-  user->score_softcore = 123;
+  user->score_casual = 123;
   user->num_unread_messages = 2;
 
   return (rc_client_user_t*)user;
@@ -594,7 +594,7 @@ static void test_login_with_token_v1_too_long_username(void)
   ASSERT_STR_EQUALS(user->display_name, "ThisUserNameIsTooLongToFitIntoTheUserAvatarBufferWithoutOverflowing");
   ASSERT_STR_EQUALS(user->token, "ApiToken");
   ASSERT_NUM_EQUALS(user->score, 12345);
-  ASSERT_NUM_EQUALS(user->score_softcore, 123);
+  ASSERT_NUM_EQUALS(user->score_casual, 123);
   ASSERT_NUM_EQUALS(user->num_unread_messages, 2);
   /* overly long URL will be truncated, but should not cause an exception.
    * test_login_with_token_v1_long_username validates the longest allowed username, so this shouldn't occur anyway */
@@ -625,7 +625,7 @@ static void test_login_with_token(void)
   ASSERT_STR_EQUALS(user->display_name, "User");
   ASSERT_STR_EQUALS(user->token, "ApiToken");
   ASSERT_NUM_EQUALS(user->score, 12345);
-  ASSERT_NUM_EQUALS(user->score_softcore, 123);
+  ASSERT_NUM_EQUALS(user->score_casual, 123);
   ASSERT_NUM_EQUALS(user->num_unread_messages, 2);
   ASSERT_STR_EQUALS(user->avatar_url, "/UserPic/User.png");
 


### PR DESCRIPTION
This is a breaking change as it touches several API function names and enum values.

To resolve compilation errors related to these changes, simply change "softcore" to "casual".

Clients should also update any messaging referencing "softcore" to now say "casual".